### PR TITLE
Read west URL and revision from  manifest instead of config file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -97,12 +97,8 @@ This somewhat unusual arrangement is because:
 Using a Custom "Main" West
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To initialize west from a non-default location::
-
-  west init -w https://example.com/your-west-repository.git
-
-You can also add ``--west-rev some-branch`` to use ``some-branch``
-instead of ``master``.
+To initialize west from a non-default location add a section ``west`` in the
+manifest ``.yml`` file that points to a ``url`` and ``revision`` of your choice.
 
 To use another manifest repository (optionally with ``--mr
 some-manifest-branch``)::

--- a/src/west/_bootstrap/west-schema.yml
+++ b/src/west/_bootstrap/west-schema.yml
@@ -1,0 +1,17 @@
+## A pykwalify schema for basic validation of the structure of a
+## west YAML file.  (Full validation would require additional work,
+## e.g. to validate that remote URLs obey the URL format specified in
+## rfc1738.)
+##
+
+# The top-level west yaml is a map. The only top-level element is
+# 'west'. All other elements are contained within it. This allows
+# us a bit of future-proofing.
+type: map
+mapping:
+  url:
+    required: false
+    type: str
+  revision:
+    required: false
+    type: str

--- a/src/west/manifest-schema.yml
+++ b/src/west/manifest-schema.yml
@@ -54,9 +54,9 @@ mapping:
   #
   #   remotes:
   #     - name: zephyrproject-rtos
-  #       url: https://github.com/zephyrproject-rtos
+  #       url-base: https://github.com/zephyrproject-rtos
   #     - name: developer-fork
-  #       url: https://github.com/a-developer
+  #       url-base: https://github.com/a-developer
   remotes:
     required: true
     type: seq
@@ -66,7 +66,7 @@ mapping:
           name:
             required: true
             type: str
-          url:
+          url-base:
             required: true
             type: str
 
@@ -78,7 +78,7 @@ mapping:
   # Each project is a map with the following keys:
   #
   # - name: Mandatory, the name of the git repository. The clone
-  #   URL is formed by remote + '/' + name. The name cannot
+  #   URL is formed by remote url-base + '/' + name. The name cannot
   #   be one of the reserved values "west" and "manifest".
   # - remote: Optional, the name of the remote to pull it from.
   #   If the remote is missing, the remote'key in the top-level

--- a/src/west/manifest-schema.yml
+++ b/src/west/manifest-schema.yml
@@ -9,128 +9,124 @@
 ##
 ## However, the features don't map 1:1.
 
-# The top-level manifest is a map. The only top-level element is
-# 'manifest'. All other elements are contained within it. This allows
-# us a bit of future-proofing.
+# The top-level manifest is a map. There may be multiple sections in the
+# manifest file. Each section can be validated by their own schema.
+# This schema validates the 'manifest' section.
 type: map
 mapping:
-  manifest:
-    required: true
+  # The "defaults" key specifies some default values used in the
+  # rest of the manifest.
+  #
+  # The value is a map with the following keys:
+  #
+  # - remote: if given, this is the default remote in each project
+  # - revision: if given, this is the default revision to check
+  #   out of each project
+  #
+  # See below for more information about remotes and projects.
+  #
+  # Examples:
+  #
+  # default:
+  #   remote: zephyrproject-rtos
+  #   revision: master
+  defaults:
+    required: false
     type: map
     mapping:
-      # The "defaults" key specifies some default values used in the
-      # rest of the manifest.
-      #
-      # The value is a map with the following keys:
-      #
-      # - remote: if given, this is the default remote in each project
-      # - revision: if given, this is the default revision to check
-      #   out of each project
-      #
-      # See below for more information about remotes and projects.
-      #
-      # Examples:
-      #
-      # default:
-      #   remote: zephyrproject-rtos
-      #   revision: master
-      defaults:
+      remote:
         required: false
-        type: map
+        type: str
+      revision:
+        required: false
+        type: str
+
+  # The "remotes" key specifies a sequence of remotes, each of
+  # which has a name and a fetch URL.
+  #
+  # These work like repo remotes, in that they specify a URL
+  # prefix which remote-specific Git repositories hang off of.
+  # (This saves typing and makes it easier to move things around
+  # when most repositories are on the same server or GitHub
+  # organization.)
+  #
+  # Example:
+  #
+  #   remotes:
+  #     - name: zephyrproject-rtos
+  #       url: https://github.com/zephyrproject-rtos
+  #     - name: developer-fork
+  #       url: https://github.com/a-developer
+  remotes:
+    required: true
+    type: seq
+    sequence:
+      - type: map
         mapping:
+          name:
+            required: true
+            type: str
+          url:
+            required: true
+            type: str
+
+  # The "projects" key specifies a sequence of "projects",
+  # i.e. Git repositories. These work like repo projects, in that
+  # each project has a name, a remote, and optional additional
+  # metadata.
+  #
+  # Each project is a map with the following keys:
+  #
+  # - name: Mandatory, the name of the git repository. The clone
+  #   URL is formed by remote + '/' + name. The name cannot
+  #   be one of the reserved values "west" and "manifest".
+  # - remote: Optional, the name of the remote to pull it from.
+  #   If the remote is missing, the remote'key in the top-level
+  #   defaults key is used instead. If both are missing, it's an error.
+  # - revision: Optional, the name of the revision to check out.
+  #   If not given, the value from the default element will be used.
+  #   If both are missing, then the default is 'master'.
+  # - path: Where to clone the repository locally. If missing,
+  #   it's cloned at top level in a directory given by its name.
+  # - clone-depth: if given, it is a number which creates a shallow
+  #   history in the cloned repository limited to the given number
+  #   of commits.
+  #
+  # Example, using default and non-default remotes:
+  #
+  #   projects:
+  #     # Uses default remote (zephyrproject-rtos), so clone URL is:
+  #     #   https://github.com/zephyrproject-rtos/zephyr
+  #     - name: zephyr
+  #     # Manually specified remote; clone URL is:
+  #     #   https://github.com/a-developer/west
+  #     - name: west
+  #       remote: developer-fork
+  #     # Manually specified remote, clone URL is:
+  #     #   https://github.com/zephyrproject-rtos/some-vendor-hal
+  #     # Local clone path (relative to installation root) is:
+  #     #   ext/hal/some-vendor
+  #     - name: some-vendor-hal
+  #       remote: zephyrproject-rtos
+  #       path: ext/hal/some-vendor
+  projects:
+    required: true
+    type: seq
+    sequence:
+      - type: map
+        mapping:
+          name:
+            required: true
+            type: str
           remote:
             required: false
             type: str
           revision:
             required: false
+            type: text        # SHAs could be only numbers
+          path:
+            required: false
             type: str
-
-      # The "remotes" key specifies a sequence of remotes, each of
-      # which has a name and a fetch URL.
-      #
-      # These work like repo remotes, in that they specify a URL
-      # prefix which remote-specific Git repositories hang off of.
-      # (This saves typing and makes it easier to move things around
-      # when most repositories are on the same server or GitHub
-      # organization.)
-      #
-      # Example:
-      #
-      #   remotes:
-      #     - name: zephyrproject-rtos
-      #       url: https://github.com/zephyrproject-rtos
-      #     - name: developer-fork
-      #       url: https://github.com/a-developer
-      remotes:
-        required: true
-        type: seq
-        sequence:
-          - type: map
-            mapping:
-              name:
-                required: true
-                type: str
-              url:
-                required: true
-                type: str
-
-      # The "projects" key specifies a sequence of "projects",
-      # i.e. Git repositories. These work like repo projects, in that
-      # each project has a name, a remote, and optional additional
-      # metadata.
-      #
-      # Each project is a map with the following keys:
-      #
-      # - name: Mandatory, the name of the git repository. The clone
-      #   URL is formed by remote + '/' + name. The name cannot
-      #   be one of the reserved values "west" and "manifest".
-      # - remote: Optional, the name of the remote to pull it from.
-      #   If the remote is missing, the remote'key in the top-level
-      #   defaults key is used instead. If both are missing, it's an error.
-      # - revision: Optional, the name of the revision to check out.
-      #   If not given, the value from the default element will be used.
-      #   If both are missing, then the default is 'master'.
-      # - path: Where to clone the repository locally. If missing,
-      #   it's cloned at top level in a directory given by its name.
-      # - clone-depth: if given, it is a number which creates a shallow
-      #   history in the cloned repository limited to the given number
-      #   of commits.
-      #
-      # Example, using default and non-default remotes:
-      #
-      #   projects:
-      #     # Uses default remote (zephyrproject-rtos), so clone URL is:
-      #     #   https://github.com/zephyrproject-rtos/zephyr
-      #     - name: zephyr
-      #     # Manually specified remote; clone URL is:
-      #     #   https://github.com/a-developer/west
-      #     - name: west
-      #       remote: developer-fork
-      #     # Manually specified remote, clone URL is:
-      #     #   https://github.com/zephyrproject-rtos/some-vendor-hal
-      #     # Local clone path (relative to installation root) is:
-      #     #   ext/hal/some-vendor
-      #     - name: some-vendor-hal
-      #       remote: zephyrproject-rtos
-      #       path: ext/hal/some-vendor
-      projects:
-        required: true
-        type: seq
-        sequence:
-          - type: map
-            mapping:
-              name:
-                required: true
-                type: str
-              remote:
-                required: false
-                type: str
-              revision:
-                required: false
-                type: text        # SHAs could be only numbers
-              path:
-                required: false
-                type: str
-              clone-depth:
-                required: false
-                type: int
+          clone-depth:
+            required: false
+            type: int

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -183,7 +183,7 @@ class Manifest:
         manifest = data.get('manifest')
 
         # Map from each remote's name onto that remote's data in the manifest.
-        remotes = tuple(Remote(r['name'], r['url']) for r in
+        remotes = tuple(Remote(r['name'], r['url-base']) for r in
                         manifest['remotes'])
         remotes_dict = {r.name: r for r in remotes}
 

--- a/tests/west/manifest/invalid_bad_default_remote.yml
+++ b/tests/west/manifest/invalid_bad_default_remote.yml
@@ -4,7 +4,7 @@ manifest:
 
   remotes:
     - name: testremote
-      url: https://example.com
+      url-base: https://example.com
 
   projects:
     - name: foo

--- a/tests/west/manifest/invalid_duplicate_project_path.yml
+++ b/tests/west/manifest/invalid_duplicate_project_path.yml
@@ -4,7 +4,7 @@ manifest:
 
   remotes:
     - name: testremote
-      url: https://example.com
+      url-base: https://example.com
 
   projects:
     - name: foo1

--- a/tests/west/manifest/invalid_ill_defined_project.yml
+++ b/tests/west/manifest/invalid_ill_defined_project.yml
@@ -1,7 +1,7 @@
 manifest:
   remotes:
     - name: testremote
-      url: https://example.com
+      url-base: https://example.com
 
   projects:
     - name: ill_defined_no_remote

--- a/tests/west/manifest/invalid_no_projects.yml
+++ b/tests/west/manifest/invalid_no_projects.yml
@@ -1,4 +1,4 @@
 manifest:
   remotes:
     - name: testremote
-      url: https://example.com
+      url-base: https://example.com

--- a/tests/west/manifest/invalid_reserved_name_manifest.yml
+++ b/tests/west/manifest/invalid_reserved_name_manifest.yml
@@ -1,7 +1,7 @@
 manifest:
   remotes:
     - name: testremote
-      url: https://example.com
+      url-base: https://example.com
 
   projects:
     - name: manifest

--- a/tests/west/manifest/invalid_reserved_name_west.yml
+++ b/tests/west/manifest/invalid_reserved_name_west.yml
@@ -1,7 +1,7 @@
 manifest:
   remotes:
     - name: testremote
-      url: https://example.com
+      url-base: https://example.com
 
   projects:
     - name: west

--- a/tests/west/manifest/invalid_too_flat.yml
+++ b/tests/west/manifest/invalid_too_flat.yml
@@ -1,7 +1,7 @@
 # This invalid manifest is too flat.
 remotes:
   - name: testremote
-    url: https://example.com
+    url-base: https://example.com
 projects:
   - name: testproject
     remote: testremote

--- a/tests/west/manifest/invalid_west_section.yml
+++ b/tests/west/manifest/invalid_west_section.yml
@@ -1,0 +1,20 @@
+# The default West manifest file to be used for Zephyr.
+#
+
+west:
+  url: https://example.com
+  revision: arevision
+  invalidfield: thisfieldisinvalid
+
+manifest:
+  defaults:
+    remote: upstream
+    revision: master
+
+  remotes:
+    - name: upstream
+      url: https://example.com
+
+  projects:
+    - name: zephyr
+      revision: abranch

--- a/tests/west/manifest/invalid_west_section.yml
+++ b/tests/west/manifest/invalid_west_section.yml
@@ -13,7 +13,7 @@ manifest:
 
   remotes:
     - name: upstream
-      url: https://example.com
+      url-base: https://example.com
 
   projects:
     - name: zephyr

--- a/tests/west/manifest/test_manifest.py
+++ b/tests/west/manifest/test_manifest.py
@@ -33,9 +33,9 @@ def test_no_defaults():
     manifest:
       remotes:
         - name: testremote1
-          url: https://example1.com
+          url-base: https://example1.com
         - name: testremote2
-          url: https://example2.com
+          url-base: https://example2.com
 
       projects:
         - name: testproject1
@@ -74,9 +74,9 @@ def test_default_clone_depth():
 
       remotes:
         - name: testremote1
-          url: https://example1.com
+          url-base: https://example1.com
         - name: testremote2
-          url: https://example2.com
+          url-base: https://example2.com
 
       projects:
         - name: testproject1
@@ -116,7 +116,7 @@ def test_path():
     manifest:
       remotes:
         - name: testremote
-          url: https://example.com
+          url-base: https://example.com
       projects:
         - name: testproject
           remote: testremote
@@ -137,7 +137,7 @@ def test_sections():
     manifest:
       remotes:
         - name: testremote
-          url: https://example.com
+          url-base: https://example.com
       projects:
         - name: testproject
           remote: testremote
@@ -155,7 +155,7 @@ def test_sections():
     manifest:
       remotes:
         - name: testremote
-          url: https://example.com
+          url-base: https://example.com
       projects:
         - name: testproject
           remote: testremote

--- a/tests/west/manifest/test_manifest.py
+++ b/tests/west/manifest/test_manifest.py
@@ -164,8 +164,8 @@ def test_sections():
     with patch('west.util.west_topdir', return_value=os.path.realpath('/west_top')):
         # Parsing west section only, no exception raised
         manifest = Manifest.from_data(yaml.safe_load(content_wrong_manifest), 'west')
-    assert manifest.westmeta.url == 'https://example.com'
-    assert manifest.westmeta.revision == 'abranch'
+    assert manifest.west_project.url == 'https://example.com'
+    assert manifest.west_project.revision == 'abranch'
 
 # Invalid manifests should raise MalformedManifest.
 @pytest.mark.parametrize('invalid',

--- a/tests/west/manifest/test_manifest.py
+++ b/tests/west/manifest/test_manifest.py
@@ -127,6 +127,45 @@ def test_path():
     assert manifest.projects[0].path == 'sub/directory'
     assert manifest.projects[0].abspath == os.path.realpath('/west_top/sub/directory')
 
+def test_sections():
+    # Projects must be able to override their default paths.
+    content_wrong_west = '''\
+    west:
+      url: https://example.com
+      revision: abranch
+      wrongfield: avalue
+    manifest:
+      remotes:
+        - name: testremote
+          url: https://example.com
+      projects:
+        - name: testproject
+          remote: testremote
+          path: sub/directory
+    '''
+    with patch('west.util.west_topdir', return_value=os.path.realpath('/west_top')):
+        # Parsing manifest only, no exception raised
+        manifest = Manifest.from_data(yaml.safe_load(content_wrong_west), 'manifest')
+    assert manifest.projects[0].path == 'sub/directory'
+    assert manifest.projects[0].abspath == os.path.realpath('/west_top/sub/directory')
+    content_wrong_manifest = '''\
+    west:
+      url: https://example.com
+      revision: abranch
+    manifest:
+      remotes:
+        - name: testremote
+          url: https://example.com
+      projects:
+        - name: testproject
+          remote: testremote
+          path: sub/directory
+    '''
+    with patch('west.util.west_topdir', return_value=os.path.realpath('/west_top')):
+        # Parsing west section only, no exception raised
+        manifest = Manifest.from_data(yaml.safe_load(content_wrong_manifest), 'west')
+    assert manifest.westmeta.url == 'https://example.com'
+    assert manifest.westmeta.revision == 'abranch'
 
 # Invalid manifests should raise MalformedManifest.
 @pytest.mark.parametrize('invalid',

--- a/tests/west/project/test_project.py
+++ b/tests/west/project/test_project.py
@@ -76,7 +76,7 @@ manifest:
 
   remotes:
     - name: repos
-      url: file://{}
+      url-base: file://{}
 
   projects:
     - name: net-tools

--- a/tests/west/project/test_project.py
+++ b/tests/west/project/test_project.py
@@ -294,13 +294,16 @@ def test_update(clean_west_topdir):
 [manifest]
 remote = {0}/remote-repos/manifest
 revision = master
-
-[west]
-remote = {0}/remote-repos/west
-revision = master
 '''.format(clean_west_topdir))
 
     config.read_config()
+
+    # modify the manifest to point to another west
+    clean_west_topdir.join('manifest.yml').write('''
+west:
+  url: file://{}/remote-repos/west
+  revision: master
+'''.format(clean_west_topdir), 'a')
 
     # Fetch the net-tools repository
     cmd('fetch --no-update net-tools')
@@ -360,16 +363,10 @@ def test_bootstrap_reinit(clean_west_topdir, monkeypatch):
         bootstrap.init([])  # West already initialized
 
     for init_args, west_args in (
-        (['-m',   'foo'], ['update', '--reset-manifest', '--reset-projects']),
-        (['--mr', 'foo'], ['update', '--reset-manifest', '--reset-projects']),
-        (['-w',   'foo'], ['update', '--reset-west']),
-        (['--wr', 'foo'], ['update', '--reset-west']),
-        (['--wr', 'foo'], ['update', '--reset-west']),
-        (['-m',   'foo', '-w', 'foo'],
-         ['update', '--reset-manifest', '--reset-projects', '--reset-west']),
-        (['-b',   'foo'],
-         ['update', '--reset-manifest', '--reset-projects', '--reset-west']),
-        (['-b',   'foo', '--no-reset'], [])):
+        (['-m',   'foo'], ['update', '--reset-manifest', '--reset-projects',
+                           '--reset-west']),
+        (['--mr', 'foo'], ['update', '--reset-manifest', '--reset-projects',
+                           '--reset-west'])):
 
         # Reset wrap_args before each test so that it ends up as [] if wrap()
         # isn't called (for the --no-reset case)


### PR DESCRIPTION
~Early RFC to get feedback, only partially tested~

Full implementation with additional proposal by @tejlmand:
https://github.com/carlescufi/west/pull/1

Also coupled to this PR to the manifest:
https://github.com/zephyrproject-rtos/manifest/pull/6

Fixes #106 (we will be able to simply tag the manifest with this PR)