### PR TITLE
Tweak west topdir

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,9 @@
 This is the Zephyr RTOS meta tool, ``west``.
 
+For more information about west, see:
+
+https://docs.zephyrproject.org/latest/west/index.html
+
 Installation
 ------------
 

--- a/setup.py
+++ b/setup.py
@@ -25,13 +25,13 @@ setuptools.setup(
     url='https://github.com/zephyrproject-rtos/west',
     packages=setuptools.find_packages('src', include=('bootstrap',)),
     package_dir={'': 'src'},
-    classifiers=(
+    classifiers=[
         'Programming Language :: Python :: 3',
         'License :: OSI Approved :: Apache Software License',
         'Operating System :: POSIX :: Linux',
         'Operating System :: MacOS :: MacOS X',
         'Operating System :: Microsoft :: Windows',
-        ),
+        ],
     install_requires=install_requires,
     python_requires='>=3.4',
     tests_require=tests_require,

--- a/src/bootstrap/main.py
+++ b/src/bootstrap/main.py
@@ -15,9 +15,13 @@ import sys
 if sys.version_info < (3,):
     sys.exit('fatal error: you are running Python 2')
 
-MANIFEST = 'manifest'
-MANIFEST_DEFAULT = 'https://github.com/zephyrproject-rtos/manifest'
-MANIFEST_REV_DEFAULT = 'master'
+
+#
+# Special files and directories in the west installation.
+#
+# These are given variable names for clarity, but they can't be
+# changed without propagating the changes into west itself.
+#
 
 # Top-level west directory, containing west itself and the manifest.
 WEST_DIR = 'west'
@@ -34,6 +38,14 @@ WEST_REV_DEFAULT = 'master'
 # the top level; other directories named "west" may exist elsewhere,
 # e.g. zephyr/doc/west.)
 WEST_TOPDIR = '.west_topdir'
+
+# Manifest repository directory under WEST_DIR.
+MANIFEST = 'manifest'
+# Default manifest repository URL.
+MANIFEST_DEFAULT = 'https://github.com/zephyrproject-rtos/manifest'
+# Default revision to check out of the manifest repository.
+MANIFEST_REV_DEFAULT = 'master'
+
 
 #
 # Helpers shared between init and wrapper mode

--- a/src/west/util.py
+++ b/src/west/util.py
@@ -42,15 +42,20 @@ def west_topdir():
     Like west_dir(), but returns the path to the parent directory of the west/
     directory instead, where project repositories are stored
     '''
+    # If you change this function, make sure to update the bootstrap
+    # script's find_west_topdir().
+    def is_west_dir(d):
+        return os.path.isdir(d) and '.west_topdir' in os.listdir(d)
+
     cur_dir = os.getcwd()
 
     while True:
-        if os.path.isdir(os.path.join(cur_dir, 'west')):
+        if is_west_dir(os.path.join(cur_dir, 'west')):
             return cur_dir
 
         parent_dir = os.path.dirname(cur_dir)
         if cur_dir == parent_dir:
             # At the root
-            raise WestNotFound('Could not find a West installation (a west/ '
-                               'directory) in this or any parent directory')
+            raise WestNotFound('Could not find a West installation '
+                               'in this or any parent directory')
         cur_dir = parent_dir

--- a/tests/west/project/manifest.yml
+++ b/tests/west/project/manifest.yml
@@ -1,18 +1,19 @@
-# Testing manifest
+# Simple manifest template used for testing project commands.
+#
+# The local-tmpdir URL is rewritten to the temporary directory used
+# when tests are run.
 
 manifest:
   defaults:
-    remote: zephyrproject-rtos
+    remote: local-tmpdir
     revision: master
 
   remotes:
-    - name: zephyrproject-rtos
-      url: https://github.com/zephyrproject-rtos
+    - name: local-tmpdir
+      url: file://{tmpdir}
 
   projects:
     - name: net-tools
-      clone-depth: 1
     - name: Kconfiglib
-      clone-depth: 1
       revision: zephyr
-      path: sub/kconfiglib
+      path: sub/Kconfiglib

--- a/tests/west/project/test_project.py
+++ b/tests/west/project/test_project.py
@@ -1,7 +1,6 @@
 import argparse
 import os
 import shlex
-import tempfile
 
 import pytest
 

--- a/tests/west/project/test_project.py
+++ b/tests/west/project/test_project.py
@@ -99,6 +99,7 @@ def clean_west_topdir(tmpdir):
     zephyrproject = tmpdir.join('zephyrproject')
     zephyrproject.mkdir()
     zephyrproject.mkdir('west')
+    zephyrproject.join('west', '.west_topdir').ensure()
     zephyrproject.chdir()
 
 


### PR DESCRIPTION
This adjusts the way the top level west directory is found by searching for a `west/.west_topdir`  file.

I've piggybacked some trivial fixes, as well as refactorings to the project test suite.