### PR TITLE
west: nrfjprog: Do verify after programming.

### DIFF
--- a/src/west/runners/nrfjprog.py
+++ b/src/west/runners/nrfjprog.py
@@ -89,7 +89,7 @@ class NrfJprogBinaryRunner(ZephyrBinaryRunner):
         else:
             board_snr = self.snr.lstrip("0")
         program_cmd = ['nrfjprog', '--program', self.hex_, '-f', self.family,
-                       '--snr', board_snr]
+                       '--snr', board_snr, '--verify']
 
         print('Flashing file: {}'.format(self.hex_))
         if self.erase:


### PR DESCRIPTION
Some times the --program operation fails. This patch
ensures that the nrfjprog command returns an error code
and error message if that happenes.

Without this patch, the user is not informed about the
failed program operation.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>