### PR TITLE
Revert "cmake: west: Take the 'kernel' name out of the .bin/.hex/.elf file"

### DIFF
--- a/scripts/west-completion.bash
+++ b/scripts/west-completion.bash
@@ -17,9 +17,9 @@ __comp_west()
 	--runner
 	--skip-rebuild
 	--board-dir
-	--elf-file
-	--hex-file
-	--bin-file
+	--kernel-elf
+	--kernel-hex
+	--kernel-bin
 	--gdb
 	--openocd
 	--openocd-search"

--- a/src/west/commands/run_common.py
+++ b/src/west/commands/run_common.py
@@ -75,17 +75,14 @@ def add_parser_common(parser_adder, command):
     #
     # This is how we detect if the user provided them or not when
     # overriding values from the cached configuration.
-
-    command_verb = "flash" if command == "flash" else "debug"
-
     group.add_argument('--board-dir',
                        help='Zephyr board directory')
-    group.add_argument('--elf-file',
-                       help='Path to elf file to {0}'.format(command_verb))
-    group.add_argument('--hex-file',
-                       help='Path to hex file to {0}'.format(command_verb))
-    group.add_argument('--bin-file',
-                       help='Path to binary file to {0}'.format(command_verb))
+    group.add_argument('--kernel-elf',
+                       help='Path to kernel binary in .elf format')
+    group.add_argument('--kernel-hex',
+                       help='Path to kernel binary in .hex format')
+    group.add_argument('--kernel-bin',
+                       help='Path to kernel binary in .bin format')
     group.add_argument('--gdb',
                        help='Path to GDB, if applicable')
     group.add_argument('--openocd',
@@ -114,15 +111,15 @@ def desc_common(command_name):
 def cached_runner_config(build_dir, cache):
     '''Parse the RunnerConfig from a build directory and CMake Cache.'''
     board_dir = cache['ZEPHYR_RUNNER_CONFIG_BOARD_DIR']
-    elf_file  = cache['ZEPHYR_RUNNER_CONFIG_ELF_FILE']
-    hex_file  = cache['ZEPHYR_RUNNER_CONFIG_HEX_FILE']
-    bin_file  = cache['ZEPHYR_RUNNER_CONFIG_BIN_FILE']
+    kernel_elf = cache['ZEPHYR_RUNNER_CONFIG_KERNEL_ELF']
+    kernel_hex = cache['ZEPHYR_RUNNER_CONFIG_KERNEL_HEX']
+    kernel_bin = cache['ZEPHYR_RUNNER_CONFIG_KERNEL_BIN']
     gdb = cache.get('ZEPHYR_RUNNER_CONFIG_GDB')
     openocd = cache.get('ZEPHYR_RUNNER_CONFIG_OPENOCD')
     openocd_search = cache.get('ZEPHYR_RUNNER_CONFIG_OPENOCD_SEARCH')
 
     return RunnerConfig(build_dir, board_dir,
-                        elf_file, hex_file, bin_file,
+                        kernel_elf, kernel_hex, kernel_bin,
                         gdb=gdb, openocd=openocd,
                         openocd_search=openocd_search)
 

--- a/src/west/runners/arc.py
+++ b/src/west/runners/arc.py
@@ -93,7 +93,7 @@ class EmStarterKitBinaryRunner(ZephyrBinaryRunner):
                    ['-ex', 'target remote :{}'.format(self.gdb_port),
                     '-ex', 'load'] +
                    continue_arg +
-                   [self.cfg.elf_file])
+                   [self.cfg.kernel_elf])
 
         self.run_server_and_client(server_cmd, gdb_cmd)
 

--- a/src/west/runners/bossac.py
+++ b/src/west/runners/bossac.py
@@ -48,7 +48,7 @@ class BossacBinaryRunner(ZephyrBinaryRunner):
                     'ospeed', '1200', 'cs8', '-cstopb', 'ignpar', 'eol', '255',
                     'eof', '255']
         cmd_flash = [self.bossac, '-p', self.port, '-R', '-e', '-w', '-v',
-                     '-b', self.cfg.bin_file]
+                     '-b', self.cfg.kernel_bin]
 
         self.check_call(cmd_stty)
         self.check_call(cmd_flash)

--- a/src/west/runners/core.py
+++ b/src/west/runners/core.py
@@ -191,8 +191,8 @@ class RunnerConfig:
     This class's __slots__ contains exactly the configuration variables.
     '''
 
-    __slots__ = ['build_dir', 'board_dir', 'elf_file', 'hex_file',
-                 'bin_file', 'gdb', 'openocd', 'openocd_search']
+    __slots__ = ['build_dir', 'board_dir', 'kernel_elf', 'kernel_hex',
+                 'kernel_bin', 'gdb', 'openocd', 'openocd_search']
 
     # TODO: revisit whether we can get rid of some of these.  Having
     # tool-specific configuration options here is a layering
@@ -200,7 +200,7 @@ class RunnerConfig:
     # store the locations of tools (like gdb and openocd) that are
     # needed by multiple ZephyrBinaryRunner subclasses.
     def __init__(self, build_dir, board_dir,
-                 elf_file, hex_file, bin_file,
+                 kernel_elf, kernel_hex, kernel_bin,
                  gdb=None, openocd=None, openocd_search=None):
         self.build_dir = build_dir
         '''Zephyr application build directory'''
@@ -208,14 +208,14 @@ class RunnerConfig:
         self.board_dir = board_dir
         '''Zephyr board directory'''
 
-        self.elf_file = elf_file
-        '''Path to the elf file that the runner should operate on'''
+        self.kernel_elf = kernel_elf
+        '''Path to kernel binary in .elf format'''
 
-        self.hex_file = hex_file
-        '''Path to the hex file that the runner should operate on'''
+        self.kernel_hex = kernel_hex
+        '''Path to kernel binary in .hex format'''
 
-        self.bin_file = bin_file
-        '''Path to the bin file that the runner should operate on'''
+        self.kernel_bin = kernel_bin
+        '''Path to kernel binary in .bin format'''
 
         self.gdb = gdb
         ''''Path to GDB compatible with the target, may be None.'''

--- a/src/west/runners/dfu.py
+++ b/src/west/runners/dfu.py
@@ -54,7 +54,7 @@ class DfuUtilBinaryRunner(ZephyrBinaryRunner):
 
         # Optional:
         parser.add_argument("--img",
-                            help="binary to flash, default is --bin-file")
+                            help="binary to flash, default is --kernel-bin")
         parser.add_argument("--dfuse", default=False, action='store_true',
                             help='''set if target is a DfuSe device;
                             implies --dt-flash.''')
@@ -69,7 +69,7 @@ class DfuUtilBinaryRunner(ZephyrBinaryRunner):
     @classmethod
     def create(cls, cfg, args):
         if args.img is None:
-            args.img = cfg.bin_file
+            args.img = cfg.kernel_bin
 
         if args.dfuse:
             args.dt_flash = True  # --dfuse implies --dt-flash.

--- a/src/west/runners/esp32.py
+++ b/src/west/runners/esp32.py
@@ -17,7 +17,7 @@ class Esp32BinaryRunner(ZephyrBinaryRunner):
                  flash_freq='40m', flash_mode='dio', espidf='espidf',
                  bootloader_bin=None, partition_table_bin=None):
         super(Esp32BinaryRunner, self).__init__(cfg)
-        self.elf = cfg.elf_file
+        self.elf = cfg.kernel_elf
         self.device = device
         self.baud = baud
         self.flash_size = flash_size

--- a/src/west/runners/intel_s1000.py
+++ b/src/west/runners/intel_s1000.py
@@ -22,7 +22,7 @@ class IntelS1000BinaryRunner(ZephyrBinaryRunner):
                  gdb_port=DEFAULT_XT_GDB_PORT):
         super(IntelS1000BinaryRunner, self).__init__(cfg)
         self.board_dir = cfg.board_dir
-        self.elf_name = cfg.elf_file
+        self.elf_name = cfg.kernel_elf
         self.gdb_cmd = cfg.gdb
         self.xt_ocd_dir = xt_ocd_dir
         self.ocd_topology = ocd_topology

--- a/src/west/runners/jlink.py
+++ b/src/west/runners/jlink.py
@@ -23,8 +23,8 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
                  gdbserver='JLinkGDBServer', gdb_port=DEFAULT_JLINK_GDB_PORT,
                  tui=False):
         super(JLinkBinaryRunner, self).__init__(cfg)
-        self.bin_name = cfg.bin_file
-        self.elf_name = cfg.elf_file
+        self.bin_name = cfg.kernel_bin
+        self.elf_name = cfg.kernel_elf
         self.gdb_cmd = [cfg.gdb] if cfg.gdb else None
         self.device = device
         self.commander = commander

--- a/src/west/runners/nios2.py
+++ b/src/west/runners/nios2.py
@@ -19,8 +19,8 @@ class Nios2BinaryRunner(ZephyrBinaryRunner):
 
     def __init__(self, cfg, quartus_py=None, cpu_sof=None, tui=False):
         super(Nios2BinaryRunner, self).__init__(cfg)
-        self.hex_name = cfg.hex_file
-        self.elf_name = cfg.elf_file
+        self.hex_name = cfg.kernel_hex
+        self.elf_name = cfg.kernel_elf
         self.cpu_sof = cpu_sof
         self.quartus_py = quartus_py
         self.gdb_cmd = [cfg.gdb] if cfg.gdb else None

--- a/src/west/runners/nrfjprog.py
+++ b/src/west/runners/nrfjprog.py
@@ -15,7 +15,7 @@ class NrfJprogBinaryRunner(ZephyrBinaryRunner):
 
     def __init__(self, cfg, family, softreset, snr, erase=False):
         super(NrfJprogBinaryRunner, self).__init__(cfg)
-        self.hex_ = cfg.hex_file
+        self.hex_ = cfg.kernel_hex
         self.family = family
         self.softreset = softreset
         self.snr = snr

--- a/src/west/runners/nsim.py
+++ b/src/west/runners/nsim.py
@@ -69,7 +69,7 @@ class NsimBinaryRunner(ZephyrBinaryRunner):
         config = kwargs['nsim-cfg']
 
         cmd = (self.nsim_cmd +
-            ['-propsfile', config, self.cfg.elf_file])
+            ['-propsfile', config, self.cfg.kernel_elf])
         self.check_call(cmd)
 
     def do_debug(self, **kwargs):
@@ -81,7 +81,7 @@ class NsimBinaryRunner(ZephyrBinaryRunner):
 
         gdb_cmd = (self.gdb_cmd +
                    ['-ex', 'target remote :{}'.format(self.gdb_port),
-                    '-ex', 'load', self.cfg.elf_file])
+                    '-ex', 'load', self.cfg.kernel_elf])
 
         self.run_server_and_client(server_cmd, gdb_cmd)
 

--- a/src/west/runners/openocd.py
+++ b/src/west/runners/openocd.py
@@ -30,7 +30,7 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
         if cfg.openocd_search is not None:
             search_args = ['-s', cfg.openocd_search]
         self.openocd_cmd = [cfg.openocd] + search_args
-        self.elf_name = cfg.elf_file
+        self.elf_name = cfg.kernel_elf
         self.load_cmd = load_cmd
         self.verify_cmd = verify_cmd
         self.pre_cmd = pre_cmd

--- a/src/west/runners/pyocd.py
+++ b/src/west/runners/pyocd.py
@@ -31,9 +31,9 @@ class PyOcdBinaryRunner(ZephyrBinaryRunner):
         self.gdbserver = gdbserver
         self.gdb_port = gdb_port
         self.tui_args = ['-tui'] if tui else []
-        self.hex_name = cfg.hex_file
-        self.bin_name = cfg.bin_file
-        self.elf_name = cfg.elf_file
+        self.bin_name = cfg.kernel_bin
+        self.hex_name = cfg.kernel_hex
+        self.elf_name = cfg.kernel_elf
 
         board_args = []
         if board_id is not None:

--- a/src/west/runners/xtensa.py
+++ b/src/west/runners/xtensa.py
@@ -35,6 +35,6 @@ class XtensaBinaryRunner(ZephyrBinaryRunner):
         return XtensaBinaryRunner(cfg)
 
     def do_run(self, command, **kwargs):
-        gdb_cmd = [self.cfg.gdb, self.cfg.elf_file]
+        gdb_cmd = [self.cfg.gdb, self.cfg.kernel_elf]
 
         self.check_call(gdb_cmd)


### PR DESCRIPTION
cc @SebastianBoe 

This reverts commit c466a5617fe7d043bfdf061cecc87f90b04544e9, which
breaks 'west flash' on the latest zephyr mainline:

```
$ west -vvv flash
ZEPHYR_BASE=/home/mbolivar/src/zephyr-west/zephyr (origin: manifest file /home/mbolivar/src/zephyr-west/west/manifest/default.yml)
/home/mbolivar/src/zephyr-west/build is a zephyr build directory
Running CMake: ['/usr/bin/cmake', '--build', '/home/mbolivar/src/zephyr-west/build']
As command: /usr/bin/cmake --build /home/mbolivar/src/zephyr-west/build
ninja: no work to do.
Using runner: pyocd
Traceback (most recent call last):
  File "/home/mbolivar/src/zephyr-west/west/west/src/west/main.py", line 236, in <module>
    main()
  File "/home/mbolivar/src/zephyr-west/west/west/src/west/main.py", line 216, in main
    args.handler(args, unknown)
  File "/home/mbolivar/src/zephyr-west/west/west/src/west/main.py", line 68, in command_handler
    command.run(known_args, unknown_args)
  File "/home/mbolivar/src/zephyr-west/west/west/src/west/commands/__init__.py", line 47, in run
    self.do_run(args, unknown)
  File "/home/mbolivar/src/zephyr-west/west/west/src/west/commands/flash.py", line 26, in do_run
    'ZEPHYR_BOARD_FLASH_RUNNER')
  File "/home/mbolivar/src/zephyr-west/west/west/src/west/commands/run_common.py", line 215, in do_run_common
    cfg = cached_runner_config(build_dir, cache)
  File "/home/mbolivar/src/zephyr-west/west/west/src/west/commands/run_common.py", line 117, in cached_runner_config
    elf_file  = cache['ZEPHYR_RUNNER_CONFIG_ELF_FILE']
  File "/home/mbolivar/src/zephyr-west/west/west/src/west/cmake.py", line 208, in __getitem__
    return self._entries[name].value
KeyError: 'ZEPHYR_RUNNER_CONFIG_ELF_FILE'
```

@SebastianBoe mind taking a look?