### PR TITLE
[RFC][DNM] Feature west reset

### DIFF
--- a/src/west/commands/project.py
+++ b/src/west/commands/project.py
@@ -56,9 +56,9 @@ class Reset(WestCommand):
     def do_run(self, args, user_args):
         # Arg parse, if project not given, use 'zephyr'
         # Only one project can be given.
-        #
         # ToDo: Check SHA is valid ?
         n=0
+        args.projects = [args.projects]
         project = _projects(args)[0]
         manifest = _special_project(args, 'manifest')
         reset_projects = _all_projects(args)
@@ -66,8 +66,9 @@ class Reset(WestCommand):
         while True:
             n += 1
 
+            sha = project.sha or project.revision
             rev_list = _git(project,
-                   'rev-list --topo-order (revision) ^{}'.format(args.revision),
+                   'rev-list --topo-order {} ^{}'.format(sha, args.revision),
                    capture_stdout=True).stdout
             if not rev_list:
                 # Empty string, thus we are ahead of last manifest commit.
@@ -91,9 +92,14 @@ class Reset(WestCommand):
                             "supported by current west".
                             format(args.revision, manifest.url, n))
         for proj in reset_projects:
-            rev_list = _git(proj,
-                   'reset {} {}'.format(args.gitargs, args.revision),
-                   capture_stdout=False)
+            if proj.name in args.projects:
+                _git(proj,
+                    'reset {} {}'.format(args.gitargs, args.revision),
+                    capture_stdout=False)
+            else:
+                _git(proj,
+                    'reset {} {}'.format(args.gitargs, proj.sha or proj.revision),
+                    capture_stdout=False)
 
 
 class List(WestCommand):

--- a/src/west/commands/project.py
+++ b/src/west/commands/project.py
@@ -710,8 +710,13 @@ def _fetch(project):
     # separately.
     #
     # --tags is required to get tags when the remote is specified as an URL.
-    _git(project, fetch_cmd + ' --tags -- (url) (revision)')
-    _git(project, 'update-ref (qual-manifest-rev-branch) FETCH_HEAD^{commit}')
+    if _is_sha(project.revision):
+        # Don't fetch a SHA directly, as server may restrict from doing so.
+        _git(project, fetch_cmd + ' --tags -- (url)')
+        _git(project, 'update-ref (qual-manifest-rev-branch) (revision)')
+    else:
+        _git(project, fetch_cmd + ' --tags -- (url) (revision)')
+        _git(project, 'update-ref (qual-manifest-rev-branch) FETCH_HEAD^{commit}')
 
     if not _head_ok(project):
         # If nothing it checked out (which would usually only happen just after

--- a/src/west/main.py
+++ b/src/west/main.py
@@ -23,7 +23,7 @@ from west.commands.flash import Flash
 from west.commands.debug import Debug, DebugServer, Attach
 from west.commands.project import List, Clone, Fetch, Pull, Rebase, Branch, \
                              Checkout, Diff, Status, Update, ForAll, \
-                             WestUpdated
+                             WestUpdated, Reset
 from west.manifest import Manifest
 from west.util import quote_sh_list, in_multirepo_install, west_dir
 
@@ -38,6 +38,7 @@ BUILD_FLASH_COMMANDS = [
 ]
 
 PROJECT_COMMANDS = [
+    Reset(),
     List(),
     Clone(),
     Fetch(),

--- a/src/west/manifest-schema.yml
+++ b/src/west/manifest-schema.yml
@@ -130,3 +130,7 @@ mapping:
           clone-depth:
             required: false
             type: int
+          sha:
+            required: false
+            type: text        # SHAs could be only numbers
+

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -241,7 +241,8 @@ class Manifest:
                               defaults,
                               path=mp.get('path'),
                               clone_depth=mp.get('clone-depth'),
-                              revision=mp.get('revision'))
+                              revision=mp.get('revision'),
+                              sha=mp.get('sha'))
 
             # Two projects cannot have the same path. We use absolute
             # paths to check for collisions to ensure paths are
@@ -321,10 +322,10 @@ class Project:
 
     Projects are neither comparable nor hashable.'''
 
-    __slots__ = 'name remote url path abspath clone_depth revision'.split()
+    __slots__ = 'name remote url path abspath clone_depth revision sha'.split()
 
     def __init__(self, name, remote, defaults, path=None, clone_depth=None,
-                 revision=None, url=None):
+                 revision=None, url=None, sha=None):
         '''Specify a Project by name, Remote, and optional information.
 
         :param name: Project's user-defined name in the manifest
@@ -346,6 +347,7 @@ class Project:
         self.abspath = os.path.realpath(os.path.join(util.west_topdir(), self.path))
         self.clone_depth = clone_depth
         self.revision = revision or defaults.revision
+        self.sha = sha
 
     def __eq__(self, other):
         raise NotImplemented
@@ -353,9 +355,9 @@ class Project:
     def __repr__(self):
         reprs = [repr(x) for x in
                  (self.name, self.remote, self.url, self.path,
-                  self.abspath, self.clone_depth, self.revision)]
+                  self.abspath, self.clone_depth, self.revision, self.sha)]
         return ('Project(name={}, remote={}, url={}, path={}, abspath={}, '
-                'clone_depth={}, revision={})').format(*reprs)
+                'clone_depth={}, revision={}, sha={})').format(*reprs)
 
 class SpecialProject(Project):
     '''Represents a special project, e.g. the west or manifest project.
@@ -378,6 +380,7 @@ class SpecialProject(Project):
         self.revision = revision
         self.remote = None
         self.clone_depth = None
+        self.sha = None
 
 
 def _wrn_if_not_remote(remote):

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -55,7 +55,7 @@ class Manifest:
         '''Create and return a new Manifest object given a source YAML file.
 
         :param source_file: Path to a YAML file containing the manifest.
-        :param sections: Only parse specified sections from YAML file, 
+        :param sections: Only parse specified sections from YAML file,
                          default: all sections are parsed.
 
         If source_file is None, the value returned by default_path()
@@ -71,10 +71,22 @@ class Manifest:
         '''Create and return a new Manifest object given parsed YAML data.
 
         :param source_data: Parsed YAML data as a Python object.
-        :param sections: Only parse specified sections from YAML data, 
+        :param sections: Only parse specified sections from YAML data,
                          default: all sections are parsed.
 
         Raises MalformedManifest in case of validation errors.'''
+        return Manifest(source_data=source_data, sections=sections)
+
+    @staticmethod
+    def from_string(string_data, sections=MANIFEST_SECTIONS):
+        '''Create and return a new Manifest object given text string.
+
+        :param string_data: String containing data to parse.
+        :param sections: Only parse specified sections from YAML data,
+                         default: all sections are parsed.
+
+        Raises MalformedManifest in case of validation errors.'''
+        source_data = yaml.safe_load(string_data)
         return Manifest(source_data=source_data, sections=sections)
 
     def __init__(self, source_file=None, source_data=None, sections=MANIFEST_SECTIONS):
@@ -82,7 +94,7 @@ class Manifest:
 
         :param source_file: Path to a YAML file containing the manifest.
         :param source_data: Parsed YAML data as a Python object.
-        :param sections: Only parse specified sections from YAML file, 
+        :param sections: Only parse specified sections from YAML file,
                          default: all sections are parsed.
 
         Normally, it is more convenient to use the `from_file` and
@@ -364,8 +376,8 @@ class SpecialProject(Project):
         self.path = path or name
         self.abspath = os.path.realpath(os.path.join(util.west_topdir(), self.path))
         self.revision = revision
-        self.remote = None 
-        self.clone_depth = None 
+        self.remote = None
+        self.clone_depth = None
 
 
 def _wrn_if_not_remote(remote):


### PR DESCRIPTION
Initial prototype of a `west reset` feature in order to spawn further discussions.

A supplementary repo has been created from which `zephyr` and `mcuboot` can be found here:
https://github.com/tejlmand/manifest-reset.git

This manifest repo can be used to test the reset feature.
Example:
```
west init -m https://github.com/tejlmand/manifest-reset.git
west clone
```
Run `west reset` and see all repo jumping to correct revisions:
```
west reset -r cb2445d8fe2023b5db1ff9816ccc126c8dfa0ca5 -g ' --hard' zephyr 
```
which should give you:
```
HEAD is now at cb2445d tests: subsys: settings: extend nffs back-end testing
HEAD is now at 4d20525 boot: zephyr: cleanup nrf52840_pca10059 configuration
```

go forward:
```
west pull
```
Jump to manifest revision of zephyr, based upon mcuboot revision:
```
west reset -r 68b305369463bc39d66b336b9b68d687e4ddd79f -g ' --hard' mcuboot
```
which should give you:
```
HEAD is now at d8285e4 pci: General code cleanup
HEAD is now at 68b3053 Add deprecated warning to Jira and Confluence links
```
