### PR TITLE
runner: Introduce attach command

### DIFF
--- a/src/west/cmd/debug.py
+++ b/src/west/cmd/debug.py
@@ -15,7 +15,9 @@ class Debug(WestCommand):
     def __init__(self):
         super(Debug, self).__init__(
             'debug',
-            'Connect to the board and start a debugging session.\n\n' +
+            dedent('''
+            Connect to the board, program the flash, and start a
+            debugging session.\n\n''') +
             desc_common('debug'),
             accepts_unknown_args=True)
 
@@ -39,6 +41,24 @@ class DebugServer(WestCommand):
             started elsewhere to connect to it and debug the running
             Zephyr image.\n\n''') +
             desc_common('debugserver'),
+            accepts_unknown_args=True)
+
+    def do_add_parser(self, parser_adder):
+        return add_parser_common(parser_adder, self)
+
+    def do_run(self, my_args, runner_args):
+        do_run_common(self, my_args, runner_args,
+                      'ZEPHYR_BOARD_DEBUG_RUNNER')
+
+class Attach(WestCommand):
+
+    def __init__(self):
+        super(Attach, self).__init__(
+            'attach',
+            dedent('''
+            Connect to the board without programming the flash, and
+            start a debugging session.\n\n''') +
+            desc_common('attach'),
             accepts_unknown_args=True)
 
     def do_add_parser(self, parser_adder):

--- a/src/west/main.py
+++ b/src/west/main.py
@@ -16,7 +16,7 @@ from . import log
 from .cmd import CommandContextError
 from .cmd.build import Build
 from .cmd.flash import Flash
-from .cmd.debug import Debug, DebugServer
+from .cmd.debug import Debug, DebugServer, Attach
 from .cmd.project import ListProjects, Fetch, Pull, Rebase, Branch, Checkout, \
                          Diff, Status, ForAll
 from .util import quote_sh_list
@@ -27,6 +27,7 @@ COMMANDS = (
     Flash(),
     Debug(),
     DebugServer(),
+    Attach(),
 
     # Project-related commands
     ListProjects(),

--- a/src/west/runner/core.py
+++ b/src/west/runner/core.py
@@ -163,7 +163,7 @@ class RunnerCaps:
     Available capabilities:
 
     - commands: set of supported commands; default is {'flash',
-      'debug', 'debugserver'}.
+      'debug', 'debugserver', 'attach'}.
 
     - flash_addr: whether the runner supports flashing to an
       arbitrary address. Default is False. If true, the runner
@@ -171,7 +171,7 @@ class RunnerCaps:
     '''
 
     def __init__(self,
-                 commands={'flash', 'debug', 'debugserver'},
+                 commands={'flash', 'debug', 'debugserver', 'attach'},
                  flash_addr=False):
         self.commands = commands
         self.flash_addr = bool(flash_addr)
@@ -256,14 +256,20 @@ class ZephyrBinaryRunner(abc.ABC):
     - 'flash': flash a previously configured binary to the board,
       start execution on the target, then return.
 
-    - 'debug': connect to the board via a debugging protocol, then
-      drop the user into a debugger interface with symbol tables
-      loaded from the current binary, and block until it exits.
+    - 'debug': connect to the board via a debugging protocol, program
+      the flash, then drop the user into a debugger interface with
+      symbol tables loaded from the current binary, and block until it
+      exits.
 
     - 'debugserver': connect via a board-specific debugging protocol,
       then reset and halt the target. Ensure the user is now able to
       connect to a debug server with symbol tables loaded from the
       binary.
+
+    - 'attach': connect to the board via a debugging protocol, then drop
+      the user into a debugger interface with symbol tables loaded from
+      the current binary, and block until it exits. Unlike 'debug', this
+      command does not program the flash.
 
     This class provides an API for these commands. Every runner has a
     name (like 'pyocd'), and declares commands it can handle (like
@@ -391,7 +397,7 @@ class ZephyrBinaryRunner(abc.ABC):
             return default
 
     def run(self, command, **kwargs):
-        '''Runs command ('flash', 'debug', 'debugserver').
+        '''Runs command ('flash', 'debug', 'debugserver', 'attach').
 
         This is the main entry point to this runner.'''
         caps = self.capabilities()

--- a/src/west/runner/jlink.py
+++ b/src/west/runner/jlink.py
@@ -42,7 +42,7 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
 
     @classmethod
     def capabilities(cls):
-        return RunnerCaps(commands={'flash', 'debug', 'debugserver'},
+        return RunnerCaps(commands={'flash', 'debug', 'debugserver', 'attach'},
                           flash_addr=True)
 
     @classmethod
@@ -105,10 +105,11 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
             client_cmd = (self.gdb_cmd +
                           self.tui_arg +
                           [self.elf_name] +
-                          ['-ex', 'target remote :{}'.format(self.gdb_port),
-                           '-ex', 'monitor halt',
-                           '-ex', 'monitor reset',
-                           '-ex', 'load'])
+                          ['-ex', 'target remote :{}'.format(self.gdb_port)])
+            if command == 'debug':
+                client_cmd += ['-ex', 'monitor halt',
+                               '-ex', 'monitor reset',
+                               '-ex', 'load']
             self.print_gdbserver_message()
             self.run_server_and_client(server_cmd, client_cmd)
 

--- a/src/west/runner/jlink.py
+++ b/src/west/runner/jlink.py
@@ -42,7 +42,8 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
 
     @classmethod
     def capabilities(cls):
-        return RunnerCaps(flash_addr=True)
+        return RunnerCaps(commands={'flash', 'debug', 'debugserver'},
+                          flash_addr=True)
 
     @classmethod
     def do_add_parser(cls, parser):

--- a/src/west/runner/pyocd.py
+++ b/src/west/runner/pyocd.py
@@ -51,7 +51,7 @@ class PyOcdBinaryRunner(ZephyrBinaryRunner):
 
     @classmethod
     def capabilities(cls):
-        return RunnerCaps(commands={'flash', 'debug', 'debugserver'},
+        return RunnerCaps(commands={'flash', 'debug', 'debugserver', 'attach'},
                           flash_addr=True)
 
     @classmethod
@@ -141,8 +141,10 @@ class PyOcdBinaryRunner(ZephyrBinaryRunner):
             client_cmd = (self.gdb_cmd +
                           self.tui_args +
                           [self.elf_name] +
-                          ['-ex', 'target remote :{}'.format(self.gdb_port),
-                           '-ex', 'load',
-                           '-ex', 'monitor reset halt'])
+                          ['-ex', 'target remote :{}'.format(self.gdb_port)])
+            if command == 'debug':
+                client_cmd += ['-ex', 'load',
+                               '-ex', 'monitor reset halt']
+
             self.print_gdbserver_message()
             self.run_server_and_client(server_cmd, client_cmd)

--- a/src/west/runner/pyocd.py
+++ b/src/west/runner/pyocd.py
@@ -51,7 +51,8 @@ class PyOcdBinaryRunner(ZephyrBinaryRunner):
 
     @classmethod
     def capabilities(cls):
-        return RunnerCaps(flash_addr=True)
+        return RunnerCaps(commands={'flash', 'debug', 'debugserver'},
+                          flash_addr=True)
 
     @classmethod
     def do_add_parser(cls, parser):


### PR DESCRIPTION
Introduces a new west command to start a debugging session without
programming the flash. This can be used when you want to debug a Zephyr
application that is already running.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>