### PR TITLE
runner: pyocd: add support for specifying SWDCLK frequency

### DIFF
--- a/src/west/runners/pyocd.py
+++ b/src/west/runners/pyocd.py
@@ -20,7 +20,7 @@ class PyOcdBinaryRunner(ZephyrBinaryRunner):
                  flashtool_opts=None,
                  gdbserver='pyocd-gdbserver',
                  gdb_port=DEFAULT_PYOCD_GDB_PORT, tui=False,
-                 board_id=None, daparg=None):
+                 board_id=None, daparg=None, frequency=None):
         super(PyOcdBinaryRunner, self).__init__(cfg)
 
         self.target_args = ['-t', target]
@@ -42,6 +42,11 @@ class PyOcdBinaryRunner(ZephyrBinaryRunner):
         if daparg is not None:
             daparg_args = ['-da', daparg]
         self.daparg_args = daparg_args
+
+        frequency_args = []
+        if frequency is not None:
+            frequency_args = ['-f', frequency]
+        self.frequency_args = frequency_args
 
         self.flashtool_extra = flashtool_opts if flashtool_opts else []
 
@@ -66,6 +71,8 @@ class PyOcdBinaryRunner(ZephyrBinaryRunner):
         parser.add_argument('--flashtool-opt', default=[], action='append',
                             help='''Additional options for pyocd-flashtool,
                             e.g. -ce to chip erase''')
+        parser.add_argument('--frequency',
+                            help='SWD clock frequency in Hz')
         parser.add_argument('--gdbserver', default='pyocd-gdbserver',
                             help='GDB server, default is pyocd-gdbserver')
         parser.add_argument('--gdb-port', default=DEFAULT_PYOCD_GDB_PORT,
@@ -94,7 +101,7 @@ class PyOcdBinaryRunner(ZephyrBinaryRunner):
             cfg, args.target, flashtool=args.flashtool,
             flash_addr=flash_addr, flashtool_opts=args.flashtool_opt,
             gdbserver=args.gdbserver, gdb_port=args.gdb_port, tui=args.tui,
-            board_id=args.board_id, daparg=args.daparg)
+            board_id=args.board_id, daparg=args.daparg, frequency=args.frequency)
 
     def port_args(self):
         return ['-p', str(self.gdb_port)]
@@ -114,6 +121,7 @@ class PyOcdBinaryRunner(ZephyrBinaryRunner):
                self.daparg_args +
                self.target_args +
                self.board_args +
+               self.frequency_args +
                self.flashtool_extra +
                [self.bin_name])
 
@@ -128,7 +136,8 @@ class PyOcdBinaryRunner(ZephyrBinaryRunner):
                       self.daparg_args +
                       self.port_args() +
                       self.target_args +
-                      self.board_args)
+                      self.board_args  +
+                      self.frequency_args)
 
         if command == 'debugserver':
             self.print_gdbserver_message()

--- a/tests/west/runners/test_pyocd.py
+++ b/tests/west/runners/test_pyocd.py
@@ -19,6 +19,7 @@ from conftest import RC_BUILD_DIR, RC_GDB, RC_KERNEL_BIN, RC_KERNEL_ELF
 TEST_TOOL = 'test-tool'
 TEST_ADDR = 0xadd
 TEST_BOARD_ID = 'test-board-id'
+TEST_FREQUENCY = 'test-frequency'
 TEST_DAPARG = 'test-daparg'
 TEST_TARGET = 'test-target'
 TEST_FLASHTOOL_OPTS = ['--test-flashtool', 'args']
@@ -33,6 +34,7 @@ TEST_ALL_KWARGS = {
     'gdb_port': TEST_PORT,
     'tui': False,
     'board_id': TEST_BOARD_ID,
+    'frequency': TEST_FREQUENCY,
     'daparg': TEST_DAPARG
     }
 
@@ -45,7 +47,8 @@ TEST_ALL_PARAMS = (['--target', TEST_TARGET,
                     TEST_FLASHTOOL_OPTS] +
                    ['--gdbserver', TEST_SERVER,
                     '--gdb-port', str(TEST_PORT),
-                    '--board-id', TEST_BOARD_ID])
+                    '--board-id', TEST_BOARD_ID,
+                    '--frequency', str(TEST_FREQUENCY)])
 
 TEST_DEF_PARAMS = ['--target', TEST_TARGET]
 
@@ -63,7 +66,8 @@ TEST_DEF_PARAMS = ['--target', TEST_TARGET]
 
 FLASH_ALL_EXPECTED_CALL = ([TEST_TOOL,
                             '-a', hex(TEST_ADDR), '-da', TEST_DAPARG,
-                            '-t', TEST_TARGET, '-b', TEST_BOARD_ID] +
+                            '-t', TEST_TARGET, '-b', TEST_BOARD_ID,
+                            '-f', TEST_FREQUENCY] +
                            TEST_FLASHTOOL_OPTS +
                            [RC_KERNEL_BIN])
 FLASH_DEF_EXPECTED_CALL = ['pyocd-flashtool', '-t', TEST_TARGET, RC_KERNEL_BIN]
@@ -73,7 +77,8 @@ DEBUG_ALL_EXPECTED_SERVER = [TEST_SERVER,
                              '-da', TEST_DAPARG,
                              '-p', str(TEST_PORT),
                              '-t', TEST_TARGET,
-                             '-b', TEST_BOARD_ID]
+                             '-b', TEST_BOARD_ID,
+                             '-f', TEST_FREQUENCY]
 DEBUG_ALL_EXPECTED_CLIENT = [RC_GDB, RC_KERNEL_ELF,
                              '-ex', 'target remote :{}'.format(TEST_PORT),
                              '-ex', 'load',
@@ -91,7 +96,8 @@ DEBUGSERVER_ALL_EXPECTED_CALL = [TEST_SERVER,
                                  '-da', TEST_DAPARG,
                                  '-p', str(TEST_PORT),
                                  '-t', TEST_TARGET,
-                                 '-b', TEST_BOARD_ID]
+                                 '-b', TEST_BOARD_ID,
+                                 '-f', TEST_FREQUENCY]
 DEBUGSERVER_DEF_EXPECTED_CALL = ['pyocd-gdbserver',
                                  '-p', '3333',
                                  '-t', TEST_TARGET]


### PR DESCRIPTION
Add support for specifying the SWDCLK frequency in Hz for pyOCD.

Signed-off-by: Henrik Brix Andersen <henrik@brixandersen.dk>