### PR TITLE
runners: jlink: Default to correct JLink executable

### DIFF
--- a/src/west/runners/jlink.py
+++ b/src/west/runners/jlink.py
@@ -6,10 +6,12 @@
 
 import os
 import tempfile
+import sys
 
 from west import log
 from west.runners.core import ZephyrBinaryRunner, RunnerCaps, BuildConfiguration
 
+DEFAULT_JLINK_EXE = 'JLink.exe' if sys.platform == 'win32' else 'JLinkExe'
 DEFAULT_JLINK_GDB_PORT = 2331
 
 
@@ -17,7 +19,7 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
     '''Runner front-end for the J-Link GDB server.'''
 
     def __init__(self, cfg, device,
-                 commander='JLinkExe',
+                 commander=DEFAULT_JLINK_EXE,
                  flash_addr=0x0, erase=True,
                  iface='swd', speed='auto',
                  gdbserver='JLinkGDBServer', gdb_port=DEFAULT_JLINK_GDB_PORT,
@@ -62,7 +64,7 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
         parser.add_argument('--gdb-port', default=DEFAULT_JLINK_GDB_PORT,
                             help='pyocd gdb port, defaults to {}'.format(
                                 DEFAULT_JLINK_GDB_PORT))
-        parser.add_argument('--commander', default='JLinkExe',
+        parser.add_argument('--commander', default=DEFAULT_JLINK_EXE,
                             help='J-Link Commander, default is JLinkExe')
         parser.add_argument('--erase', default=False, action='store_true',
                             help='if given, mass erase flash before loading')


### PR DESCRIPTION
On Microsoft Windows, the default name of the JLink executable is
"JLink.exe", while on *NIX it is instead "JLinkExe". Detect and
correctly set the default name based on the platform.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>