### PR TITLE
Set bootstrap version to post-release 0.2.99

### DIFF
--- a/src/west/_bootstrap/version.py
+++ b/src/west/_bootstrap/version.py
@@ -2,4 +2,4 @@
 #
 # This is the Python 3 version of option 3 in:
 # https://packaging.python.org/guides/single-sourcing-package-version/#single-sourcing-the-version
-__version__ = '0.2.0'
+__version__ = '0.2.99'


### PR DESCRIPTION
This mirrors what gets done in Zephyr.
