### PR TITLE
bootstrap: Don't error out for 'git@' URLs

### DIFF
--- a/src/west/_bootstrap/main.py
+++ b/src/west/_bootstrap/main.py
@@ -86,7 +86,8 @@ def clone(desc, url, rev, dest):
     if os.path.exists(dest):
         raise WestError('refusing to clone into existing location ' + dest)
 
-    if not url.startswith(('http:', 'https:', 'git:', 'git+shh:', 'file:')):
+    if not url.startswith(('http:', 'https:', 'git:', 'git+ssh:', 'file:',
+                           'git@')):
         raise WestError('Unknown URL scheme for repository: {}'.format(url))
 
     print('=== Cloning {} from {}, rev. {} ==='.format(desc, url, rev))


### PR DESCRIPTION
Add 'git@' to the list of accepted prefixes. Alternatively, any username
could be accepted, but keep it simple while we have the URL check.

IMO, the check should be removed instead. It artificially restricts us to
a subset of what Git really supports, for no good reason.

Also fix a typo: s/git-shh:/git-ssh:/