### PR TITLE
version: Print script location next to version

### DIFF
--- a/src/west/_bootstrap/main.py
+++ b/src/west/_bootstrap/main.py
@@ -215,7 +215,8 @@ def wrap(argv):
     printing_version = False
 
     if argv and argv[0] in ('-V', '--version'):
-        print('West bootstrapper version:', 'v' + version.__version__)
+        print('West bootstrapper version: v{} ({})'.format(version.__version__,
+                                                    os.path.dirname(__file__)))
         printing_version = True
 
     start = os.getcwd()
@@ -235,7 +236,8 @@ def wrap(argv):
                 ['git', 'describe', '--tags'],
                 stderr=subprocess.DEVNULL,
                 cwd=west_git_repo).decode(sys.getdefaultencoding()).strip()
-            print('West repository version:', git_describe)
+            print('West repository version:{} ({})'.format(git_describe,
+                                                           west_git_repo))
         except subprocess.CalledProcessError:
             print('West repository verison: unknown; no tags were found')
         sys.exit(0)

--- a/src/west/main.py
+++ b/src/west/main.py
@@ -96,13 +96,16 @@ def parse_args(argv):
     args, unknown = west_parser.parse_known_args(args=argv)
 
     if args.version:
+        log.inf('West bootstrapper version: v{} ({})'.format(version.__version__,
+                                           os.path.dirname(version.___file__)))
         log.inf('West bootstrapper version:', version.__version__)
         try:
             git_describe = check_output(['git', 'describe', '--tags'],
                                         stderr=DEVNULL,
                                         cwd=os.path.dirname(__file__)).decode(
                                             sys.getdefaultencoding()).strip()
-            print('West repository version:', git_describe)
+            print('West repository version:{} ({})'.format(git_describe,
+                                                    os.path.dirname(__file__)))
         except CalledProcessError as e:
             print('West repository version: unknown, no tags found')
         sys.exit(0)


### PR DESCRIPTION
In order to simplify debugging and support to users starting with west,
print the location of both the bootstrapper and west itself when running
west --version.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>