### PR TITLE
Simplify west/.west_toplevel existence checks

### DIFF
--- a/src/bootstrap/main.py
+++ b/src/bootstrap/main.py
@@ -65,13 +65,11 @@ def find_west_topdir(start):
 
     If none is found, raises WestNotFound.'''
     # If you change this function, make sure to update west.util.west_topdir().
-    def is_west_dir(d):
-        return os.path.isdir(d) and '.west_topdir' in os.listdir(d)
 
     cur_dir = os.getcwd()
 
     while True:
-        if is_west_dir(os.path.join(cur_dir, 'west')):
+        if os.path.isfile(os.path.join(cur_dir, WEST_DIR, WEST_TOPDIR)):
             return cur_dir
 
         parent_dir = os.path.dirname(cur_dir)

--- a/src/west/util.py
+++ b/src/west/util.py
@@ -44,13 +44,11 @@ def west_topdir():
     '''
     # If you change this function, make sure to update the bootstrap
     # script's find_west_topdir().
-    def is_west_dir(d):
-        return os.path.isdir(d) and '.west_topdir' in os.listdir(d)
 
     cur_dir = os.getcwd()
 
     while True:
-        if is_west_dir(os.path.join(cur_dir, 'west')):
+        if os.path.isfile(os.path.join(cur_dir, 'west', '.west_topdir')):
             return cur_dir
 
         parent_dir = os.path.dirname(cur_dir)


### PR DESCRIPTION
Directly check whether west/.west_toplevel exists instead of checking if
'west' is a directory whose contents include '.west_toplevel', which is
also a bit more efficient.