### PR TITLE
Misc fixes

### DIFF
--- a/src/west/cmd/project.py
+++ b/src/west/cmd/project.py
@@ -369,7 +369,6 @@ def _projects(args, listed_must_be_cloned=True):
         # No projects specified. Return all projects.
         return projects
 
-
     # Got a list of projects on the command line. First, check that they exist
     # in the manifest.
 
@@ -409,7 +408,6 @@ def _all_projects(args):
     manifest_path = _manifest_path(args)
 
     _validate_manifest(manifest_path)
-
 
     with open(manifest_path) as f:
         manifest = yaml.safe_load(f)['manifest']
@@ -599,7 +597,8 @@ def _is_sha(s):
     return len(s) == 40
 
 
-def _git_base(project, cmd, *, extra_args=(), capture_stdout=False, check=True):
+def _git_base(project, cmd, *, extra_args=(), capture_stdout=False,
+              check=True):
     # Runs a git command in the West top directory. See _git_helper() for
     # parameter documentation.
     #
@@ -651,9 +650,9 @@ def _git_helper(project, cmd, extra_args, cwd, capture_stdout, check):
     if shutil.which('git') is None:
         log.die('Git is not installed or cannot be found')
 
-    args = ('git',) + \
-           tuple(_expand_shorthands(project, arg) for arg in cmd.split()) + \
-           tuple(extra_args)
+    args = (('git',) +
+            tuple(_expand_shorthands(project, arg) for arg in cmd.split()) +
+            tuple(extra_args))
 
     popen = subprocess.Popen(
         args, stdout=subprocess.PIPE if capture_stdout else None, cwd=cwd)

--- a/src/west/cmd/project.py
+++ b/src/west/cmd/project.py
@@ -415,11 +415,13 @@ def _all_projects(args):
     projects = []
 
     # mp = manifest project (dictionary with values parsed from the manifest)
+    project_defaults = ('remote', 'revision')
     for mp in manifest['projects']:
         # Fill in any missing fields in 'mp' with values from the 'defaults'
         # dictionary
         for key, val in manifest['defaults'].items():
-            mp.setdefault(key, val)
+            if key in project_defaults:
+                mp.setdefault(key, val)
 
         # Add the repository URL to 'mp'
         for remote in manifest['remotes']:

--- a/src/west/cmd/project.py
+++ b/src/west/cmd/project.py
@@ -503,8 +503,15 @@ def _fetch(project):
 
         msg = 'Cloning (name-and-path)'
         cmd = 'clone'
-        if not _is_sha(project.revision):
+        if _is_sha(project.revision):
+            # If the project revision is a SHA and the remote repo's
+            # HEAD doesn't point to anything valid, the clone
+            # operation might fail to check anything out. In that
+            # case, make sure to check out the given revision.
+            checkout = True
+        else:
             cmd += ' --branch (revision)'
+            checkout = False
         if project.clone_depth:
             msg += ' with --depth (clone-depth)'
             cmd += ' --depth (clone-depth)'
@@ -512,6 +519,9 @@ def _fetch(project):
 
         _inf(project, msg)
         _git_base(project, cmd)
+
+        if checkout:
+            _checkout(project, project.revision)
 
     # Update manifest-rev branch
     _git(project,
@@ -548,7 +558,7 @@ def _cloned(project):
     res = _git(project, 'rev-parse --show-cdup', capture_stdout=True,
                check=False)
 
-    return handle(not(res.returncode or res.stdout))
+    return handle(not (res.returncode or res.stdout))
 
 
 def _branches(project):

--- a/src/west/cmd/project.py
+++ b/src/west/cmd/project.py
@@ -413,9 +413,11 @@ def _all_projects(args):
         manifest = yaml.safe_load(f)['manifest']
 
     projects = []
+    # Manifest "defaults" keys whose values get copied to each project
+    # that doesn't specify its own value.
+    project_defaults = ('remote', 'revision')
 
     # mp = manifest project (dictionary with values parsed from the manifest)
-    project_defaults = ('remote', 'revision')
     for mp in manifest['projects']:
         # Fill in any missing fields in 'mp' with values from the 'defaults'
         # dictionary
@@ -426,7 +428,7 @@ def _all_projects(args):
         # Add the repository URL to 'mp'
         for remote in manifest['remotes']:
             if remote['name'] == mp['remote']:
-                mp['url'] = remote['url']
+                mp['url'] = remote['url'] + '/' + mp['name']
                 break
         else:
             log.die('Remote {} not defined in {}'
@@ -507,7 +509,7 @@ def _fetch(project):
         if project.clone_depth:
             msg += ' with --depth (clone-depth)'
             cmd += ' --depth (clone-depth)'
-        cmd += ' (url)/(name) (path)'
+        cmd += ' (url) (path)'
 
         _inf(project, msg)
         _git_base(project, cmd)


### PR DESCRIPTION
Hi @ulfalizer, I gave the new project commands a go and (with these patches) was able to get a manifest written for my company's Zephyr-based product and run 'west init + west fetch' successfully.

The only real fix is the _verify_repo()-related patch; everything else is just future-proofing, OCD, and the like.

Haven't tested anything else yet but optimistic about the start! Thanks for all the great work.