### PR TITLE
version: Set post-release version to 0.3.99

### DIFF
--- a/src/west/_bootstrap/version.py
+++ b/src/west/_bootstrap/version.py
@@ -2,4 +2,4 @@
 #
 # This is the Python 3 version of option 3 in:
 # https://packaging.python.org/guides/single-sourcing-package-version/#single-sourcing-the-version
-__version__ = '0.3.0'
+__version__ = '0.3.99'


### PR DESCRIPTION
After releasing 0.3.0, set the .99 marker.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>