### PR TITLE
List enhancements

### DIFF
--- a/src/west/commands/project.py
+++ b/src/west/commands/project.py
@@ -38,12 +38,10 @@ class List(WestCommand):
             '''))
 
     def do_add_parser(self, parser_adder):
-        return _add_parser(parser_adder, self)
+        return _add_parser(parser_adder, self, _project_list_arg)
 
     def do_run(self, args, user_args):
-        log.inf("Manifest path: {}\n".format(_manifest_path(args)))
-
-        for project in _all_projects(args):
+        for project in _projects(args):
             log.inf('{:14}  {:18}  {:13}  {}  {}'.format(
                 project.name,
                 project.path,

--- a/src/west/commands/project.py
+++ b/src/west/commands/project.py
@@ -46,7 +46,7 @@ class List(WestCommand):
         for project in _all_projects(args):
             log.inf('{:14}  {:18}  {:13}  {}  {}'.format(
                 project.name,
-                os.path.join(project.path, ''),  # Add final '/' if missing
+                project.path,
                 project.revision,
                 project.url,
                 "(cloned)" if _cloned(project) else "(not cloned)"))

--- a/src/west/commands/project.py
+++ b/src/west/commands/project.py
@@ -16,16 +16,13 @@ from west import log
 from west import util
 from west.commands import WestCommand
 from west.manifest import default_path, Remote, Project, \
-                          Manifest, MalformedManifest
+                          Manifest, MalformedManifest, META_NAMES
 
 
 # Branch that points to the revision specified in the manifest (which might be
 # an SHA). Local branches created with 'west branch' are set to track this
 # branch.
 _MANIFEST_REV_BRANCH = 'manifest-rev'
-
-# Names of the "meta" projects in the west directory.
-_META_NAMES = ['west', 'manifest']
 
 
 class List(WestCommand):
@@ -87,7 +84,7 @@ class List(WestCommand):
         list_meta = bool(args.projects) or args.all
 
         for project in _projects(args, include_meta=True):
-            if project.name in _META_NAMES and not list_meta:
+            if project.name in META_NAMES and not list_meta:
                 continue
 
             # Spelling out the format keys explicitly here gives us
@@ -556,7 +553,7 @@ def _projects(args, listed_must_be_cloned=True, include_meta=False):
     projects = _all_projects(args)
 
     if include_meta:
-        projects += [_special_project(name) for name in _META_NAMES]
+        projects += [_special_project(name) for name in META_NAMES]
 
     if not args.projects:
         # No projects specified. Return all projects.
@@ -581,7 +578,7 @@ def _projects(args, listed_must_be_cloned=True, include_meta=False):
         # We could still get here with a missing manifest repository if the
         # user gave a --manifest argument.
         uncloned_meta = [prj.name for prj in res if not _cloned(prj)
-                         and prj.name in _META_NAMES]
+                         and prj.name in META_NAMES]
         if uncloned_meta:
             log.die('Missing meta project{}: {}.'.
                     format('s' if len(uncloned_meta) > 1 else '',
@@ -589,7 +586,7 @@ def _projects(args, listed_must_be_cloned=True, include_meta=False):
                     'The Zephyr installation has been corrupted.')
 
         uncloned = [prj.name for prj in res
-                    if not _cloned(prj) and prj.name not in _META_NAMES]
+                    if not _cloned(prj) and prj.name not in META_NAMES]
         if uncloned:
             log.die('Uncloned project{}: {}.'.
                     format('s' if len(uncloned) > 1 else '',

--- a/src/west/manifest-schema.yml
+++ b/src/west/manifest-schema.yml
@@ -82,7 +82,8 @@ mapping:
       # Each project is a map with the following keys:
       #
       # - name: Mandatory, the name of the git repository. The clone
-      #   URL is formed by remote + '/' + name
+      #   URL is formed by remote + '/' + name. The name cannot
+      #   be one of the reserved values "west" and "manifest".
       # - remote: Optional, the name of the remote to pull it from.
       #   If the remote is missing, the remote'key in the top-level
       #   defaults key is used instead. If both are missing, it's an error.

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -24,6 +24,11 @@ import yaml
 from west import util, log
 
 
+META_NAMES = ['west', 'manifest']
+'''Names of the special "meta-projects", which are reserved and cannot
+be used to name a project in the manifest file.'''
+
+
 def default_path():
     '''Return the path to the default manifest in the west directory.
 
@@ -163,15 +168,22 @@ class Manifest:
         # mp = manifest project (dictionary with values parsed from
         # the manifest)
         for mp in manifest['projects']:
+            # Validate the project name.
+            name = mp['name']
+            if name in META_NAMES:
+                self._malformed('the name "{}" is reserved and cannot '.
+                                format(name) +
+                                'be used to name a manifest project')
+
             # Validate the project remote.
             remote_name = mp.get('remote', default_remote_name)
             if remote_name is None:
                 self._malformed('project {} does not specify a remote'.
-                                format(mp['name']))
+                                format(name))
             if remote_name not in remotes_dict:
                 self._malformed('project {} remote {} is not defined'.
-                                format(mp['name'], remote_name))
-            project = Project(mp['name'],
+                                format(name, remote_name))
+            project = Project(name,
                               remotes_dict[remote_name],
                               defaults,
                               path=mp.get('path'),

--- a/tests/west/manifest/invalid_reserved_name_manifest.yml
+++ b/tests/west/manifest/invalid_reserved_name_manifest.yml
@@ -1,0 +1,8 @@
+manifest:
+  remotes:
+    - name: testremote
+      url: https://example.com
+
+  projects:
+    - name: manifest
+      remote: testremote

--- a/tests/west/manifest/invalid_reserved_name_west.yml
+++ b/tests/west/manifest/invalid_reserved_name_west.yml
@@ -1,0 +1,8 @@
+manifest:
+  remotes:
+    - name: testremote
+      url: https://example.com
+
+  projects:
+    - name: west
+      remote: testremote


### PR DESCRIPTION
Add two options to `west list` will be useful when processing its output in programs:

- `-p` / `--path`: just print project paths
- `-a` / `--abspath`: just print project absolute paths (takes precedence)

Also add a `-s` / `--special` option to include the "special" projects (west and the manifest) in the output.

The command `west list -as west` will be needed by the Zephyr documentation system to find the West source code for use in autodoc Sphinx directives.

The command `west list -a` will be needed by the Zephyr build system to obtain the paths of all West projects to consider for building.