### PR TITLE
commands: project: Allow projects to be specified via their path

### DIFF
--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -290,7 +290,7 @@ class Project:
         self.remote = remote
         self.url = remote.url + '/' + name
         self.path = path or name
-        self.abspath = os.path.normpath(os.path.join(util.west_topdir(), self.path))
+        self.abspath = os.path.realpath(os.path.join(util.west_topdir(), self.path))
         self.clone_depth = clone_depth
         self.revision = revision or defaults.revision
 

--- a/tests/west/manifest/test_manifest.py
+++ b/tests/west/manifest/test_manifest.py
@@ -61,7 +61,7 @@ def test_no_defaults():
     # Check the projects are as expected.
     for p, e in zip(manifest.projects, expected):
         deep_eq_check(p, e)
-    assert all(p.abspath == os.path.normpath(os.path.join('/west_top', p.path))
+    assert all(p.abspath == os.path.realpath(os.path.join('/west_top', p.path))
             for p in manifest.projects)
 
 def test_default_clone_depth():
@@ -107,7 +107,7 @@ def test_default_clone_depth():
     # Check that the projects are as expected.
     for p, e in zip(manifest.projects, expected):
         deep_eq_check(p, e)
-    assert all(p.abspath == os.path.normpath(os.path.join('/west_top', p.path))
+    assert all(p.abspath == os.path.realpath(os.path.join('/west_top', p.path))
             for p in manifest.projects)
 
 def test_path():
@@ -122,10 +122,10 @@ def test_path():
           remote: testremote
           path: sub/directory
     '''
-    with patch('west.util.west_topdir', return_value=os.path.normpath('/west_top')):
+    with patch('west.util.west_topdir', return_value=os.path.realpath('/west_top')):
         manifest = Manifest.from_data(yaml.safe_load(content))
     assert manifest.projects[0].path == 'sub/directory'
-    assert manifest.projects[0].abspath == os.path.normpath('/west_top/sub/directory')
+    assert manifest.projects[0].abspath == os.path.realpath('/west_top/sub/directory')
 
 
 # Invalid manifests should raise MalformedManifest.


### PR DESCRIPTION
Make commands that accept project names also accept project paths. For
example, 'west branch fix-foo .' can be run inside the zephyr/
directory, instead of running 'west branch fix-foo zephyr'.

Paths are mapped to projects by checking if the realpath (canonicalized
absolute) of any project is a prefix of the realpath of the supplied
path. That method will map subdirectories of projects to the project as
well.

Switch to using realpath() to calculate project.abspath as well, which
streamlines things and gets rid of gotchas related to symbolic links.

Project names and paths can be mixed in the same command. If both a
project name and a path matches, the name takes precedence (this can
always be worked around with './foo').