### PR TITLE
Rename 'list-projects' to 'list'

### DIFF
--- a/src/west/commands/project.py
+++ b/src/west/commands/project.py
@@ -24,10 +24,10 @@ from west.manifest import default_path, Remote, Project, \
 _MANIFEST_REV_BRANCH = 'manifest-rev'
 
 
-class ListProjects(WestCommand):
+class List(WestCommand):
     def __init__(self):
         super().__init__(
-            'list-projects',
+            'list',
             _wrap('''
             List projects.
 

--- a/src/west/main.py
+++ b/src/west/main.py
@@ -21,7 +21,7 @@ from west.commands import CommandContextError
 from west.commands.build import Build
 from west.commands.flash import Flash
 from west.commands.debug import Debug, DebugServer, Attach
-from west.commands.project import ListProjects, Fetch, Pull, Rebase, Branch, \
+from west.commands.project import List, Fetch, Pull, Rebase, Branch, \
                              Checkout, Diff, Status, Update, ForAll, \
                              WestUpdated
 from west.manifest import Manifest
@@ -38,7 +38,7 @@ BUILD_FLASH_COMMANDS = [
 ]
 
 PROJECT_COMMANDS = [
-    ListProjects(),
+    List(),
     Fetch(),
     Pull(),
     Rebase(),

--- a/tests/west/project/test_project.py
+++ b/tests/west/project/test_project.py
@@ -19,7 +19,7 @@ NET_TOOLS_PATH = 'net-tools'
 KCONFIGLIB_PATH = 'sub/Kconfiglib'
 
 COMMAND_OBJECTS = (
-    project.ListProjects(),
+    project.List(),
     project.Fetch(),
     project.Pull(),
     project.Rebase(),
@@ -103,9 +103,9 @@ def clean_west_topdir(tmpdir):
     zephyrproject.chdir()
 
 
-def test_list_projects(clean_west_topdir):
+def test_list(clean_west_topdir):
     # TODO: Check output
-    cmd('list-projects')
+    cmd('list')
 
 
 def test_fetch(clean_west_topdir):


### PR DESCRIPTION
I got tired of typing 'list-projects' all the time.

'list' might be a bit less obviously related to projects, but I don't
think it would be that bad. Feel free to complain.