### PR TITLE
Add 'forall' command

### DIFF
--- a/src/west/main.py
+++ b/src/west/main.py
@@ -18,7 +18,7 @@ from .cmd.build import Build
 from .cmd.flash import Flash
 from .cmd.debug import Debug, DebugServer
 from .cmd.project import ListProjects, Fetch, Pull, Rebase, Branch, Checkout, \
-                         Diff, Status
+                         Diff, Status, ForAll
 from .util import quote_sh_list
 
 
@@ -37,6 +37,7 @@ COMMANDS = (
     Checkout(),
     Diff(),
     Status(),
+    ForAll(),
 )
 '''Built-in West commands.'''
 

--- a/tests/west/project/test_project.py
+++ b/tests/west/project/test_project.py
@@ -25,6 +25,7 @@ COMMAND_OBJECTS = (
     west.cmd.project.Checkout(),
     west.cmd.project.Diff(),
     west.cmd.project.Status(),
+    west.cmd.project.ForAll(),
 )
 
 
@@ -187,13 +188,30 @@ def test_status(clean_west_topdir):
     # TODO: Check output
 
     # Status with no projects cloned shouldn't fail
+
     cmd('status')
 
     # Neither should it fail after fetching one or both projects
+
     cmd('fetch net-tools')
     cmd('status')
 
-    # Neither should it fail after fetching one or both projects
     cmd('fetch Kconfiglib')
-    # Pass a custom flag too
     cmd('status --long')  # Pass a custom flag too
+
+
+def test_forall(clean_west_topdir):
+    # TODO: Check output
+    # The 'echo' command is available in both 'shell' and 'batch'
+
+    # 'forall' with no projects cloned shouldn't fail
+
+    cmd("forall -c 'echo *'")
+
+    # Neither should it fail after fetching one or both projects
+
+    cmd('fetch net-tools')
+    cmd("forall -c 'echo *'")
+
+    cmd('fetch Kconfiglib')
+    cmd("forall -c 'echo *'")


### PR DESCRIPTION
Passes its command as-is to the shell, within the repositories of each
of the specified projects (or all cloned projects by default).

I was thinking of making the shell quoting for long commands optional,
by joining all the words with a space or the like, but it might get
tricky with argparse. Could look into it more later.

Piggyback some cleanup: Make the absolute path of a project available in
project.abspath, to avoid having to do a bunch of join()s with
util.west_topdir().

Fix some copy-paste comment mess-ups in the tests too.