### PR TITLE
Make bootstrap's clone() a bit more robust and clean up a bit

### DIFF
--- a/src/west/_bootstrap/main.py
+++ b/src/west/_bootstrap/main.py
@@ -95,7 +95,7 @@ def clone(url, rev, dest):
         raise WestError(msg)
 
     if repository_type(url) == 'GIT':
-        subprocess.check_call(['git', 'clone', url, '-b', rev, dest])
+        subprocess.check_call(['git', 'clone', '-b', rev, '--', url, dest])
     else:
         raise WestError('Unknown URL scheme for repository: {}'.format(url))
 

--- a/src/west/_bootstrap/main.py
+++ b/src/west/_bootstrap/main.py
@@ -84,20 +84,13 @@ def find_west_topdir(start):
 
 
 def clone(url, rev, dest):
-    def repository_type(url):
-        if url.startswith(('http:', 'https:', 'git:', 'git+ssh:', 'file:')):
-            return 'GIT'
-        else:
-            return 'UNKNOWN'
-
     if os.path.exists(dest):
-        msg = 'refusing to clone into existing location {}'.format(dest)
-        raise WestError(msg)
+        raise WestError('refusing to clone into existing location ' + dest)
 
-    if repository_type(url) == 'GIT':
-        subprocess.check_call(['git', 'clone', '-b', rev, '--', url, dest])
-    else:
+    if not url.startswith(('http:', 'https:', 'git:', 'git+shh:', 'file:')):
         raise WestError('Unknown URL scheme for repository: {}'.format(url))
+
+    subprocess.check_call(('git', 'clone', '-b', rev, '--', url, dest))
 
 
 #


### PR DESCRIPTION
Commit messages say it all:

```
bootstrap: Clean up 'git clone' parameters a bit

Reorganize parameters to match git-clone(1), and add a '--' to allow
weird project names (which could indirectly give more informative error
messages). This ought to be done for the project code too.
```

```
bootstrap: Clean up clone() a bit

Shorten the code a bit while preserving readability.

SVN also uses e.g. http:// and file://, so checking the URL scheme is
probably not a reliable way to guess intention.
```