### PR TITLE
Add project commands for dealing with multiple repositories

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 PyYAML
+pykwalify

--- a/src/west/cmd/project.py
+++ b/src/west/cmd/project.py
@@ -1,0 +1,646 @@
+# Copyright (c) 2018, Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+
+'''West project commands'''
+
+import argparse
+import collections
+import os
+import shlex
+import shutil
+import subprocess
+import textwrap
+
+import pykwalify.core
+import yaml
+
+from . import WestCommand
+from .. import log
+from .. import util
+
+
+# Branch that points to the revision specified in the manifest (which might be
+# an SHA). Local branches created with 'west branch' are set to track this
+# branch.
+_MANIFEST_REV_BRANCH = 'manifest-rev'
+
+
+class ListProjects(WestCommand):
+    def __init__(self):
+        super().__init__(
+            'list-projects',
+            _wrap('''
+            List projects.
+
+            Prints the path to the manifest file and lists all projects along
+            with their clone paths and manifest revisions. Also includes
+            information on which projects are currently cloned.
+            '''))
+
+    def do_add_parser(self, parser_adder):
+        return _add_parser(parser_adder, self)
+
+    def do_run(self, args, user_args):
+        log.inf("Manifest path: {}\n".format(_manifest_path(args)))
+
+        for project in _all_projects(args):
+            log.inf('{:15} {:30} {:15} {}'.format(
+                project.name,
+                os.path.join(project.path, ''),  # Add final '/' if missing
+                project.revision,
+                "(cloned)" if _cloned(project) else "(not cloned)"))
+
+
+class Fetch(WestCommand):
+    def __init__(self):
+        super().__init__(
+            'fetch',
+            _wrap('''
+            Clone/fetch projects.
+
+            Fetches upstream changes in each of the specified projects
+            (default: all projects). Repositories that do not already exist are
+            cloned.
+
+            ''' + _MANIFEST_REV_HELP))
+
+    def do_add_parser(self, parser_adder):
+        return _add_parser(parser_adder, self, _project_list_arg)
+
+    def do_run(self, args, user_args):
+        for project in _projects(args, listed_must_be_cloned=False):
+            _fetch(project)
+
+
+class Pull(WestCommand):
+    def __init__(self):
+        super().__init__(
+            'pull',
+            _wrap('''
+            Clone/fetch and rebase projects.
+
+            Fetches upstream changes in each of the specified projects
+            (default: all projects) and rebases the checked-out branch (or
+            detached HEAD state) on top of '{}', effectively bringing the
+            branch up to date. Repositories that do not already exist are
+            cloned.
+
+            '''.format(_MANIFEST_REV_BRANCH) + _MANIFEST_REV_HELP))
+
+    def do_add_parser(self, parser_adder):
+        return _add_parser(parser_adder, self, _project_list_arg)
+
+    def do_run(self, args, user_args):
+        for project in _projects(args, listed_must_be_cloned=False):
+            if _fetch(project):
+                _rebase(project)
+
+
+class Rebase(WestCommand):
+    def __init__(self):
+        super().__init__(
+            'rebase',
+            _wrap('''
+            Rebase projects.
+
+            Rebases the checked-out branch (or detached HEAD) on top of '{}' in
+            each of the specified projects (default: all cloned projects),
+            effectively bringing the branch up to date.
+
+            '''.format(_MANIFEST_REV_BRANCH) + _MANIFEST_REV_HELP))
+
+    def do_add_parser(self, parser_adder):
+        return _add_parser(parser_adder, self, _project_list_arg)
+
+    def do_run(self, args, user_args):
+        for project in _projects(args):
+            if _cloned(project):
+                _rebase(project)
+
+
+class Branch(WestCommand):
+    def __init__(self):
+        super().__init__(
+            'branch',
+            _wrap('''
+            Create topic branch.
+
+            Creates a branch in each of the specified projects (default: all
+            cloned projects).
+
+            The new branches are set to track '{}'.
+
+            '''.format(_MANIFEST_REV_BRANCH) + _MANIFEST_REV_HELP))
+
+    def do_add_parser(self, parser_adder):
+        return _add_parser(parser_adder, self, _branch_arg, _project_list_arg)
+
+    def do_run(self, args, user_args):
+        for project in _projects(args):
+            if _cloned(project):
+                _create_branch(project, args.branch)
+
+
+class Checkout(WestCommand):
+    def __init__(self):
+        super().__init__(
+            'checkout',
+            _wrap('''
+            Check out topic branch.
+
+            Checks out the specified branch in each of the specified projects
+            (default: all cloned projects). Projects that do not have the
+            branch are left alone.
+            '''))
+
+    def do_add_parser(self, parser_adder):
+        return _add_parser(parser_adder, self, _b_flag, _branch_arg,
+                           _project_list_arg)
+
+    def do_run(self, args, user_args):
+        branch_exists = False
+
+        for project in _projects(args):
+            if _cloned(project):
+                if args.create_branch:
+                    _create_branch(project, args.branch)
+                    _checkout(project, args.branch)
+                    branch_exists = True
+                elif _has_branch(project, args.branch):
+                    _checkout(project, args.branch)
+                    branch_exists = True
+
+        if not branch_exists:
+            msg = 'No branch {} exists in any '.format(args.branch)
+            if args.projects:
+                log.die(msg + 'of the listed projects')
+            else:
+                log.die(msg + 'cloned project')
+
+
+class Diff(WestCommand):
+    def __init__(self):
+        super().__init__(
+            'diff',
+            _wrap('''
+            'git diff' projects.
+
+            Runs 'git diff' for each of the specified projects (default: all
+            cloned projects).
+
+            Extra arguments are passed as-is to 'git diff'.
+            '''),
+            accepts_unknown_args=True)
+
+    def do_add_parser(self, parser_adder):
+        return _add_parser(parser_adder, self, _project_list_arg)
+
+    def do_run(self, args, user_args):
+        for project in _projects(args):
+            if _cloned(project):
+                # Use paths that are relative to the base directory to make it
+                # easier to see where the changes are
+                _git(project, 'diff --src-prefix=(path)/ --dst-prefix=(path)/',
+                     extra_args=user_args)
+
+
+class Status(WestCommand):
+    def __init__(self):
+        super().__init__(
+            'status',
+            _wrap('''
+            Runs 'git status' for each of the specified projects (default: all
+            cloned projects). Extra arguments are passed as-is to 'git status'.
+            '''),
+            accepts_unknown_args=True)
+
+    def do_add_parser(self, parser_adder):
+        return _add_parser(parser_adder, self, _project_list_arg)
+
+    def do_run(self, args, user_args):
+        for project in _projects(args):
+            if _cloned(project):
+                _inf(project, 'status of (name-and-path)')
+                _git(project, 'status', extra_args=user_args)
+
+
+def _add_parser(parser_adder, cmd, *extra_args):
+    # Adds and returns a subparser for the project-related WestCommand 'cmd'.
+    # All of these commands (currently) take the manifest path flag, so it's
+    # hardcoded here.
+
+    return parser_adder.add_parser(
+        cmd.name,
+        description=cmd.description,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        parents=(_manifest_arg,) + extra_args)
+
+
+def _wrap(s):
+    # Wraps help texts for commands. Some of them have variable length (due to
+    # _MANIFEST_REV_BRANCH), so just a textwrap.dedent() can look a bit wonky.
+
+    # [1:] gets rid of the initial newline. It's turned into a space by
+    # textwrap.fill() otherwise.
+    paragraphs = textwrap.dedent(s[1:]).split("\n\n")
+
+    return "\n\n".join(textwrap.fill(paragraph) for paragraph in paragraphs)
+
+
+_MANIFEST_REV_HELP = """
+The '{}' branch points to the revision that the manifest specified for the
+project as of the most recent 'west fetch'/'west pull'.
+""".format(_MANIFEST_REV_BRANCH)[1:].replace("\n", " ")
+
+
+def _arg(*args, **kwargs):
+    # Helper for creating a new argument parser for a single argument,
+    # later passed in parents= to add_parser()
+
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument(*args, **kwargs)
+    return parser
+
+
+# Common manifest file argument
+_manifest_arg = _arg(
+    '-m', '--manifest',
+    help='path to manifest file (default: <west-topdir>/manifest/default.yml)')
+
+# Optional -b flag for 'west checkout'
+_b_flag = _arg(
+    '-b',
+    dest='create_branch',
+    action='store_true',
+    help='create the branch before checking it out')
+
+# Common branch argument
+_branch_arg = _arg('branch', metavar='BRANCH_NAME')
+
+# Common project list argument
+_project_list_arg = _arg('projects', metavar='PROJECT', nargs='*')
+
+
+# Holds information about a project, taken from the manifest file
+Project = collections.namedtuple(
+    'Project',
+    'name url revision path clone_depth')
+
+
+def _projects(args, listed_must_be_cloned=True):
+    # Returns a list of project instances for the projects requested in 'args'
+    # (the command-line arguments), in the same order that they were listed by
+    # the user. If args.projects is empty, no projects were listed, and all
+    # projects will be returned. If a non-existent project was listed by the
+    # user, an error is raised.
+    #
+    # Before the manifest is parsed, it is validated agains a pykwalify schema.
+    # An error is raised on validation errors.
+    #
+    # listed_must_be_cloned (default: True):
+    #   If True, an error is raised if an uncloned project was listed (or if a
+    #   listed project's directory doesn't look like a Git repository). This
+    #   only applies to projects listed explicitly on the command line.
+
+    projects = _all_projects(args)
+
+    if not args.projects:
+        # No projects specified. Return all projects.
+        return projects
+
+
+    # Got a list of projects on the command line. First, check that they exist
+    # in the manifest.
+
+    project_names = [project.name for project in projects]
+    nonexistent = set(args.projects) - set(project_names)
+    if nonexistent:
+        log.die('Unknown project{} {} (available projects: {})'
+                .format('s' if len(nonexistent) > 1 else '',
+                        ', '.join(nonexistent),
+                        ', '.join(project_names)))
+
+    # Return the projects in the order they were listed
+    res = []
+    for name in args.projects:
+        for project in projects:
+            if project.name == name:
+                res.append(project)
+                break
+
+    # Check that all listed repositories are cloned, if requested
+    if listed_must_be_cloned:
+        uncloned = [prj.name for prj in res if not _cloned(prj)]
+        if uncloned:
+            log.die('The following projects are not cloned: {}. Please clone '
+                    "them first (with 'west fetch')."
+                    .format(", ".join(uncloned)))
+
+    return res
+
+
+def _all_projects(args):
+    # Parses the manifest file, returning a list of Project instances.
+    #
+    # Before the manifest is parsed, it is validated against a pykwalify
+    # schema. An error is raised on validation errors.
+
+    manifest_path = _manifest_path(args)
+
+    _validate_manifest(manifest_path)
+
+
+    with open(manifest_path) as f:
+        manifest = yaml.safe_load(f)['manifest']
+
+    projects = []
+
+    # mp = manifest project (dictionary with values parsed from the manifest)
+    for mp in manifest['projects']:
+        # Fill in any missing fields in 'mp' with values from the 'defaults'
+        # dictionary
+        for key, val in manifest['defaults'].items():
+            mp.setdefault(key, val)
+
+        # Add the repository URL to 'mp'
+        for remote in manifest['remotes']:
+            if remote['name'] == mp['remote']:
+                mp['url'] = remote['url']
+                break
+        else:
+            log.die('Remote {} not defined in {}'
+                    .format(mp['remote'], manifest_path))
+
+        # Use named tuples to store project information. That gives nicer
+        # syntax compared to a dict (project.name instead of project['name'],
+        # etc.)
+        projects.append(Project(
+            mp['name'],
+            mp['url'],
+            # If no revision is specified, 'master' is used
+            mp.get('revision', 'master'),
+            # If no clone path is specified, the project's name is used
+            mp.get('path', mp['name']),
+            # If no clone depth is specified, we fetch the entire history
+            mp.get('clone-depth', None)))
+
+    return projects
+
+
+def _validate_manifest(manifest_path):
+    # Validates the manifest with pykwalify. schema.yml holds the schema.
+
+    schema_path = os.path.join(os.path.dirname(__file__), "schema.yml")
+
+    try:
+        pykwalify.core.Core(
+            source_file=manifest_path,
+            schema_files=[schema_path]
+        ).validate()
+    except pykwalify.errors.SchemaError as e:
+        log.die('{} malformed (schema: {}):\n{}'
+                .format(manifest_path, schema_path, e))
+
+
+def _manifest_path(args):
+    # Returns the path to the manifest file. Unless explicitly specified by the
+    # user, it defaults to manifest/default.yml within the West top directory.
+
+    if args.manifest:
+        return args.manifest
+
+    return os.path.join(util.west_topdir(), 'manifest', 'default.yml')
+
+
+def _fetch(project):
+    # Clone 'project' if it does not exist, and 'git fetch' it otherwise. Also
+    # update the 'manifest-rev' branch to point to the revision specified in
+    # the manifest.
+    #
+    # Returns True if the project already existed, and False if it was cloned.
+
+    if os.path.exists(os.path.join(util.west_topdir(), project.path)):
+        existed = True
+        _verify_repo(project)
+        _inf(project, 'Fetching changes for (name-and-path)')
+        _git(project, 'remote update')
+    else:
+        existed = False
+
+        # --depth implies --single-branch, so we must pass --branch when
+        # creating a shallow clone (since the remote might not have HEAD
+        # pointing to the 'revision' branch).
+        #
+        # Currently, we also pass --branch for non-shallow clones, which checks
+        # the 'revision' branch out in the newly created repo, but this might
+        # change.
+
+        msg = 'Cloning (name-and-path)'
+        cmd = 'clone'
+        if not _is_sha(project.revision):
+            cmd += ' --branch (revision)'
+        if project.clone_depth:
+            msg += ' with --depth (clone-depth)'
+            cmd += ' --depth (clone-depth)'
+        cmd += ' (url)/(name) (path)'
+
+        _inf(project, msg)
+        _git_base(project, cmd)
+
+    # Update manifest-rev branch
+    _git(project,
+         'update-ref refs/heads/(manifest-rev-branch) {}'.format(
+             (project.revision if _is_sha(project.revision) else
+                 'origin/' + project.revision)))
+
+    return existed
+
+
+def _rebase(project):
+    _inf(project, 'Rebasing (name-and-path) to (manifest-rev-branch)')
+    _git(project, 'rebase (manifest-rev-branch)')
+
+
+def _cloned(project):
+    # Returns True if the project's repository exists and looks like a Git
+    # repository.
+    #
+    # Prints a warning if the project's clone path exist but doesn't look like
+    # a Git repository.
+
+    if os.path.exists(os.path.join(util.west_topdir(), project.path)):
+        _verify_repo(project)
+        return True
+
+    return False
+
+
+def _verify_repo(project):
+    # Raises an error if the project's clone path is not the top-level
+    # directory of a Git repository
+
+    # --is-inside-work-tree doesn't require that the directory is the top-level
+    # directory of a Git repository. Use --show-cdup instead, which prints an
+    # empty string (i.e., just a newline, which we strip) for the top-level
+    # directory.
+    res = _git(project, 'rev-parse --show-cdup', capture_stdout=True,
+               check=False)
+
+    if res.returncode or res.stdout:
+        _die(project, '(name-and-path) is not the top-level directory of a '
+                      'Git repository, as reported by '
+                      "'git rev-parse --show-cdup'")
+
+
+def _create_branch(project, branch):
+    if _has_branch(project, branch):
+        _inf(project, "Branch '{}' already exists in (name-and-path)"
+                      .format(branch))
+    else:
+        _inf(project, "Creating branch '{}' in (name-and-path)"
+                      .format(branch))
+        _git(project, 'branch --quiet --track {} (manifest-rev-branch)'
+                      .format(branch))
+
+
+def _has_branch(project, branch):
+    return _git(project, 'show-ref --quiet --verify refs/heads/' + branch,
+                check=False).returncode == 0
+
+
+def _checkout(project, branch):
+    _inf(project, "Checking out branch '{}' in (name-and-path)".format(branch))
+    _git(project, 'checkout ' + branch)
+
+
+def _is_sha(s):
+    try:
+        int(s, 16)
+    except ValueError:
+        return False
+
+    return len(s) == 40
+
+
+def _git_base(project, cmd, *, extra_args=(), capture_stdout=False, check=True):
+    # Runs a git command in the West top directory. See _git_helper() for
+    # parameter documentation.
+    #
+    # Returns a CompletedProcess instance (see below).
+
+    return _git_helper(project, cmd, extra_args, util.west_topdir(),
+                       capture_stdout, check)
+
+
+def _git(project, cmd, *, extra_args=(), capture_stdout=False, check=True):
+    # Runs a git command within a particular project. See _git_helper() for
+    # parameter documentation.
+    #
+    # Returns a CompletedProcess instance (see below).
+
+    return _git_helper(project, cmd, extra_args,
+                       os.path.join(util.west_topdir(), project.path),
+                       capture_stdout, check)
+
+
+def _git_helper(project, cmd, extra_args, cwd, capture_stdout, check):
+    # Runs a git command.
+    #
+    # project:
+    #   The Project instance for the project, derived from the manifest file.
+    #
+    # cmd:
+    #   String with git arguments. Supports some "(foo)" shorthands. See below.
+    #
+    # extra_args:
+    #   List of additional arguments to pass to the git command (e.g. from the
+    #   user).
+    #
+    # cwd:
+    #   Directory to switch to first (None = current directory)
+    #
+    # capture_stdout:
+    #   True if stdout should be captured into the returned
+    #   subprocess.CompletedProcess instance instead of being printed.
+    #
+    #   We never capture stderr, to prevent error messages from being eaten.
+    #
+    # check:
+    #   True if an error should be raised if the git command finishes with a
+    #   non-zero return code.
+    #
+    # Returns a subprocess.CompletedProcess instance.
+
+    # TODO: Run once somewhere?
+    if shutil.which('git') is None:
+        log.die('Git is not installed or cannot be found')
+
+    args = ('git',) + \
+           tuple(_expand_shorthands(project, arg) for arg in cmd.split()) + \
+           tuple(extra_args)
+
+    popen = subprocess.Popen(
+        args, stdout=subprocess.PIPE if capture_stdout else None, cwd=cwd)
+
+    stdout, _ = popen.communicate()
+
+    if check and popen.returncode:
+        _die(project, "Command '{}' failed for (name-and-path)"
+                      .format(" ".join(shlex.quote(arg) for arg in args)))
+
+    if capture_stdout:
+        # Manual UTF-8 decoding and universal newlines. Before Python 3.6,
+        # Popen doesn't seem to allow using universal newlines mode (which
+        # enables decoding) with a specific encoding (because the encoding=
+        # parameter is missing).
+        #
+        # Also strip all trailing newlines as convenience. The splitlines()
+        # already means we lose a final '\n' anyway.
+        stdout = "\n".join(stdout.decode('utf-8').splitlines()).rstrip("\n")
+
+    return CompletedProcess(popen.args, popen.returncode, stdout)
+
+
+def _expand_shorthands(project, s):
+    # Expands project-related shorthands in 's' to their values,
+    # returning the expanded string
+
+    return s.replace('(name)', project.name) \
+            .replace('(name-and-path)',
+                     '{} ({})'.format(
+                         project.name, os.path.join(project.path, ""))) \
+            .replace('(url)', project.url) \
+            .replace('(path)', project.path) \
+            .replace('(revision)', project.revision) \
+            .replace('(manifest-rev-branch)', _MANIFEST_REV_BRANCH) \
+            .replace('(clone-depth)', str(project.clone_depth))
+
+
+def _die(project, msg):
+    # Die with 'msg'. Supports the same (foo) shorthands as the git commands.
+
+    log.die(_expand_shorthands(project, msg))
+
+
+def _inf(project, msg):
+    # Print '=== msg' (to clearly separate it from Git output). Supports the
+    # same (foo) shorthands as the git commands.
+
+    log.inf('=== ' + _expand_shorthands(project, msg))
+
+
+def _wrn(project, msg):
+    # Warn with 'msg'. Supports the same (foo) shorthands as the git commands.
+
+    log.wrn(_expand_shorthands(project, msg))
+
+
+# subprocess.CompletedProcess-alike, used instead of the real deal for Python
+# 3.4 compatibility, and with two small differences:
+#
+# - Trailing newlines are stripped from stdout
+#
+# - The 'stderr' attribute is omitted, because we never capture stderr
+CompletedProcess = collections.namedtuple(
+    'CompletedProcess', 'args returncode stdout')

--- a/src/west/cmd/schema.yml
+++ b/src/west/cmd/schema.yml
@@ -1,0 +1,135 @@
+## A pykwalify schema for basic validation of the structure of a
+## manifest YAML file.  (Full validation would require additional work,
+## e.g. to validate that remote URLs obey the URL format specified in
+## rfc1738.)
+##
+## This schema has similar semantics to the repo XML format:
+##
+## https://gerrit.googlesource.com/git-repo/+/master/docs/manifest-format.txt
+##
+## However, the features don't map 1:1.
+
+# The top-level manifest is a map. The only top-level element is
+# 'manifest'. All other elements are contained within it. This allows
+# us a bit of future-proofing.
+type: map
+mapping:
+  manifest:
+    required: true
+    type: map
+    mapping:
+      # The "defaults" key specifies some default values used in the
+      # rest of the manifest.
+      #
+      # The value is a map with the following keys:
+      #
+      # - remote: if given, this is the default remote in each project
+      # - revision: if given, this is the default revision to check
+      #   out of each project
+      #
+      # See below for more information about remotes and projects.
+      #
+      # Examples:
+      #
+      # default:
+      #   remote: zephyrproject-rtos
+      #   revision: master
+      defaults:
+        required: false
+        type: map
+        mapping:
+          remote:
+            required: false
+            type: str
+          revision:
+            required: false
+            type: str
+
+      # The "remotes" key specifies a sequence of remotes, each of
+      # which has a name and a fetch URL.
+      #
+      # These work like repo remotes, in that they specify a URL
+      # prefix which remote-specific Git repositories hang off of.
+      # (This saves typing and makes it easier to move things around
+      # when most repositories are on the same server or GitHub
+      # organization.)
+      #
+      # Example:
+      #
+      #   remotes:
+      #     - name: zephyrproject-rtos
+      #       url: https://github.com/zephyrproject-rtos
+      #     - name: developer-fork
+      #       url: https://github.com/a-developer
+      remotes:
+        required: true
+        type: seq
+        sequence:
+          - type: map
+            mapping:
+              name:
+                required: true
+                type: str
+              url:
+                required: true
+                type: str
+
+      # The "projects" key specifies a sequence of "projects",
+      # i.e. Git repositories. These work like repo projects, in that
+      # each project has a name, a remote, and optional additional
+      # metadata.
+      #
+      # Each project is a map with the following keys:
+      #
+      # - name: Mandatory, the name of the git repository. The clone
+      #   URL is formed by remote + '/' + name
+      # - remote: Optional, the name of the remote to pull it from.
+      #   If the remote is missing, the remote'key in the top-level
+      #   defaults key is used instead. If both are missing, it's an error.
+      # - revision: Optional, the name of the revision to check out.
+      #   If not given, the value from the default element will be used.
+      #   If both are missing, then the default is 'master'.
+      # - path: Where to clone the repository locally. If missing,
+      #   it's cloned at top level in a directory given by its name.
+      # - clone-depth: if given, it is a number which creates a shallow
+      #   history in the cloned repository limited to the given number
+      #   of commits.
+      #
+      # Example, using default and non-default remotes:
+      #
+      #   projects:
+      #     # Uses default remote (zephyrproject-rtos), so clone URL is:
+      #     #   https://github.com/zephyrproject-rtos/zephyr
+      #     - name: zephyr
+      #     # Manually specified remote; clone URL is:
+      #     #   https://github.com/a-developer/west
+      #     - name: west
+      #       remote: developer-fork
+      #     # Manually specified remote, clone URL is:
+      #     #   https://github.com/zephyrproject-rtos/some-vendor-hal
+      #     # Local clone path (relative to installation root) is:
+      #     #   ext/hal/some-vendor
+      #     - name: some-vendor-hal
+      #       remote: zephyrproject-rtos
+      #       path: ext/hal/some-vendor
+      projects:
+        required: true
+        type: seq
+        sequence:
+          - type: map
+            mapping:
+              name:
+                required: true
+                type: str
+              remote:
+                required: false
+                type: str
+              revision:
+                required: false
+                type: text        # SHAs could be only numbers
+              path:
+                required: false
+                type: str
+              clone-depth:
+                required: false
+                type: int

--- a/src/west/main.py
+++ b/src/west/main.py
@@ -17,10 +17,27 @@ from .cmd import CommandContextError
 from .cmd.build import Build
 from .cmd.flash import Flash
 from .cmd.debug import Debug, DebugServer
+from .cmd.project import ListProjects, Fetch, Pull, Rebase, Branch, Checkout, \
+                         Diff, Status
 from .util import quote_sh_list
 
 
-COMMANDS = (Build(), Flash(), Debug(), DebugServer())
+COMMANDS = (
+    Build(),
+    Flash(),
+    Debug(),
+    DebugServer(),
+
+    # Project-related commands
+    ListProjects(),
+    Fetch(),
+    Pull(),
+    Rebase(),
+    Branch(),
+    Checkout(),
+    Diff(),
+    Status(),
+)
 '''Built-in West commands.'''
 
 

--- a/src/west/util.py
+++ b/src/west/util.py
@@ -5,6 +5,7 @@
 '''Miscellaneous utilities used by west
 '''
 
+import os
 import shlex
 import textwrap
 
@@ -20,3 +21,26 @@ def wrap(text, indent):
     '''Convenience routine for wrapping text to a consistent indent.'''
     return textwrap.wrap(text, initial_indent=indent,
                          subsequent_indent=indent)
+
+
+class WestNotFound(RuntimeError):
+    '''Neither the current directory nor any parent has a West installation.'''
+
+
+def west_topdir():
+    '''
+    Returns the absolute path of the first directory containing a .west/
+    directory, searching the current directory and its parents.
+
+    Raises WestNotFound if no .west/ directory is found.
+    '''
+    search_dir = os.getcwd()
+
+    # While the directory is not the root directory...
+    while search_dir != os.path.dirname(search_dir):
+        if os.path.isdir(os.path.join(search_dir, '.west')):
+            return search_dir
+        search_dir = os.path.dirname(search_dir)
+
+    raise WestNotFound('Could not find a West installation (a .west/ '
+                       'directory) in this or any parent directory')

--- a/tests/west/project/__init__.py
+++ b/tests/west/project/__init__.py
@@ -1,0 +1,1 @@
+# Nothing here.

--- a/tests/west/project/manifest.yml
+++ b/tests/west/project/manifest.yml
@@ -1,0 +1,18 @@
+# Testing manifest
+
+manifest:
+  defaults:
+    remote: zephyrproject-rtos
+    revision: master
+
+  remotes:
+    - name: zephyrproject-rtos
+      url: https://github.com/zephyrproject-rtos
+
+  projects:
+    - name: net-tools
+      clone-depth: 1
+    - name: Kconfiglib
+      clone-depth: 1
+      revision: zephyr
+      path: sub/kconfiglib

--- a/tests/west/project/test_project.py
+++ b/tests/west/project/test_project.py
@@ -1,0 +1,199 @@
+import argparse
+import os
+import shlex
+import tempfile
+
+import pytest
+
+import west.cmd.project
+
+
+MANIFEST_PATH = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), 'manifest.yml')
+)
+
+# Where the projects are cloned to
+NET_TOOLS_PATH = 'net-tools'
+KCONFIGLIB_PATH = 'sub/kconfiglib'
+
+COMMAND_OBJECTS = (
+    west.cmd.project.ListProjects(),
+    west.cmd.project.Fetch(),
+    west.cmd.project.Pull(),
+    west.cmd.project.Rebase(),
+    west.cmd.project.Branch(),
+    west.cmd.project.Checkout(),
+    west.cmd.project.Diff(),
+    west.cmd.project.Status(),
+)
+
+
+def cmd(cmd):
+    cmd += ' -m ' + MANIFEST_PATH
+
+    # cmd() takes the command as a string, which is less clunky to work with.
+    # Split it according to shell rules.
+    split_cmd = shlex.split(cmd)
+    command_name = split_cmd[0]
+
+    for command_object in COMMAND_OBJECTS:
+        # Find the WestCommand object that implements the command
+        if command_object.name == command_name:
+            # Use it to parse the arguments
+            parser = argparse.ArgumentParser()
+            command_object.do_add_parser(parser.add_subparsers())
+
+            # Pass the parsed arguments and unknown arguments to run it
+            command_object.do_run(*parser.parse_known_args(shlex.split(cmd)))
+            break
+    else:
+        assert False, "unknown command " + command_name
+
+
+@pytest.fixture
+def clean_west_topdir(tmpdir):
+    tmpdir.mkdir('.west')
+    tmpdir.chdir()
+
+
+def test_list_projects(clean_west_topdir):
+    # TODO: Check output
+    cmd('list-projects')
+
+
+def test_fetch(clean_west_topdir):
+    # Clone all projects
+    cmd('fetch')
+
+    # Check that they got cloned
+    assert os.path.isdir(NET_TOOLS_PATH)
+    assert os.path.isdir(KCONFIGLIB_PATH)
+
+    # Non-existent project
+    with pytest.raises(SystemExit):
+        cmd('fetch non-existent')
+
+    # Update a specific project
+    cmd('fetch net-tools')
+
+
+def test_pull(clean_west_topdir):
+    # Clone all projects
+    cmd('pull')
+
+    # Check that they got cloned
+    assert os.path.isdir(NET_TOOLS_PATH)
+    assert os.path.isdir(KCONFIGLIB_PATH)
+
+    # Non-existent project
+    with pytest.raises(SystemExit):
+        cmd('pull non-existent')
+
+    # Update a specific project
+    cmd('pull net-tools')
+
+
+def test_rebase(clean_west_topdir):
+    # Clone just one project
+    cmd('fetch net-tools')
+
+    # Piggyback a check that just that project got cloned
+    assert not os.path.exists(KCONFIGLIB_PATH)
+
+    # Rebase the project (non-cloned project should be silently skipped)
+    cmd('rebase')
+
+    # Rebase the project again, naming it explicitly
+    cmd('rebase net-tools')
+
+    # Try rebasing a project that hasn't been cloned
+    with pytest.raises(SystemExit):
+        cmd('pull rebase Kconfiglib')
+
+    # Clone the other project
+    cmd('pull Kconfiglib')
+
+    # Will rebase both projects now
+    cmd('rebase')
+
+
+def test_branches(clean_west_topdir):
+    # Missing branch name
+    with pytest.raises(SystemExit):
+        cmd('branch')
+
+    # Missing branch name
+    with pytest.raises(SystemExit):
+        cmd('checkout')
+
+
+    # Clone just one project
+    cmd('fetch net-tools')
+
+    # Create a branch in the cloned project
+    cmd('branch foo')
+
+    # Check out the branch
+    cmd('checkout foo')
+
+    # Check out the branch again, naming the project explicitly
+    cmd('checkout foo net-tools')
+
+    # Try checking out a branch that doesn't exist in any project
+    with pytest.raises(SystemExit):
+        cmd('checkout nonexistent')
+
+    # Try checking out a branch in a non-cloned project
+    with pytest.raises(SystemExit):
+        cmd('checkout foo Kconfiglib')
+
+    # Clone the other project
+    cmd('fetch Kconfiglib')
+
+    # It still doesn't have the branch
+    with pytest.raises(SystemExit):
+        cmd('checkout foo Kconfiglib')
+
+    # Create a differently-named branch it
+    cmd('branch bar Kconfiglib')
+
+    # That branch shouldn't exist in the other project
+    with pytest.raises(SystemExit):
+        cmd('checkout bar net-tools')
+
+    # It should be possible to check out each branch even though they only
+    # exists in one project
+    cmd('checkout foo')
+    cmd('checkout bar')
+
+
+def test_diff(clean_west_topdir):
+    # TODO: Check output
+
+    # Diff with no projects cloned shouldn't fail
+
+    cmd('diff')
+
+    # Neither should it fail after fetching one or both projects
+
+    cmd('fetch net-tools')
+    cmd('diff')
+
+    cmd('fetch Kconfiglib')
+    cmd('diff --cached')  # Pass a custom flag too
+
+
+def test_status(clean_west_topdir):
+    # TODO: Check output
+
+    # Status with no projects cloned shouldn't fail
+    cmd('status')
+
+    # Neither should it fail after fetching one or both projects
+    cmd('fetch net-tools')
+    cmd('status')
+
+    # Neither should it fail after fetching one or both projects
+    cmd('fetch Kconfiglib')
+    # Pass a custom flag too
+    cmd('status --long')  # Pass a custom flag too


### PR DESCRIPTION
Add simple Google repo-like functionality, for dealing with multiple Git
repositories.

The command set is mirrored after Git. All commands except
'list-projects' accept an optional list of projects, and default to all
(cloned) projects.

  - west list-projects

    Lists projects and their repositories

  - west fetch

    Clone/fetch projects. Supports 'clone-depth', for making shallow
    clones.

  - west rebase

    Rebase local branches to the revision specified in the manifest

  - west pull

    'west fetch' + 'west rebase' (similar to 'sync' in Google repo)

  - west branch

    Create a new branch in one or more repositories (for working on some
    issue)

  - west checkout

    Check out a branch in each repository that has it

  - west diff

    Run 'git diff' in each repository

  - west status

    Run 'git status' in reach repository

There's no way to submit a multi-repository change for review yet.

Currently, a convenience branch 'manifest-rev' is created in each
project, which points to the revision specified for the project in the
manifest. 'manifest-rev' is updated by 'west fetch' and 'west pull'.

Local branches created with 'west branch' are set to track
'manifest-rev'. This makes e.g. a plain 'git status' or 'git pull' work
sensibly even when the manifest revision is an SHA.

We'll see if 'manifest-rev' is too magic later. It's explained in the
help texts of all the relevant commands at least.

It might be nicer to create 'manifest-rev' in e.g. refs/remotes instead
of refs/heads. Git doesn't seem to like trying to create a branch that
tracks a branch in refs/remotes unless it's a "proper" upstream branch
though.