### PR TITLE
runners: jlink: debug log commander script contents

### DIFF
--- a/src/west/commands/flash.py
+++ b/src/west/commands/flash.py
@@ -14,7 +14,7 @@ class Flash(WestCommand):
     def __init__(self):
         super(Flash, self).__init__(
             'flash',
-            'Flash and run a binary onto a board.\n\n' +
+            'Flash and run a binary on a board.\n\n' +
             desc_common('flash'),
             accepts_unknown_args=True)
 

--- a/src/west/runners/jlink.py
+++ b/src/west/runners/jlink.py
@@ -127,6 +127,9 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
         lines.append('g') # Start the CPU
         lines.append('q') # Close the connection and quit
 
+        log.dbg('JLink commander script:')
+        log.dbg('\n'.join(lines))
+
         # Don't use NamedTemporaryFile: the resulting file can't be
         # opened again on Windows.
         with tempfile.TemporaryDirectory(suffix='jlink') as d:


### PR DESCRIPTION
@pfalcon does this fix your issue?

As explained in the log, it is certainly our intent that `west -v flash` prints enough information for users to stop using the wrapper if they desire.