### PR TITLE
Get west and manifest revisions from a configuration file + support any revision format + misc.

### DIFF
--- a/src/west/_bootstrap/main.py
+++ b/src/west/_bootstrap/main.py
@@ -199,8 +199,17 @@ def init_bootstrap(directory, args):
     # Create an initial configuration file
 
     config = configparser.ConfigParser()
-    config['west'] = {'revision': args.west_rev}
-    config['manifest'] = {'revision': args.manifest_rev}
+
+    config['west'] = {
+        'remote': 'origin',
+        'revision': args.west_rev
+    }
+
+    config['manifest'] = {
+        'remote': 'origin',
+        'revision': args.manifest_rev
+    }
+
     with open(os.path.join(directory, WEST_DIR, 'config'), 'w') as f:
         config.write(f)
 

--- a/src/west/_bootstrap/main.py
+++ b/src/west/_bootstrap/main.py
@@ -82,13 +82,14 @@ def find_west_topdir(start):
         cur_dir = parent_dir
 
 
-def clone(url, rev, dest):
+def clone(desc, url, rev, dest):
     if os.path.exists(dest):
         raise WestError('refusing to clone into existing location ' + dest)
 
     if not url.startswith(('http:', 'https:', 'git:', 'git+shh:', 'file:')):
         raise WestError('Unknown URL scheme for repository: {}'.format(url))
 
+    print('=== Cloning {} from {}, rev. {} ==='.format(desc, url, rev))
     subprocess.check_call(('git', 'clone', '-b', rev, '--', url, dest))
 
 
@@ -190,10 +191,10 @@ def init_bootstrap(directory, args):
     # Clone the west source code and the manifest into west/. Git will create
     # the west/ directory if it does not exist.
 
-    clone(args.west_url, args.west_rev,
+    clone('west repository', args.west_url, args.west_rev,
           os.path.join(directory, WEST_DIR, WEST))
 
-    clone(args.manifest_url, args.manifest_rev,
+    clone('manifest repository', args.manifest_url, args.manifest_rev,
           os.path.join(directory, WEST_DIR, MANIFEST))
 
     # Create an initial configuration file
@@ -210,13 +211,19 @@ def init_bootstrap(directory, args):
         'revision': args.manifest_rev
     }
 
-    with open(os.path.join(directory, WEST_DIR, 'config'), 'w') as f:
+    config_path = os.path.join(directory, WEST_DIR, 'config')
+
+    with open(config_path, 'w') as f:
         config.write(f)
+
+    print('=== Initial configuration written to {} ==='.format(config_path))
 
     # Create a dotfile to mark the installation. Hide it on Windows.
 
     with open(os.path.join(directory, WEST_DIR, WEST_MARKER), 'w') as f:
         hide_file(f.name)
+
+    print('=== West initialized ===')
 
 
 def init_reinit(directory, args):

--- a/src/west/_bootstrap/main.py
+++ b/src/west/_bootstrap/main.py
@@ -6,6 +6,7 @@
 '''
 
 import argparse
+import configparser
 import os
 import platform
 import subprocess
@@ -194,6 +195,14 @@ def init_bootstrap(directory, args):
 
     clone(args.manifest_url, args.manifest_rev,
           os.path.join(directory, WEST_DIR, MANIFEST))
+
+    # Create an initial configuration file
+
+    config = configparser.ConfigParser()
+    config['west'] = {'revision': args.west_rev}
+    config['manifest'] = {'revision': args.manifest_rev}
+    with open(os.path.join(directory, WEST_DIR, 'config'), 'w') as f:
+        config.write(f)
 
     # Create a dotfile to mark the installation. Hide it on Windows.
 

--- a/src/west/commands/project.py
+++ b/src/west/commands/project.py
@@ -479,7 +479,7 @@ def _fetch(project):
     if not exists:
         _inf(project, 'Creating repository for (name-and-path)')
         _git_base(project, 'init (abspath)')
-        _git(project, 'remote add origin -- (url)')
+        _git(project, 'remote add -- (remote-name) (url)')
 
     # Fetch the revision specified in the manifest into the manifest-rev branch
 
@@ -495,7 +495,7 @@ def _fetch(project):
     # when the revision is an annotated tag. ^{commit} type peeling isn't
     # supported for the <src> in a <src>:<dst> refspec, so we have to do it
     # separately.
-    _git(project, fetch_cmd + ' origin -- (revision)')
+    _git(project, fetch_cmd + ' -- (remote-name) (revision)')
     _git(project, 'update-ref (qual-manifest-rev-branch) FETCH_HEAD^{commit}')
 
     if not _ref_ok(project, 'HEAD'):
@@ -753,6 +753,7 @@ def _expand_shorthands(project, s):
             .replace('(name-and-path)',
                      '{} ({})'.format(
                          project.name, os.path.join(project.path, ""))) \
+            .replace('(remote-name)', project.remote.name) \
             .replace('(url)', project.url) \
             .replace('(path)', project.path) \
             .replace('(abspath)', project.abspath) \

--- a/src/west/commands/project.py
+++ b/src/west/commands/project.py
@@ -479,7 +479,7 @@ def _fetch(project):
     if not exists:
         _inf(project, 'Creating repository for (name-and-path)')
         _git_base(project, 'init (abspath)')
-        _git(project, 'remote add -- (remote-name) (url)')
+        _git(project, 'remote add -- (remote) (url)')
 
     # Fetch the revision specified in the manifest into the manifest-rev branch
 
@@ -495,7 +495,7 @@ def _fetch(project):
     # when the revision is an annotated tag. ^{commit} type peeling isn't
     # supported for the <src> in a <src>:<dst> refspec, so we have to do it
     # separately.
-    _git(project, fetch_cmd + ' -- (remote-name) (revision)')
+    _git(project, fetch_cmd + ' -- (remote) (revision)')
     _git(project, 'update-ref (qual-manifest-rev-branch) FETCH_HEAD^{commit}')
 
     if not _ref_ok(project, 'HEAD'):
@@ -588,7 +588,7 @@ def _checkout(project, branch):
 def _special_project(name):
     # Returns a Project instance for one of the special repositories in west/,
     # so that we can reuse the project-related functions for them
-    remote = Remote(name='dummy name for {} repository'.format(name),
+    remote = Remote(name=config.get(name, 'remote', fallback='origin'),
                     url='dummy URL for {} repository'.format(name))
 
     # 'revision' always exists and defaults to 'master'
@@ -617,7 +617,7 @@ def _update(update_west, update_manifest):
         _dbg(project, 'Updating (name-and-path)', level=log.VERBOSE_NORMAL)
 
         # Fetch changes from upstream
-        attempt(project, 'fetch --quiet origin -- (revision)')
+        attempt(project, 'fetch --quiet (remote) -- (revision)')
 
         # Upstream SHA
         upstream_sha = attempt(project, 'rev-parse FETCH_HEAD^{commit}')
@@ -752,7 +752,7 @@ def _expand_shorthands(project, s):
             .replace('(name-and-path)',
                      '{} ({})'.format(
                          project.name, os.path.join(project.path, ""))) \
-            .replace('(remote-name)', project.remote.name) \
+            .replace('(remote)', project.remote.name) \
             .replace('(url)', project.url) \
             .replace('(path)', project.path) \
             .replace('(abspath)', project.abspath) \

--- a/src/west/commands/project.py
+++ b/src/west/commands/project.py
@@ -11,7 +11,7 @@ import shutil
 import subprocess
 import textwrap
 
-from west import config
+from west.config import config
 from west import log
 from west import util
 from west.commands import WestCommand
@@ -593,8 +593,7 @@ def _special_project(name):
 
     # 'revision' always exists and defaults to 'master'
     return Project(name, remote, None,
-                   revision=config.config.get(name, 'revision',
-                                              fallback='master'),
+                   revision=config.get(name, 'revision', fallback='master'),
                    path=os.path.join('west', name))
 
 

--- a/src/west/config.py
+++ b/src/west/config.py
@@ -42,9 +42,13 @@ def read_config():
     Configuration values from later configuration files override configuration
     from earlier ones. Instance-specific configuration values have the highest
     precedence, and system-wide the lowest.
+
+    A convenience boolean 'colorize' is exported by this module as well, set to
+    True if the output should be colorized, based on configuration settings.
     '''
 
     global config
+    global colorize
 
     # Gather (potential) configuration file paths
 
@@ -78,3 +82,14 @@ def read_config():
 
     config = configparser.ConfigParser()
     config.read(files, encoding='utf-8')
+
+    #
+    # Set convenience variables
+    #
+
+    colorize = config.getboolean('color', 'ui', fallback=True)
+
+
+# Value to use before the configuration file has been read. This also fixes
+# tests that run stuff without reading the configuration file first.
+colorize = False

--- a/src/west/config.py
+++ b/src/west/config.py
@@ -9,6 +9,15 @@ import platform
 from west.util import west_dir
 
 
+# Configuration values.
+#
+# Initially empty, populated in read_config(). Always having this available is
+# nice in case something checks configuration values before the configuration
+# file has been read (e.g. the log.py functions, to check color settings, and
+# tests).
+config = configparser.ConfigParser()
+
+
 def read_config():
     '''
     Reads all configuration files, making the configuration values available as
@@ -42,13 +51,7 @@ def read_config():
     Configuration values from later configuration files override configuration
     from earlier ones. Instance-specific configuration values have the highest
     precedence, and system-wide the lowest.
-
-    A convenience boolean 'colorize' is exported by this module as well, set to
-    True if the output should be colorized, based on configuration settings.
     '''
-
-    global config
-    global colorize
 
     # Gather (potential) configuration file paths
 
@@ -80,16 +83,9 @@ def read_config():
     # Parse all existing configuration files
     #
 
-    config = configparser.ConfigParser()
     config.read(files, encoding='utf-8')
 
-    #
-    # Set convenience variables
-    #
 
-    colorize = config.getboolean('color', 'ui', fallback=True)
-
-
-# Value to use before the configuration file has been read. This also fixes
-# tests that run stuff without reading the configuration file first.
-colorize = False
+def use_colors():
+    # Convenience function for reading the color.ui setting
+    return config.getboolean('color', 'ui', fallback=True)

--- a/src/west/config.py
+++ b/src/west/config.py
@@ -1,0 +1,80 @@
+'''
+Configuration file handling, using the standard configparser module.
+'''
+
+import configparser
+import os
+import platform
+
+from west.util import west_dir
+
+
+def read_config():
+    '''
+    Reads all configuration files, making the configuration values available as
+    a configparser.ConfigParser object in config.config. This object works
+    similarly to a dictionary: config.config['foo']['bar'] gets the value for
+    key 'bar' in section 'foo'.
+
+    Git conventions for configuration file locations are used. See the FILES
+    section in the git-config(1) man page.
+
+    The following configuration files are read.
+
+    System-wide:
+
+        Linux:   /etc/westconfig
+        Mac OS:  /usr/local/etc/westconfig
+        Windows: %PROGRAMDATA%\west\config
+
+    User-specific:
+
+        $XDG_CONFIG_HOME/west/config (on Linux)
+          and
+        ~/.westconfig
+
+        ($XDG_CONFIG_DIR defaults to ~/.config/ if unset.)
+
+    Instance-specific:
+
+        <West base directory>/west/config
+
+    Configuration values from later configuration files override configuration
+    from earlier ones. Instance-specific configuration values have the highest
+    precedence, and system-wide the lowest.
+    '''
+
+    global config
+
+    # Gather (potential) configuration file paths
+
+    # System-wide and user-specific
+
+    if platform.system() == 'Linux':
+        # Probably wouldn't hurt to check $XDG_CONFIG_HOME (defaults to
+        # ~/.config) on all systems. It's listed in git-config(1). People were
+        # iffy about it as of writing though.
+        files = ['/etc/westconfig',
+                 os.path.join(os.environ.get('XDG_CONFIG_HOME',
+                                             os.path.expanduser('~/.config')),
+                              'west', 'config')]
+
+    elif platform.system() == 'Darwin':  # Mac OS
+        # This was seen on a local machine ($(prefix) = /usr/local)
+        files = ['/usr/local/etc/westconfig']
+    elif platform.system() == 'Windows':
+        # Seen on a local machine
+        files = [os.path.expandvars('%PROGRAMDATA%\\west\\config')]
+
+    files.append(os.path.expanduser('~/.westconfig'))
+
+    # Repository-specific
+
+    files.append(os.path.join(west_dir(), 'config'))
+
+    #
+    # Parse all existing configuration files
+    #
+
+    config = configparser.ConfigParser()
+    config.read(files, encoding='utf-8')

--- a/src/west/log.py
+++ b/src/west/log.py
@@ -6,6 +6,8 @@
 
 Provides common methods for logging messages to display to the user.'''
 
+from west import config
+
 import colorama
 import sys
 
@@ -47,6 +49,10 @@ def inf(*args, colorize=False):
     colorize (default: False):
       If True, the message is printed in bright green if stdout is a terminal.
     '''
+
+    if not config.colorize:
+        colorize = False
+
     # This approach colorizes any sep= and end= text too, as expected.
     #
     # colorama automatically strips the ANSI escapes when stdout isn't a
@@ -57,29 +63,43 @@ def inf(*args, colorize=False):
     print(*args)
 
     if colorize:
-        # The final flush=True avoids issues with unrelated output from
-        # commands (usually Git) becoming green, due to the final attribute
-        # reset ANSI escape getting line-buffered.
-        print(colorama.Style.RESET_ALL, end='', flush=True)
+        _reset_colors(sys.stdout)
 
 
 def wrn(*args):
     '''Print a warning.'''
-    print(colorama.Fore.LIGHTRED_EX + 'WARNING: ', end='', file=sys.stderr)
+
+    if config.colorize:
+        print(colorama.Fore.LIGHTRED_EX, end='', file=sys.stderr)
+
+    print('WARNING: ', end='', file=sys.stderr)
     print(*args, file=sys.stderr)
-    print(colorama.Style.RESET_ALL, end='', file=sys.stderr, flush=True)
+
+    if config.colorize:
+        _reset_colors(sys.stderr)
 
 
 def err(*args, fatal=False):
     '''Print an error.'''
-    print(colorama.Fore.LIGHTRED_EX
-              + ('FATAL ERROR: ' if fatal else 'ERROR: '),
-          end='', file=sys.stderr)
+
+    if config.colorize:
+        print(colorama.Fore.LIGHTRED_EX, end='', file=sys.stderr)
+
+    print('FATAL ERROR: ' if fatal else 'ERROR: ', end='', file=sys.stderr)
     print(*args, file=sys.stderr)
-    print(colorama.Style.RESET_ALL, end='', file=sys.stderr, flush=True)
+
+    if config.colorize:
+        _reset_colors(sys.stderr)
 
 
 def die(*args, exit_code=1):
     '''Print a fatal error, and abort with the given exit code.'''
     err(*args, fatal=True)
     sys.exit(exit_code)
+
+
+def _reset_colors(file):
+    # The flush=True avoids issues with unrelated output from commands (usually
+    # Git) becoming colorized, due to the final attribute reset ANSI escape
+    # getting line-buffered
+    print(colorama.Style.RESET_ALL, end='', file=file, flush=True)

--- a/src/west/log.py
+++ b/src/west/log.py
@@ -50,7 +50,7 @@ def inf(*args, colorize=False):
       If True, the message is printed in bright green if stdout is a terminal.
     '''
 
-    if not config.colorize:
+    if not config.use_colors():
         colorize = False
 
     # This approach colorizes any sep= and end= text too, as expected.
@@ -69,26 +69,26 @@ def inf(*args, colorize=False):
 def wrn(*args):
     '''Print a warning.'''
 
-    if config.colorize:
+    if config.use_colors():
         print(colorama.Fore.LIGHTRED_EX, end='', file=sys.stderr)
 
     print('WARNING: ', end='', file=sys.stderr)
     print(*args, file=sys.stderr)
 
-    if config.colorize:
+    if config.use_colors():
         _reset_colors(sys.stderr)
 
 
 def err(*args, fatal=False):
     '''Print an error.'''
 
-    if config.colorize:
+    if config.use_colors():
         print(colorama.Fore.LIGHTRED_EX, end='', file=sys.stderr)
 
     print('FATAL ERROR: ' if fatal else 'ERROR: ', end='', file=sys.stderr)
     print(*args, file=sys.stderr)
 
-    if config.colorize:
+    if config.use_colors():
         _reset_colors(sys.stderr)
 
 

--- a/src/west/main.py
+++ b/src/west/main.py
@@ -21,7 +21,7 @@ from west.commands import CommandContextError
 from west.commands.build import Build
 from west.commands.flash import Flash
 from west.commands.debug import Debug, DebugServer, Attach
-from west.commands.project import List, Fetch, Pull, Rebase, Branch, \
+from west.commands.project import List, Clone, Fetch, Pull, Rebase, Branch, \
                              Checkout, Diff, Status, Update, ForAll, \
                              WestUpdated
 from west.manifest import Manifest
@@ -39,6 +39,7 @@ BUILD_FLASH_COMMANDS = [
 
 PROJECT_COMMANDS = [
     List(),
+    Clone(),
     Fetch(),
     Pull(),
     Rebase(),

--- a/src/west/main.py
+++ b/src/west/main.py
@@ -12,11 +12,11 @@ import argparse
 import colorama
 from functools import partial
 import os
-import platform
 import sys
 from subprocess import CalledProcessError, check_output, DEVNULL
 
 from west import log
+from west import config
 from west.commands import CommandContextError
 from west.commands.build import Build
 from west.commands.flash import Flash
@@ -198,6 +198,9 @@ def main(argv=None):
     if argv is None:
         argv = sys.argv[1:]
     args, unknown = parse_args(argv)
+
+    # Read the configuration files
+    config.read_config()
 
     for_stack_trace = 'run as "west -v ... {} ..." for a stack trace'.format(
         args.command)


### PR DESCRIPTION
```
Get west and manifest revisions from a configuration file

Add configuration file support via the standard Python configparser
module, which uses a Git-like .ini format. Use it to save the west and
manifest revisions specified when running 'west init', and use the saved
revisions when updating the west and manifest repositories.

Configuration file paths are based on Git, for consistency with the
Git-like commands. See the FILES section in git-config(1). Mac OS and
Windows paths were checked by Carles Cufi with
'git config --list --show-origin'.

Add some new shorthands to _expand_shorthands() in project.py to factor
out some logic while removing the hardcoding of the west and manifest
upstream branches. The qual-* versions of shorthands give the full path
to refs (refs/heads/foo, remotes/origin/bar, etc.)

Fixes: #63
Fixes: #67 
```

```
commands: project: Support any kind of revision format

Switch to a simpler and more flexible approach for dealing with upstream
revisions, that works with any revision format (SHA, branch, qualified
ref (e.g. refs/heads/foo), or (annotated) tag):

 1. Fetch (just) the upstream revision, exactly as specified.

 2. Dereference it to a commit via FETCH_HEAD, and point 'manifest-rev'
    at it.

    Using FETCH_HEAD makes it possible to apply ^{commit} peeling (see
    git-rev-parse(1)), which makes things work for e.g. annotated tags
    too (git tag -a ...).

A regression (could be an improvement, depending on how you see it) is
that just the upstream revision is fetched now. It'd be simple to do a
full fetch if we'd want that later though.
```

```
commands: project: Improve behavior for an aborted initial 'fetch'

The old _fetch() behavior was to check out a detached HEAD at
'manifest-rev' if the repository was initialized in the same call to
_fetch(). This meant that no detached HEAD was checked out if the
initial fetch was aborted and then resumed.

Instead, always check out a detached head at 'manifest-rev' if nothing
is checked out in the repository (which is almost guaranteed to mean
that we're still in the 'git init' state). That makes aborting and
resuming safe.

Nothing being checked out can be detected by looking at HEAD, which will
point to a non-existing ref.

Fixes: #78 
```

```
commands: project: Use remote name from manifest instead of 'origin'

To be consistent with repo (though I haven't actually checked the
behavior myself).

Fixes: #73
```

```
Add color.ui option for turning colors on/off

Based on the corresponding git option (see git-config(1)).

'true'/'false' are the only supported values at the moment, but they
work the same as in git (output is colorized if color.ui = true and the
output file is a terminal). If color.ui isn't specified, it defaults to
true.

color.ui is not written to west/config, since it makes more sense as a
global option than a per-repository option. It can still be disabled in
west/config though, though ~/.westconfig would make more sense.

I was thinking of toggling colors at a higher level with colorama
at first, but colorama.init() makes it a bit tricky to get right for
both Linux and Windows. Probably not too bad to make it explicit like
this.

Add a _reset_colors() helper to log.py as well to factor out a tricky
and easily typo'd print().
```

```
Make configuration values always available

This is nice in case something tries to read a configuration value
before the configuration files have been read. This could happen for the
logging functions for example, and for tests.

The configuration is empty before the configuration files have been
read, so defaults must be provided. They must be anyway though, for the
code to be robust in case configuration files are missing.
```

```
commands: project: Allow West/manifest remote to be changed

Store the name of the remote used for West and manifest updates in
west/config, like Git does it. That way the remote can be switched
(after adding a remote).

Another option would be to store a URL, but it's less flexible and would
add hairy remote management code to rewrite remote URLs. It'd also make
it impossible for users to manually manage remotes in Git, as their
settings would get overwritten.
```

```
commands: project: Check if projects are up-to-date when rebasing

_update() updates the special west/ and manifest/ repositories and has
code for checking if HEAD contains all the commits from a particular
revision (is up-to-date re. the revision). Move that code into a
separate _up_to_date_with() function, and also use it when rebasing
normal projects.

This gives a less spammy message when running 'pull' and 'rebase' on
already up-to-date projects:

  $ west rebase
  === zephyr (zephyr/) is up-to-date with manifest-rev

This commit also removes the special error message when self-updating
fails, returning to plain _git() with check=True. A separate context
hint mechanism will be added after this commit instead.

We could probably get rid of the Remote.url field. That information is
already available in the Git repository (we could fetch it from there if
we want to show it), and we should respect the repository settings in
case they have been changed by the user.
```

```
commands: project: Give context-specific errors for failed self-updates

Add a context manager ('with foo:' thingy) for setting a context for a
block of code. The context is just some text that gets added to the
error whenever a Git command fails.

Use the context manager to point out whenever a failing Git command is
related to self-updates. That could be a bit tricky to debug otherwise.

Example error:

  FATAL ERROR: Command 'git rebase 'FETCH_HEAD^{commit}'' failed for
  manifest (west/manifest/), while running automatic self-update. Please
  fix the state of the repository, or pass --no-update to 'west
  fetch/pull' to skip updating the manifest and West for the duration of
  the command.
```

```
commands: project: Refactor self-update a bit

Just have two _update_manifest() and _update_west() functions and get
rid of the flags. Bit easier to follow.

_update() was a bit overly generic as a name too.
```

```
commands: project: Add a 'west clone' command

This is just a shorthand for 'west fetch' + 'west checkout -b <branch>'.

The name of the branch is based on the revision from the manifest. For
revisions that are qualified refs (refs/heads/foo), the last component
(foo) is used as the name.

For SHA revisions, it doesn't make much much sense to name the branch
after the SHA, so 'work' is used instead.

The name of the created branch(es) can be overriden by passing
'-s <branch name>' to 'west clone'.
```

```
bootstrap: Print some information during initalization

Makes it a bit clearer what's going on, and helps people find the
configuration file.

Example output:

    Initializing in /home/ulf/westwest
    === Cloning west repository from https://github.com/zephyrproject-rtos/west, rev. master ===
    Cloning into '/home/ulf/westwest/west/west'...
    remote: Enumerating objects: 803, done.
    remote: Total 803 (delta 0), reused 0 (delta 0), pack-reused 803
    Receiving objects: 100% (803/803), 239.55 KiB | 371.00 KiB/s, done.
    Resolving deltas: 100% (428/428), done.
    === Cloning manifest repisitory from https://github.com/zephyrproject-rtos/manifest, rev. master ===
    Cloning into '/home/ulf/westwest/west/manifest'...
    remote: Enumerating objects: 6, done.
    remote: Counting objects: 100% (6/6), done.
    remote: Compressing objects: 100% (6/6), done.
    remote: Total 25 (delta 0), reused 2 (delta 0), pack-reused 19
    Unpacking objects: 100% (25/25), done.
    === Initial configuration written to /home/ulf/westwest/west/config ===
    === West initialized ===

Maybe some helpful hint could be added to the end too.
```