### PR TITLE
config.py: add missing copyright and license

### DIFF
--- a/src/west/config.py
+++ b/src/west/config.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2018, Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+
 '''
 Configuration file handling, using the standard configparser module.
 '''


### PR DESCRIPTION
Trivial cleanup based on git blame.
