### PR TITLE
commands: projects: Put '--' before URL in 'git remote add'

### DIFF
--- a/src/west/commands/project.py
+++ b/src/west/commands/project.py
@@ -478,7 +478,7 @@ def _fetch(project):
     if not exists:
         _inf(project, 'Creating repository for (name-and-path)')
         _git_base(project, 'init (abspath)')
-        _git(project, 'remote add origin (url)')
+        _git(project, 'remote add origin -- (url)')
 
     if project.clone_depth:
         _inf(project,


### PR DESCRIPTION
The URL is taken literally from the manifest. It's unlikely that anyone
would put a URL starting with a '-', but having weirdly named stuff be
correctly interpreted by Git could help with diagnosing bugs.

Maybe some other Git commands could be tightened up too, but they looked
safe from a glance.