### PR TITLE
runners: pyocd: Don't reset after load

### DIFF
--- a/src/west/runners/pyocd.py
+++ b/src/west/runners/pyocd.py
@@ -160,8 +160,9 @@ class PyOcdBinaryRunner(ZephyrBinaryRunner):
                           [self.elf_name] +
                           ['-ex', 'target remote :{}'.format(self.gdb_port)])
             if command == 'debug':
-                client_cmd += ['-ex', 'load',
-                               '-ex', 'monitor reset halt']
+                client_cmd += ['-ex', 'monitor halt',
+                               '-ex', 'monitor reset',
+                               '-ex', 'load']
 
             self.print_gdbserver_message()
             self.run_server_and_client(server_cmd, client_cmd)

--- a/tests/west/runners/test_pyocd.py
+++ b/tests/west/runners/test_pyocd.py
@@ -81,15 +81,17 @@ DEBUG_ALL_EXPECTED_SERVER = [TEST_SERVER,
                              '-f', TEST_FREQUENCY]
 DEBUG_ALL_EXPECTED_CLIENT = [RC_GDB, RC_KERNEL_ELF,
                              '-ex', 'target remote :{}'.format(TEST_PORT),
-                             '-ex', 'load',
-                             '-ex', 'monitor reset halt']
+                             '-ex', 'monitor halt',
+                             '-ex', 'monitor reset',
+                             '-ex', 'load']
 DEBUG_DEF_EXPECTED_SERVER = ['pyocd-gdbserver',
                              '-p', '3333',
                              '-t', TEST_TARGET]
 DEBUG_DEF_EXPECTED_CLIENT = [RC_GDB, RC_KERNEL_ELF,
                              '-ex', 'target remote :3333',
-                             '-ex', 'load',
-                             '-ex', 'monitor reset halt']
+                             '-ex', 'monitor halt',
+                             '-ex', 'monitor reset',
+                             '-ex', 'load']
 
 
 DEBUGSERVER_ALL_EXPECTED_CALL = [TEST_SERVER,


### PR DESCRIPTION
The mimxrt1052 does not have any internal flash, therefore a reset after
load blows away the code when loaded into sram. Reverse the order of the
pyocd commands such that the load follows the reset.

The command order now matches jlink.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>