### PR TITLE
Fix gdb ctrl-c regression

### DIFF
--- a/src/west/_bootstrap/main.py
+++ b/src/west/_bootstrap/main.py
@@ -406,18 +406,17 @@ def wrap(argv):
             print('West repository version: unknown; no tags were found')
         sys.exit(0)
 
-    # Replace the wrapper process with the "real" west
-
-    # sys.argv[1:] strips the argv[0] of the wrapper script itself
-    argv = ([sys.executable,
-             os.path.join(west_git_repo, 'src', 'west', 'main.py')] +
-            argv)
-
-    append_to_pythonpath(os.path.join(west_git_repo, 'src'))
-    try:
-        subprocess.check_call(argv)
-    except subprocess.CalledProcessError as e:
-        sys.exit(1)
+    # Import the west package from the installation and run its main
+    # function with the given command-line arguments.
+    #
+    # This can't be done as a subprocess: that would break the
+    # runners' debug handling for GDB, which needs to block the usual
+    # control-C signal handling. GDB uses Ctrl-C to halt the debug
+    # target. So we really do need to import west and delegate within
+    # this bootstrap process.
+    sys.path.append(os.path.join(west_git_repo, 'src'))
+    import west.main
+    west.main.main(argv)
 
 
 #

--- a/src/west/_bootstrap/main.py
+++ b/src/west/_bootstrap/main.py
@@ -74,6 +74,7 @@ def west_dir(start=None):
     '''
     return os.path.join(west_topdir(start), WEST_DIR)
 
+
 def manifest_dir(start=None):
     '''
     Returns the path to the manifest/ directory, searching ``start`` and its
@@ -82,6 +83,7 @@ def manifest_dir(start=None):
     Raises WestNotFound if no west directory is found.
     '''
     return os.path.join(west_topdir(start), MANIFEST)
+
 
 def west_topdir(start=None):
     '''
@@ -132,8 +134,7 @@ def init(argv):
     init_parser = argparse.ArgumentParser(
         prog='west init',
         formatter_class=argparse.RawDescriptionHelpFormatter,
-        description=
-'''
+        description='''
 Initializes a Zephyr installation. Use "west clone" afterwards to fetch the
 sources.
 
@@ -238,7 +239,7 @@ def bootstrap(args):
             ).validate()
         except pykwalify.errors.SchemaError as e:
             sys.exit("Error: Failed to parse manifest file '{}': {}"
-                      .format(manifest_file, e))
+                     .format(manifest_file, e))
 
         if 'url' in wdata:
             west_url = wdata['url']
@@ -282,7 +283,8 @@ def reinit(config_path, args):
     print('=== Updated configuration written to {} ==='.format(config_path))
 
     if args.reset:
-        cmd = ['update', '--reset-manifest', '--reset-projects', '--reset-west']
+        cmd = ['update', '--reset-manifest', '--reset-projects',
+               '--reset-west']
         print("=== Running 'west {}' to update repositories ==="
               .format(' '.join(cmd)))
         wrap(cmd)
@@ -401,7 +403,7 @@ def wrap(argv):
             print('West repository version: {} ({})'.format(git_describe,
                                                             west_git_repo))
         except subprocess.CalledProcessError:
-            print('West repository verison: unknown; no tags were found')
+            print('West repository version: unknown; no tags were found')
         sys.exit(0)
 
     # Replace the wrapper process with the "real" west

--- a/src/west/_bootstrap/version.py
+++ b/src/west/_bootstrap/version.py
@@ -2,4 +2,4 @@
 #
 # This is the Python 3 version of option 3 in:
 # https://packaging.python.org/guides/single-sourcing-package-version/#single-sourcing-the-version
-__version__ = '0.4.0'
+__version__ = '0.4.1'

--- a/src/west/main.py
+++ b/src/west/main.py
@@ -219,7 +219,7 @@ def main(argv=None):
     except WestUpdated:
         # West has been automatically updated. Restart ourselves to run the
         # latest version, with the same arguments that we were given.
-        os.execv(sys.executable, [sys.executable] + sys.argv)
+        os.execv(sys.executable, [sys.executable] + argv)
     except KeyboardInterrupt:
         sys.exit(0)
     except CalledProcessError as cpe:


### PR DESCRIPTION
This PR fixes a bug in the bootstrapper which caused 'west debug' to stop working properly.

We'll need to make a similar change to zephyr/scripts/west while we maintain that:

https://github.com/zephyrproject-rtos/zephyr/blob/master/scripts/west#L84

Because this is a bootstrapper change, we need to cut a new west release to make this available to users.

If this gets merged, I'll push a tag and update PyPI as well.