### PR TITLE
commands: project: Fetch directly from URLs instead of remotes + support reinit

### DIFF
--- a/src/west/_bootstrap/main.py
+++ b/src/west/_bootstrap/main.py
@@ -134,9 +134,10 @@ configuration settings. This is just an alternative to manually editing
 west/config. Only explicitly passed configuration values (e.g.
 --mr NEW_MANIFEST_REVISION) are updated.
 
-Note: If you update the west/manifest revision or URL, the change will take
-effect whenever the configuration setting is next read, e.g. in `west fetch`.
-'west init' only updates configuration settings.
+If the URL/revision of the manifest or west repositories is updated, then
+'west update' is automatically run afterwards to update the repositories. Note
+that this will fail if the new revision can't be fast-forwarded to. In that
+case, you will need to e.g. stash away your changes in a separate branch.
 '''.format(WEST_MARKER))
 
     init_parser.add_argument(
@@ -257,6 +258,15 @@ def reinit(config_path, args):
                 west_url, args.west_rev, manifest_url, args.manifest_rev)
 
     print('=== Updated configuration written to {} ==='.format(config_path))
+
+    cmd = ['update']
+    if west_url or args.west_rev:
+        cmd.append('--update-west')
+    if manifest_url or args.manifest_rev:
+        cmd.append('--update-manifest')
+    print("=== Running 'west {}' to update repositories ==="
+          .format(' '.join(cmd)))
+    wrap(cmd)
 
 
 def update_conf(config_path, west_url, west_rev, manifest_url, manifest_rev):

--- a/src/west/_bootstrap/main.py
+++ b/src/west/_bootstrap/main.py
@@ -115,26 +115,59 @@ def init(argv):
     This exits the program with a nonzero exit code if fatal errors occur.'''
     init_parser = argparse.ArgumentParser(
         prog='west init',
-        description='Bootstrap initialize a Zephyr installation')
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description=
+'''
+Initializes a Zephyr installation.
+
+In more detail, does the following:
+
+  1. Clones the manifest repository to west/manifest, and the west repository
+     to west/west
+
+  2. Creates a marker file west/{}
+
+  3. Creates an initial configuration file west/config
+
+'west init' can be rerun on an already initialized West instance to update
+configuration settings. This is just an alternative to manually editing
+west/config. Only explicitly passed configuration values (e.g.
+--mr NEW_MANIFEST_REVISION) are updated.
+
+Note: If you update the west/manifest revision or URL, the change will take
+effect whenever the configuration setting is next read, e.g. in `west fetch`.
+'west init' only updates configuration settings.
+'''.format(WEST_MARKER))
+
     init_parser.add_argument(
         '-b', '--base-url',
-        help='''Base URL for both 'manifest' and 'zephyr' repositories; cannot
-        be given if either -m or -w are''')
+        help='''Base URL for the 'manifest' and 'west' repositories. Cannot
+             be given if either -m or -w are.''')
+
     init_parser.add_argument(
         '-m', '--manifest-url',
-        help='Zephyr manifest fetch URL, default ' + MANIFEST_DEFAULT)
+        help='Manifest repository URL (or remote name) (default: {})'
+             .format(MANIFEST_URL_DEFAULT))
+
     init_parser.add_argument(
         '--mr', '--manifest-rev', dest='manifest_rev',
-        help='Manifest revision to fetch, default ' + MANIFEST_REV_DEFAULT)
+        help='Manifest revision to fetch (default: {})'
+             .format(MANIFEST_REV_DEFAULT))
+
     init_parser.add_argument(
         '-w', '--west-url',
-        help='West fetch URL, default ' + WEST_URL_DEFAULT)
+        help='West repository URL (or remote name) (default: {})'
+             .format(WEST_URL_DEFAULT))
+
     init_parser.add_argument(
         '--wr', '--west-rev', dest='west_rev',
-        help='West revision to fetch, default ' + WEST_REV_DEFAULT)
+        help='West revision to fetch (default: {})'
+             .format(WEST_REV_DEFAULT))
+
     init_parser.add_argument(
         'directory', nargs='?',
-        help='Initializes in this directory, creating it if necessary')
+        help='''Directory to initialize West in. Missing directories will be
+             created automatically. (default: current directory)''')
 
     args = init_parser.parse_args(args=argv)
 

--- a/src/west/_bootstrap/main.py
+++ b/src/west/_bootstrap/main.py
@@ -202,12 +202,12 @@ def init_bootstrap(directory, args):
     config = configparser.ConfigParser()
 
     config['west'] = {
-        'remote': 'origin',
+        'remote': args.west_url,
         'revision': args.west_rev
     }
 
     config['manifest'] = {
-        'remote': 'origin',
+        'remote': args.manifest_url,
         'revision': args.manifest_rev
     }
 
@@ -256,7 +256,8 @@ def wrap(argv):
             sys.exit(0)         # run outside of an installation directory
         else:
             sys.exit('Error: not a Zephyr directory (or any parent): {}\n'
-                     'Use "west init" to install Zephyr here'.format(start))
+                     'Use "west init" to install Zephyr here'
+                     .format(os.getcwd()))
 
     west_git_repo = os.path.join(topdir, WEST_DIR, WEST)
     if printing_version:


### PR DESCRIPTION
Three commits:

```
commands: project: Fetch directly from URLs instead of remotes

Instead of fetching from remotes, fetch from URLs. This bypasses the
entire remote system, which is nice in that we no longer rely on how
remotes are configured. Users could delete remotes or point them
somewhere else, and things will still work.

I had somehow managed to miss all along is that Git allows URLs wherever
names of remotes are allowed.

Also put URLs into the initial west/config configuration file. Keep the
name 'remote' for the configuration value, as putting the name of a
remote there will work as well.

IOW, both of the following will work:

    [west]
    remote = https://github.com/zephyrproject-rtos/west
    revision = master

    [west]
    remote = my-custom-remote
    revision = master

For projects, create a remote named after the remote in the manifest
(like before), just for the user's convenience. We never use it
ourselves.

Fixes: #83
```

```
commands: project: Allow changing configuration options with 'west init'

Support rerunning 'west init' in an already initialized West
installation to update configuration values. Currently, this just
modifies west/config.

Only arguments that are explicitly passed are changed. For example,
'west init --mr foo' will update the manifest revision to 'foo', leaving
all other settings unchanged.

Passing no arguments when reinitializing is a no-op, and prints an
error.

Treat the initial west/config creation as an update that happens to set
all configuration values, to reuse some code.

Piggyback some small cleanup:

 - Rename WEST/MANIFEST_DEFAULT to WEST/MANIFEST_URL_DEFAULT. There's
   already WEST/MANIFEST_REV_DEFAULT.

 - Rename find_west_topdir() to west_topdir(). This is what the version
   in the main West code is called (would be nice to reuse things
   directly from there in the future).

   Also make west_topdir() implicitly default to the working directory.

Fixes: #77
```

```
bootstrap: Add more 'west init' documentation

Add some more information to 'west init --help':

 - Explain what the bootstrap does, in some detail

 - Fix some reference to "Zephyr" that should say "West"

 - Mention that reinit just updates west/config, and that the updated
   settings won't take effect until they're read

 - Fix some documentation style consistency nits
```