### PR TITLE
Support for bootstrapping west

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/
 dist/
 west.egg-info/
+__pycache__/

--- a/README.rst
+++ b/README.rst
@@ -1,13 +1,72 @@
 This package contains the Zephyr RTOS meta tool, 'west'.
 
-To install west from this package into your user directory, run:
+WARNING
+-------
 
-$ python3 setup.py install --user
+DO NOT INSTALL WITH "python3 setup.py install".
 
-You can also try it out by just running the package as a module from
-this directory:
+Please use pip to install in development mode as documented below.
+
+Important Note
+--------------
+
+West is distributed in two pieces:
+
+1. A bootstrap/wrapper script, which is distributed via PyPI.
+2. The "main" west package and entry points, which are fetched by the
+   bootstrap script.
+
+This somewhat unusual arrangement is because:
+
+- One of West's jobs is to manage interaction with Zephyr's multiple
+  Git repositories, including its own.
+- West is in its experimental stages and is moving quickly, meaning
+  users need to stay on HEAD.
+
+The default setup.py installs the **wrapper script only**.
+
+Installation
+------------
+
+To install the West bootstrapping/wrapper script from this package in
+development mode, clone this repository and run this from the top
+level directory:
+
+$ pip3 install -e .
+
+Then use the wrapper script to initialize a Zephyr installation with::
+
+  $ west init your/zephyr/install-dir
+  $ cd your/zephyr/install-dir
+  $ west <command>
+
+The ``west init`` call will:
+
+- create your/zephyr/install-dir
+- clone the Zephyr manifest repository (whose URL can be overridden
+  with the ``-u`` option, and branch with ``--mr`` / ``--manifest-rev``)
+- clone the latest West repository (the URL override is ``-w``, and
+  revision/branch override is ``--wr`` / ``--west-rev``)
+
+Running ``west <command>`` from :file:`your/zephyr/install-dir` or
+underneath it will invoke west in "wrapper" mode: any commands other
+than ``init`` will be delegated to the West tree pulled by ``west
+init``.
+
+This arrangement may seem familiar to Android (platform, not app)
+developers. The source management features of West were indeed
+inspired by the Android Repo tool's features, but West makes
+significant departures from Repo's behavior.
+
+Alternative Usage
+-----------------
+
+If you don't want to change your system outside of cloning this
+repository, you can also clone West's Git repository and run the
+package as a module:
 
 $ python3 -m west
 
-If you go this route, make sure to install the requirements as
-specified by the install_requires line in setup.py.
+Only do this if you know what you're doing (and make sure to install
+the requirements as specified by the install_requires line in
+setup.py).

--- a/bootstrap/__init__.py
+++ b/bootstrap/__init__.py
@@ -1,0 +1,5 @@
+# Copyright 2018 Open Source Foundries Limited.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Empty file.

--- a/bootstrap/main.py
+++ b/bootstrap/main.py
@@ -1,0 +1,195 @@
+# Copyright 2018 Open Source Foundries Limited.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+'''West's bootstrap/wrapper script.
+'''
+
+import argparse
+import os
+from os.path import join
+import importlib
+import platform
+import subprocess
+import sys
+
+MANIFEST = 'manifest'
+MANIFEST_DEFAULT = 'https://github.com/zephyrproject-rtos/manifest'
+MANIFEST_REV_DEFAULT = 'master'
+WEST = 'west'
+WEST_DEFAULT = 'https://github.com/zephyrproject-rtos/west'
+WEST_REV_DEFAULT = 'master'
+# NB: on Windows, this will be hidden manually, using attrib.
+WEST_DIR = '.west'
+
+#
+# Helpers shared between init and wrapper mode
+#
+
+
+class WestError(RuntimeError):
+    pass
+
+
+class WestNotFound(WestError):
+    '''Neither the current directory nor any parent has a West installation.'''
+
+
+def find_west_topdir(start):
+    '''Find the top-level installation directory, starting at ``start``.
+
+    If none is found, raises WestNotFound.'''
+    if not os.path.isdir(start):
+        raise WestNotFound()
+
+    if WEST_DIR in os.listdir(start):
+        return start
+
+    dirname = os.path.dirname(start)
+    if start == dirname:
+        # / on POSIX, top level drive name on Windows.
+        raise WestNotFound()
+    else:
+        return find_west_topdir(dirname)
+
+
+def make_topdir_sentinel(directory):
+    '''Make the hidden sentinel that marks a West installation.
+
+    This is similar to .git or .repo directories: it marks the top
+    level directory of the installation. This allows runtime building
+    other paths, etc., which is how this script delegates to the
+    cloned west in wrapper mode (i.e. after 'west init' is run and the
+    "real" west repository has been cloned).'''
+    # The sentinel is a directory in case we ever need to stash
+    # anything inside. It could just as well be an empty file for now,
+    # but this is more future-proof.
+    sentinel = join(directory, WEST_DIR)
+    os.mkdir(sentinel)
+    # On Windows, we have to manually mark a file as hidden.
+    if platform.system() == 'Windows':
+        subprocess.check_call(['attrib', '+H', sentinel])
+
+
+def clone(url, rev, dest):
+    def repository_type(url):
+        if url.startswith(('http:', 'https:', 'git:', 'git+ssh:', 'file:')):
+            return 'GIT'
+        else:
+            return 'UNKNOWN'
+
+    if os.path.exists(dest):
+        msg = 'refusing to clone into existing location {}'.format(dest)
+        raise WestError(msg)
+
+    if repository_type(url) == 'GIT':
+        subprocess.check_call(['git', 'clone', url, '-b', rev, dest])
+    else:
+        raise WestError('Unknown URL scheme for repository: {}'.format(url))
+
+
+#
+# west init
+#
+
+
+def init(argv):
+    '''Command line handler for ``west init`` invocations.
+
+    This exits the program with a nonzero exit code if fatal errors occur.'''
+    init_parser = argparse.ArgumentParser(
+        prog='west init',
+        description='Bootstrap initialize a Zephyr installation')
+    init_parser.add_argument(
+        '-u', '--manifest-url', default=MANIFEST_DEFAULT,
+        help='Zephyr manifest fetch URL, default ' + MANIFEST_DEFAULT)
+    init_parser.add_argument(
+        '--mr', '--manifest-rev', default=MANIFEST_REV_DEFAULT,
+        dest='manifest_rev',
+        help='Manifest revision to fetch, default ' + MANIFEST_REV_DEFAULT)
+    init_parser.add_argument(
+        '-w', '--west-url', default=WEST_DEFAULT,
+        help='West fetch URL, default ' + WEST_DEFAULT)
+    init_parser.add_argument(
+        '--wr', '--west-rev', default=WEST_REV_DEFAULT, dest='west_rev',
+        help='West revision to fetch, default ' + WEST_REV_DEFAULT)
+    init_parser.add_argument(
+        'directory', nargs='?', default=None,
+        help='Initializes in this directory, creating it if necessary')
+
+    args = init_parser.parse_args(args=argv)
+    directory = args.directory or os.getcwd()
+
+    try:
+        topdir = find_west_topdir(directory)
+        init_reinit(topdir, args)
+    except WestNotFound:
+        init_bootstrap(directory, args)
+
+
+def init_bootstrap(directory, args):
+    '''Bootstrap a new manifest + West installation in the given directory.'''
+    if not os.path.isdir(directory):
+        try:
+            print('Initializing in new directory', directory)
+            os.makedirs(directory, exist_ok=False)
+        except PermissionError:
+            sys.exit('Cannot initialize in {}: permission denied'.format(
+                directory))
+        except FileExistsError:
+            sys.exit('Something else created {} concurrently; quitting'.format(
+                directory))
+        except Exception as e:
+            sys.exit("Can't create directory {}: {}".format(
+                directory, e.args))
+    else:
+        print('Initializing in', directory)
+
+    make_topdir_sentinel(directory)
+    clone(args.manifest_url, args.manifest_rev, join(directory, MANIFEST))
+    clone(args.west_url, args.west_rev, join(directory, WEST))
+
+
+def init_reinit(directory, args):
+    # TODO
+    sys.exit('Re-initializing an existing installation is not yet supported.')
+
+
+#
+# Wrap a West command
+#
+
+
+def wrap(argv):
+    start = os.getcwd()
+    try:
+        topdir = find_west_topdir(start)
+    except WestNotFound:
+        sys.exit('Error: not a Zephyr directory (or any parent): {}\n'
+                 'Use "west init" to install Zephyr here'.format(start))
+    # Put the top-level west at the highest priority except for the
+    # script directory / current working directory.
+    sys.path.insert(1, join(topdir, WEST))
+    main_module = importlib.import_module('west.main')
+    main_module.main(argv=argv)
+
+
+#
+# Main entry point
+#
+
+
+def main(wrap_argv=None):
+    '''Entry point to the wrapper script.'''
+    if wrap_argv is None:
+        wrap_argv = sys.argv[1:]
+
+    if not wrap_argv or wrap_argv[0] != 'init':
+        wrap(wrap_argv)
+    else:
+        init(wrap_argv[1:])
+        sys.exit(0)
+
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -9,15 +9,15 @@ with open('README.rst', 'r') as f:
 
 setuptools.setup(
     name='west',
-    version='0.1.10',
+    version='0.2.5',
     author='Zephyr Project',
     author_email='devel@lists.zephyrproject.org',
-    description='Zephyr RTOS Project meta-tool',
+    description='Zephyr RTOS Project meta-tool (wrapper and bootstrap)',
     long_description=long_description,
     # http://docutils.sourceforge.net/FAQ.html#what-s-the-official-mime-type-for-restructuredtext-data
     long_description_content_type="text/x-rst",
     url='https://github.com/zephyrproject-rtos/west',
-    packages=setuptools.find_packages(),
+    packages=setuptools.find_packages('bootstrap'),
     classifiers=(
         'Programming Language :: Python :: 3',
         'License :: OSI Approved :: Apache Software License',
@@ -25,13 +25,15 @@ setuptools.setup(
         'Operating System :: MacOS :: MacOS X',
         'Operating System :: Microsoft :: Windows',
         ),
+    # Note: the bootstrap script only depends on the standard library;
+    #       these dependencies are for West itself.
     install_requires=(
         'PyYAML',
         ),
     python_requires='>=3.4',
     entry_points={
         'console_scripts': (
-            'west = west.main:main',
+            'west = bootstrap.main:main',
             ),
         },
     )

--- a/west/main.py
+++ b/west/main.py
@@ -43,7 +43,7 @@ def validate_context(args, unknown):
             args.zephyr_base = os.environ['ZEPHYR_BASE']
 
 
-def parse_args(argv=None):
+def parse_args(argv):
     west_parser = argparse.ArgumentParser(
         prog='west', description='The Zephyr RTOS meta-tool.',
         epilog='Run "west <command> -h" for help on each command.')
@@ -61,8 +61,6 @@ def parse_args(argv=None):
         parser = command.add_parser(subparser_gen)
         parser.set_defaults(handler=partial(command_handler, command))
 
-    if argv is None:
-        argv = sys.argv[1:]
     args, unknown = west_parser.parse_known_args(args=argv)
 
     # Set up logging verbosity before doing anything else, so
@@ -85,8 +83,10 @@ def parse_args(argv=None):
     return args, unknown
 
 
-def main():
-    args, unknown = parse_args()
+def main(argv=None):
+    if argv is None:
+        argv = sys.argv[1:]
+    args, unknown = parse_args(argv)
 
     for_stack_trace = 'run as "west -v ... {} ..." for a stack trace'.format(
         args.command)


### PR DESCRIPTION
This pull request adds a bootstrap script, and makes that what would get uploaded to PyPI.

Not done:

1. allow reinitializing an already initialized directory (to get another manifest, manifest branch, or reinitialize the west repository)
2. macOS, Windows testing
3. actually push to PyPI (I tested this using `pip install -e` as described in the README)
4. auto-updating west itself

I think that 1. and 2. should block 3., but that 4. ought to be done within west itself, since it's more complicated. Once 1. is done and we're happy with the cross platform support I'm hoping (fingers crossed here!) that we won't have to touch the bootstrap script hardly ever.

One (I think) nice behavior of this script is that it works like "git init" rather than "repo init" in that you can optionally specify the directory to bootstrap into, and the tool will make it if it doesn't exist. This saves a mkdir in the directions.

CC: @ulfalizer
CC: @tejlmand