### PR TITLE
commands: Be compatible with more Zephyr versions

### DIFF
--- a/src/west/commands/run_common.py
+++ b/src/west/commands/run_common.py
@@ -114,9 +114,9 @@ def desc_common(command_name):
 def cached_runner_config(build_dir, cache):
     '''Parse the RunnerConfig from a build directory and CMake Cache.'''
     board_dir = cache['ZEPHYR_RUNNER_CONFIG_BOARD_DIR']
-    elf_file  = cache['ZEPHYR_RUNNER_CONFIG_ELF_FILE']
-    hex_file  = cache['ZEPHYR_RUNNER_CONFIG_HEX_FILE']
-    bin_file  = cache['ZEPHYR_RUNNER_CONFIG_BIN_FILE']
+    elf_file  = cache.get('ZEPHYR_RUNNER_CONFIG_ELF_FILE', cache['ZEPHYR_RUNNER_CONFIG_KERNEL_ELF'])
+    hex_file  = cache.get('ZEPHYR_RUNNER_CONFIG_HEX_FILE', cache['ZEPHYR_RUNNER_CONFIG_KERNEL_HEX'])
+    bin_file  = cache.get('ZEPHYR_RUNNER_CONFIG_BIN_FILE', cache['ZEPHYR_RUNNER_CONFIG_KERNEL_BIN'])
     gdb = cache.get('ZEPHYR_RUNNER_CONFIG_GDB')
     openocd = cache.get('ZEPHYR_RUNNER_CONFIG_OPENOCD')
     openocd_search = cache.get('ZEPHYR_RUNNER_CONFIG_OPENOCD_SEARCH')


### PR DESCRIPTION
Check for multiple versions of names to be compatible with more
versions of Zephyr.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>