### PR TITLE
Be more helpful to newcomers.

### DIFF
--- a/src/west/main.py
+++ b/src/west/main.py
@@ -25,7 +25,7 @@ from west.commands.project import List, Clone, Fetch, Pull, Rebase, Branch, \
                              Checkout, Diff, Status, Update, ForAll, \
                              WestUpdated
 from west.manifest import Manifest
-from west.util import quote_sh_list, in_multirepo_install
+from west.util import quote_sh_list, in_multirepo_install, west_dir
 
 IN_MULTIREPO_INSTALL = in_multirepo_install(__file__)
 
@@ -191,8 +191,10 @@ def parse_args(argv):
         set_zephyr_base(args)
 
     if 'handler' not in args:
-        log.err('you must specify a command', fatal=True)
-        west_parser.print_usage(file=sys.stderr)
+        log.err('west installation found (in {}), but no command given'.
+                format(west_dir()),
+                fatal=True)
+        west_parser.print_help(file=sys.stderr)
         sys.exit(1)
 
     return args, unknown

--- a/src/west/main.py
+++ b/src/west/main.py
@@ -159,9 +159,9 @@ def parse_args(argv):
     # flags
 
     west_parser.add_argument('-z', '--zephyr-base', default=None,
-                             help='''Path to the Zephyr base directory. If not
-                             given, ZEPHYR_BASE must be defined in the
-                             environment, and will be used instead.''')
+                             help='''Override the Zephyr base directory. The
+                             default is the manifest project with path
+                             "zephyr".''')
 
     west_parser.add_argument('-v', '--verbose', default=0, action='count',
                              help='''Display verbose output. May be given


### PR DESCRIPTION
The error output when the bootstrapper is called without arguments or with -h is lacking. Try to improve it.

Tweak the output when called without arguments when an installation is found as well, in the same spirit.

Fixes: #108
