### PR TITLE
Shippable integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ west.egg-info/
 __pycache__/
 .pytest_cache/
 .eggs/
+shippable/

--- a/.shippable.yml
+++ b/.shippable.yml
@@ -1,0 +1,17 @@
+language: python
+# TODO: 3.7 is failing. It'd be good to figure this out eventually as
+# it's the latest version which is likely what Windows and macOS users
+# run on, but is left out for now.
+python:
+  - 3.4                         # minimum supported version
+  - 3.5                         # ubuntu 16.04
+  - 3.6                         # ubuntu 18.04
+
+build:
+  ci:
+    - pip install -r requirements.txt
+    - pip install -r tests_requirements.txt
+    - pip install -e .
+    - mkdir -p shippable/{testresults,codecoverage}
+    - pytest --junitxml=shippable/testresults/nosetests.xml tests
+    - pytest --cov=west --cov-report=xml:shippable/codecoverage/coverage.xml tests

--- a/tests_requirements.txt
+++ b/tests_requirements.txt
@@ -1,1 +1,2 @@
 pytest
+pytest-cov


### PR DESCRIPTION
This ought to provide shippable integration for the recently merged test suite. It's my first time though, so I expect it might have some issues (and I haven't set up an account on shippable itself, just tried to do the local integration here).
