### PR TITLE
Store West source code and the manifest in west/

### DIFF
--- a/src/bootstrap/main.py
+++ b/src/bootstrap/main.py
@@ -7,7 +7,6 @@
 
 import argparse
 import os
-from os.path import join
 import importlib
 import platform
 import subprocess
@@ -19,8 +18,7 @@ MANIFEST_REV_DEFAULT = 'master'
 WEST = 'west'
 WEST_DEFAULT = 'https://github.com/zephyrproject-rtos/west'
 WEST_REV_DEFAULT = 'master'
-# NB: on Windows, this will be hidden manually, using attrib.
-WEST_DIR = '.west'
+WEST_DIR = 'west'
 
 #
 # Helpers shared between init and wrapper mode
@@ -51,24 +49,6 @@ def find_west_topdir(start):
         raise WestNotFound()
     else:
         return find_west_topdir(dirname)
-
-
-def make_topdir_sentinel(directory):
-    '''Make the hidden sentinel that marks a West installation.
-
-    This is similar to .git or .repo directories: it marks the top
-    level directory of the installation. This allows runtime building
-    other paths, etc., which is how this script delegates to the
-    cloned west in wrapper mode (i.e. after 'west init' is run and the
-    "real" west repository has been cloned).'''
-    # The sentinel is a directory in case we ever need to stash
-    # anything inside. It could just as well be an empty file for now,
-    # but this is more future-proof.
-    sentinel = join(directory, WEST_DIR)
-    os.mkdir(sentinel)
-    # On Windows, we have to manually mark a file as hidden.
-    if platform.system() == 'Windows':
-        subprocess.check_call(['attrib', '+H', sentinel])
 
 
 def clone(url, rev, dest):
@@ -145,9 +125,14 @@ def init_bootstrap(directory, args):
     else:
         print('Initializing in', directory)
 
-    make_topdir_sentinel(directory)
-    clone(args.manifest_url, args.manifest_rev, join(directory, MANIFEST))
-    clone(args.west_url, args.west_rev, join(directory, WEST))
+    # Clone the west source code and the manifest into west/. Git will create
+    # the west/ directory if it does not exist.
+
+    clone(args.west_url, args.west_rev,
+          os.path.join(directory, WEST_DIR, WEST))
+
+    clone(args.manifest_url, args.manifest_rev,
+          os.path.join(directory, WEST_DIR, MANIFEST))
 
 
 def init_reinit(directory, args):
@@ -169,7 +154,7 @@ def wrap(argv):
                  'Use "west init" to install Zephyr here'.format(start))
     # Put the top-level west source directory at the highest priority
     # except for the script directory / current working directory.
-    sys.path.insert(1, join(topdir, WEST, 'src'))
+    sys.path.insert(1, os.path.join(topdir, WEST, 'src'))
     main_module = importlib.import_module('west.main')
     main_module.main(argv=argv)
 

--- a/src/west/cmd/project.py
+++ b/src/west/cmd/project.py
@@ -316,7 +316,7 @@ def _arg(*args, **kwargs):
 # Common manifest file argument
 _manifest_arg = _arg(
     '-m', '--manifest',
-    help='path to manifest file (default: <west-topdir>/manifest/default.yml)')
+    help='path to manifest file (default: west/manifest/default.yml)')
 
 # Optional -b flag for 'west checkout'
 _b_flag = _arg(
@@ -470,13 +470,11 @@ def _validate_manifest(manifest_path):
 
 
 def _manifest_path(args):
-    # Returns the path to the manifest file. Unless explicitly specified by the
-    # user, it defaults to manifest/default.yml within the West top directory.
+    # Returns the path to the manifest file. Defaults to
+    # .west/manifest/default.yml if the user didn't specify a manifest.
 
-    if args.manifest:
-        return args.manifest
-
-    return os.path.join(util.west_topdir(), 'manifest', 'default.yml')
+    return args.manifest or os.path.join(util.west_dir(), 'manifest',
+                                         'default.yml')
 
 
 def _fetch(project):

--- a/src/west/util.py
+++ b/src/west/util.py
@@ -27,20 +27,30 @@ class WestNotFound(RuntimeError):
     '''Neither the current directory nor any parent has a West installation.'''
 
 
+def west_dir():
+    '''
+    Returns the absolute path of the first west/ directory found, searching the
+    current directory and its parents.
+
+    Raises WestNotFound if no west/ directory is found.
+    '''
+    return os.path.join(west_topdir(), 'west')
+
+
 def west_topdir():
     '''
-    Returns the absolute path of the first directory containing a .west/
-    directory, searching the current directory and its parents.
-
-    Raises WestNotFound if no .west/ directory is found.
+    Like west_dir(), but returns the path to the parent directory of the west/
+    directory instead, where project repositories are stored
     '''
-    search_dir = os.getcwd()
+    cur_dir = os.getcwd()
 
-    # While the directory is not the root directory...
-    while search_dir != os.path.dirname(search_dir):
-        if os.path.isdir(os.path.join(search_dir, '.west')):
-            return search_dir
-        search_dir = os.path.dirname(search_dir)
+    while True:
+        if os.path.isdir(os.path.join(cur_dir, 'west')):
+            return cur_dir
 
-    raise WestNotFound('Could not find a West installation (a .west/ '
-                       'directory) in this or any parent directory')
+        parent_dir = os.path.dirname(cur_dir)
+        if cur_dir == parent_dir:
+            # At the root
+            raise WestNotFound('Could not find a West installation (a west/ '
+                               'directory) in this or any parent directory')
+        cur_dir = parent_dir

--- a/tests/west/project/test_project.py
+++ b/tests/west/project/test_project.py
@@ -53,7 +53,7 @@ def cmd(cmd):
 
 @pytest.fixture
 def clean_west_topdir(tmpdir):
-    tmpdir.mkdir('.west')
+    tmpdir.mkdir('west')
     tmpdir.chdir()
 
 


### PR DESCRIPTION
I was confused by the other design, because I intuitively expected West
metadata to go in .west/. To me the other design feels a little bit like
having an empty /home/foo/user/ directory that marks the /home/foo/
directory as containing the user's files.

Use west/ instead of .west/ to avoid "hiding" the implementation of the
building/flashing commands. I would've preferred to split them from the
repo-like functionality instead, but if they're going to be in the same
repository, then it's a decent comprise.

Remove the code that hides the west directory on Windows (via 'attrib')
as well, since it doesn't make much sense anymore.

This commit also fixes a small bug in west_topdir(): A west/ in the root
directory wasn't found.