### PR TITLE
project: Fixed issue with fetching revision SHA

### DIFF
--- a/src/west/commands/project.py
+++ b/src/west/commands/project.py
@@ -710,8 +710,13 @@ def _fetch(project):
     # separately.
     #
     # --tags is required to get tags when the remote is specified as an URL.
-    _git(project, fetch_cmd + ' --tags -- (url) (revision)')
-    _git(project, 'update-ref (qual-manifest-rev-branch) FETCH_HEAD^{commit}')
+    if _is_sha(project.revision):
+        # Don't fetch a SHA directly, as server may restrict from doing so.
+        _git(project, fetch_cmd + ' --tags -- (url)')
+        _git(project, 'update-ref (qual-manifest-rev-branch) (revision)')
+    else:
+        _git(project, fetch_cmd + ' --tags -- (url) (revision)')
+        _git(project, 'update-ref (qual-manifest-rev-branch) FETCH_HEAD^{commit}')
 
     if not _head_ok(project):
         # If nothing it checked out (which would usually only happen just after


### PR DESCRIPTION
Fixes: #139

Fixes the issue of fetching SHAs when specified in manifest file.
It is checked if a revision is a SHA, in which case the fetch is
performed on the url and afterwards the manifest-rev reference is
updated to the SHA.

Signed-off-by: Torsten Rasmussen <torsten.rasmussen@nordicsemi.no>