### PR TITLE
git: split pull into fetch+merge

### DIFF
--- a/src/west/commands/project.py
+++ b/src/west/commands/project.py
@@ -865,12 +865,21 @@ def _update_special(name):
 
         # Only update special repositories if possible via fast-forward, as
         # automatic rebasing is probably more annoying than useful when working
-        # directly on them. --rebase=false must be passed for --ff-only to be
-        # respected e.g. when pull.rebase is set.
+        # directly on them.
         #
         # --tags is required to get tags when the remote is specified as an URL.
+        # --ff-only is required to ensure that the merge only takes place if it
+        # can be fast-forwarded.
         if _git(project,
-                'pull --quiet --tags --rebase=false --ff-only -- (url) (revision)',
+                'fetch --quiet --tags -- (url) (revision)',
+                check=False).returncode:
+
+            _wrn(project, 'Skipping automatic update of (name-and-path). '
+                          "(revision) cannot be fetched (from "
+                          '(url)).')
+
+        elif _git(project,
+                'merge --quiet --ff-only FETCH_HEAD',
                 check=False).returncode:
 
             _wrn(project, 'Skipping automatic update of (name-and-path). '


### PR DESCRIPTION
Older versions of git lack support for --rebase=false
Thus splitting pull into a fetch and merge is safer, as well as it
provides better help on which steps are failing.

See the discussion from IRC.
```
#zephyr-meta
[2018-11-21 09:36:32] <tejlmand> ok, downloading 2.1.0 from Aug 2014.
[2018-11-21 09:36:55] <tejlmand> once you have a patch, I can verify behavior
[2018-11-21 09:37:18] <tejlmand> we should be pretty safe, if everything is working with 2.1.0
[2018-11-21 09:45:17] <tejlmand> with 2.1.0 I get
[2018-11-21 09:45:25] <tejlmand> https://www.irccloud.com/pastebin/735rrjAE/
error: unknown option `rebase=false'
usage: git fetch [<options>] [<repository> [<refspec>...]]
   or: git fetch [<options>] <group>
   or: git fetch --multiple [<options>] [(<repository> | <group>)...]
   or: git fetch --all [<options>]

    -v, --verbose         be more verbose
    -q, --quiet           be more quiet
    --all                 fetch from all remotes
    -a, --append          append to .git/FETCH_HEAD instead of overwriting
    --upload-pack <path>  path to upload pack on remote end
    -f, --force           force overwrite of local branch
    -m, --multiple        fetch from multiple remotes
    -t, --tags            fetch all tags and associated objects
    -n                    do not fetch all tags (--no-tags)
    -p, --prune           prune remote-tracking branches no longer on remote
    --recurse-submodules[=<on-demand>]
                          control recursive fetching of submodules
    --dry-run             dry run
    -k, --keep            keep downloaded pack
    -u, --update-head-ok  allow updating of HEAD ref
    --progress            force progress reporting
    --depth <depth>       deepen history of shallow clone
    --unshallow           convert to a complete repository
    --update-shallow      accept refs that update .git/shallow
    --refmap <refmap>     specify fetch refmap
[2018-11-21 09:46:02] <tejlmand> so we should investigate from which `git` version `rebase=false` is supported
[2018-11-21 09:49:58] <Ulfalizer> could turn the 'git pull' into a 'git fetch' + 'git merge --ff-only FETCH_HEAD' to work around it
[2018-11-21 09:50:22] <Ulfalizer> zz time soon, but i'll send PRs later
[2018-11-21 09:50:27] <tejlmand> sure
[2018-11-21 09:51:14] <tejlmand> not in Sweden, or just been coding all night :p
[2018-11-21 09:54:05] <Ulfalizer> my sleep schedule is a bit exotic ;)
[2018-11-21 09:54:18] <Ulfalizer> it's more like no schedule
[2018-11-21 10:09:34] <tejlmand> I can look at it.
[2018-11-21 10:10:00] <tejlmand> easier to verify behavior, when I have 2.1.0, 2.7.4 and 2.19.1 installed now :p
[2018-11-21 10:34:00] <Ulfalizer> feel free to go ahead :)
[2018-11-21 10:37:50] <tejlmand> hmmm.
[2018-11-21 10:38:34] <tejlmand> when compiling the docs for `2.1.0` it does state that `--rebase=false` is supported (it is at least stated in the man page)
[2018-11-21 10:40:33] <Ulfalizer> maybe it's some bad interaction with the other flags
[2018-11-21 10:41:13] <Ulfalizer> search for 'pull --quiet --tags ...' in src/west/commands/project.py to see exactly what it runs
[2018-11-21 10:41:35] <tejlmand> most likely flag is passed down the chain, as it is printing the help for `fetch`, while we are using `pull`
[2018-11-21 10:44:28] <tejlmand> so `pull` doesn't interprete the flag correctly, and apears to just pass it on to `fetch`
```