### PR TITLE
commands: project: Show remote URLs for projects in 'west list'

### DIFF
--- a/src/west/commands/project.py
+++ b/src/west/commands/project.py
@@ -44,10 +44,11 @@ class List(WestCommand):
         log.inf("Manifest path: {}\n".format(_manifest_path(args)))
 
         for project in _all_projects(args):
-            log.inf('{:15} {:30} {:15} {}'.format(
+            log.inf('{:14}  {:18}  {:13}  {}  {}'.format(
                 project.name,
                 os.path.join(project.path, ''),  # Add final '/' if missing
                 project.revision,
+                project.url,
                 "(cloned)" if _cloned(project) else "(not cloned)"))
 
 


### PR DESCRIPTION
This came up in #52.

I'm not sure what the appropriate field widths are ({:n}). We could
tweak it later if some fields turn out to be too short/long.

Fixes: #37