### PR TITLE
commands: project: Fetch directly from URLs instead of remotes

### DIFF
--- a/src/west/_bootstrap/main.py
+++ b/src/west/_bootstrap/main.py
@@ -203,12 +203,12 @@ def init_bootstrap(directory, args):
     config = configparser.ConfigParser()
 
     config['west'] = {
-        'remote': 'origin',
+        'remote': args.west_url,
         'revision': args.west_rev
     }
 
     config['manifest'] = {
-        'remote': 'origin',
+        'remote': args.manifest_url,
         'revision': args.manifest_rev
     }
 
@@ -257,7 +257,8 @@ def wrap(argv):
             sys.exit(0)         # run outside of an installation directory
         else:
             sys.exit('Error: not a Zephyr directory (or any parent): {}\n'
-                     'Use "west init" to install Zephyr here'.format(start))
+                     'Use "west init" to install Zephyr here'
+                     .format(os.getcwd()))
 
     west_git_repo = os.path.join(topdir, WEST_DIR, WEST)
     if printing_version:


### PR DESCRIPTION
Instead of fetching from remotes, fetch from URLs. This bypasses the
entire remote system, which is nice in that we no longer rely on how
remotes are configured. Users could delete remotes or point them
somewhere else, and things will still work.

I had somehow managed to miss all along is that Git allows URLs wherever
names of remotes are allowed.

Also put URLs into the initial west/config configuration file. Keep the
name 'remote' for the configuration value, as putting the name of a
remote there will work as well.

IOW, both of the following will work:

    [west]
    remote = https://github.com/zephyrproject-rtos/west
    revision = master

    [west]
    remote = my-custom-remote
    revision = master

For projects, create a remote named after the remote in the manifest
(like before), just for the user's convenience. We never use it
ourselves.

Fixes: #83

Signed-off-by: Ulf Magnusson <Ulf.Magnusson@nordicsemi.no>