### PR TITLE
Manifest in project repository

### DIFF
--- a/src/west/_bootstrap/main.py
+++ b/src/west/_bootstrap/main.py
@@ -37,13 +37,6 @@ WEST = 'west'
 WEST_URL_DEFAULT = 'https://github.com/zephyrproject-rtos/west'
 # Default revision to check out of the west repository.
 WEST_REV_DEFAULT = 'master'
-# File inside of WEST_DIR which marks it as the top level of the
-# Zephyr project installation.
-#
-# (The WEST_DIR name is not distinct enough to use when searching for
-# the top level; other directories named "west" may exist elsewhere,
-# e.g. zephyr/doc/west.)
-WEST_MARKER = '.west_topdir'
 
 # Manifest repository directory under WEST_DIR.
 MANIFEST = 'manifest'
@@ -87,7 +80,7 @@ def west_topdir(start=None):
     cur_dir = start or os.getcwd()
 
     while True:
-        if os.path.isfile(os.path.join(cur_dir, WEST_DIR, WEST_MARKER)):
+        if os.path.isdir(os.path.join(cur_dir, WEST_DIR)):
             return cur_dir
 
         parent_dir = os.path.dirname(cur_dir)
@@ -132,11 +125,9 @@ In more detail, does the following:
   1. Clones the manifest repository to a temporary folder, and the west
      repository to .west/west
 
-  2. Creates a marker file .west/{}
+  2. Creates an initial configuration file .west/config
 
-  3. Creates an initial configuration file .west/config
-
-  4. Continues the initialization process through west.main.main() with 'init'
+  3. Continues the initialization process through west.main.main() with 'init'
      as command and '--use-cache' pointing to temporary folder as parameter
 
 As an alternative to manually editing west/config, 'west init' can be rerun on
@@ -153,7 +144,7 @@ Updating the west URL or revision also runs 'west update --reset-west'.
 To suppress the reset of the manifest, west, and projects, pass --no-reset.
 With --no-reset, only the configuration file will be updated, and you will have
 to handle any resetting yourself.
-'''.format(WEST_MARKER))
+''')
 
     init_parser.add_argument(
         '-m', '--manifest-url',
@@ -248,11 +239,6 @@ def bootstrap(args):
         update_conf(config_path, manifest_url, manifest_rev)
         print('=== Initial configuration written to {} ==='
               .format(config_path))
-
-        # Create a dotfile to mark the installation. Hide it on Windows.
-
-        with open(os.path.join(directory, WEST_DIR, WEST_MARKER), 'w') as f:
-            hide_file(f.name)
 
         # Wrap west init with --cached:
         # i.e. `west init <options> --use-cache `

--- a/src/west/_bootstrap/main.py
+++ b/src/west/_bootstrap/main.py
@@ -46,7 +46,7 @@ WEST_MARKER = '.west_topdir'
 # Manifest repository directory under WEST_DIR.
 MANIFEST = 'manifest'
 # Default manifest repository URL.
-MANIFEST_URL_DEFAULT = 'https://github.com/zephyrproject-rtos/manifest'
+MANIFEST_URL_DEFAULT = 'https://github.com/zephyrproject-rtos/zephyr'
 # Default revision to check out of the manifest repository.
 MANIFEST_REV_DEFAULT = 'master'
 
@@ -73,16 +73,6 @@ def west_dir(start=None):
     Raises WestNotFound if no west directory is found.
     '''
     return os.path.join(west_topdir(start), WEST_DIR)
-
-
-def manifest_dir(start=None):
-    '''
-    Returns the path to the manifest/ directory, searching ``start`` and its
-    parents.
-
-    Raises WestNotFound if no west directory is found.
-    '''
-    return os.path.join(west_topdir(start), MANIFEST)
 
 
 def west_topdir(start=None):
@@ -149,8 +139,8 @@ explicitly passed configuration values (e.g. --mr MANIFEST_REVISION) are
 updated.
 
 Updating the manifest URL or revision via 'west init' automatically runs 'west
-update --reset-manifest --reset-projects' afterwards to reset the manifest to
-the new revision, and all projects to their new manifest revisions.
+update --reset-projects' afterwards to reset all projects to their new manifest
+revisions.
 
 Updating the west URL or revision also runs 'west update --reset-west'.
 
@@ -219,10 +209,10 @@ def bootstrap(args):
     # the west/ directory if it does not exist.
 
     clone('manifest repository', manifest_url, manifest_rev,
-          os.path.join(directory, WEST_DIR, MANIFEST))
+          os.path.join(directory, MANIFEST))
 
     # Parse the manifest and look for a section named "west"
-    manifest_file = os.path.join(directory, WEST_DIR, MANIFEST, 'west.yml')
+    manifest_file = os.path.join(directory, MANIFEST, 'west.yml')
     with open(manifest_file, 'r') as f:
         data = yaml.safe_load(f.read())
 
@@ -279,7 +269,7 @@ def reinit(config_path, args):
     print('=== Updated configuration written to {} ==='.format(config_path))
 
     if args.reset:
-        cmd = ['update', '--reset-manifest', '--reset-projects',
+        cmd = ['update', '--reset-projects',
                '--reset-west']
         print("=== Running 'west {}' to update repositories ==="
               .format(' '.join(cmd)))

--- a/src/west/_bootstrap/main.py
+++ b/src/west/_bootstrap/main.py
@@ -222,7 +222,7 @@ def bootstrap(args):
           os.path.join(directory, WEST_DIR, MANIFEST))
 
     # Parse the manifest and look for a section named "west"
-    manifest_file = os.path.join(directory, WEST_DIR, MANIFEST, 'default.yml')
+    manifest_file = os.path.join(directory, WEST_DIR, MANIFEST, 'west.yml')
     with open(manifest_file, 'r') as f:
         data = yaml.safe_load(f.read())
 

--- a/src/west/_bootstrap/main.py
+++ b/src/west/_bootstrap/main.py
@@ -28,7 +28,7 @@ if sys.version_info < (3,):
 #
 
 # Top-level west directory, containing west itself and the manifest.
-WEST_DIR = 'west'
+WEST_DIR = '.west'
 # Subdirectory to check out the west source repository into.
 WEST = 'west'
 # Default west repository URL.

--- a/src/west/commands/project.py
+++ b/src/west/commands/project.py
@@ -858,7 +858,7 @@ def _special_project(args, name):
         url = config.get(name, 'remote', fallback='origin')
         revision = config.get(name, 'revision', fallback='master')
         return SpecialProject(name, revision=revision,
-                              path=os.path.join('west', name), url=url)
+                              path=os.path.join('.west', name), url=url)
 
     return Manifest.from_file(_manifest_path(args), name).west_project
 

--- a/src/west/commands/project.py
+++ b/src/west/commands/project.py
@@ -507,7 +507,7 @@ def _arg(*args, **kwargs):
 
 _manifest_arg = _arg(
     '-m', '--manifest',
-    help='path to manifest file (default: west/manifest/default.yml)')
+    help='path to manifest file (default: west/manifest/west.yml)')
 
 # For 'fetch' and 'pull'
 _no_update_arg = _arg(
@@ -677,7 +677,7 @@ def _all_projects(args):
 
 def _manifest_path(args):
     # Returns the path to the manifest file. Defaults to
-    # .west/manifest/default.yml if the user didn't specify a manifest.
+    # .west/manifest/west.yml if the user didn't specify a manifest.
 
     return args.manifest or default_path()
 

--- a/src/west/config.py
+++ b/src/west/config.py
@@ -46,7 +46,7 @@ def read_config():
 
     Instance-specific:
 
-        <West base directory>/west/config
+        <West base directory>/.west/config
 
     Configuration values from later configuration files override configuration
     from earlier ones. Instance-specific configuration values have the highest
@@ -82,7 +82,6 @@ def read_config():
     #
     # Parse all existing configuration files
     #
-
     config.read(files, encoding='utf-8')
 
 

--- a/src/west/main.py
+++ b/src/west/main.py
@@ -22,8 +22,8 @@ from west.commands.build import Build
 from west.commands.flash import Flash
 from west.commands.debug import Debug, DebugServer, Attach
 from west.commands.project import List, Clone, Fetch, Pull, Rebase, Branch, \
-                                  Checkout, Diff, Status, Update, ForAll, \
-                                  WestUpdated
+                             Checkout, Diff, Status, Update, ForAll, \
+                             WestUpdated, Init
 from west.manifest import Manifest
 from west.util import quote_sh_list, in_multirepo_install, west_dir
 
@@ -38,6 +38,7 @@ BUILD_FLASH_COMMANDS = [
 ]
 
 PROJECT_COMMANDS = [
+    Init(),
     List(),
     Clone(),
     Fetch(),

--- a/src/west/main.py
+++ b/src/west/main.py
@@ -207,13 +207,13 @@ def main(argv=None):
     # stdout/stderr isn't a terminal
     colorama.init()
 
-    if argv is None:
-        argv = sys.argv[1:]
-    args, unknown = parse_args(argv)
-
     if IN_MULTIREPO_INSTALL:
         # Read the configuration files
         config.read_config()
+
+    if argv is None:
+        argv = sys.argv[1:]
+    args, unknown = parse_args(argv)
 
     for_stack_trace = 'run as "west -v ... {} ..." for a stack trace'.format(
         args.command)

--- a/src/west/main.py
+++ b/src/west/main.py
@@ -24,7 +24,7 @@ from west.commands.debug import Debug, DebugServer, Attach
 from west.commands.project import List, Clone, Fetch, Pull, Rebase, Branch, \
                              Checkout, Diff, Status, Update, ForAll, \
                              WestUpdated, Init
-from west.manifest import Manifest
+from west.manifest import Manifest, MalformedConfig
 from west.util import quote_sh_list, in_multirepo_install, west_dir
 
 IN_MULTIREPO_INSTALL = in_multirepo_install(os.path.dirname(__file__))
@@ -88,7 +88,11 @@ def set_zephyr_base(args):
         # At some point, we need a more flexible way to set environment
         # variables based on manifest contents, but this is good enough
         # to get started with and to ask for wider testing.
-        manifest = Manifest.from_file()
+        try:
+            manifest = Manifest.from_file()
+        except MalformedConfig as e:
+            log.die('Parsing of manifest file failed during command',
+                    args.command, ':', *e.args)
         for project in manifest.projects:
             if project.path == 'zephyr':
                 zb = project.abspath

--- a/src/west/manifest-schema.yml
+++ b/src/west/manifest-schema.yml
@@ -130,3 +130,28 @@ mapping:
           clone-depth:
             required: false
             type: int
+
+  # The "self" key specifies values for the project containing the manifest
+  # file.
+  #
+  # The path key specifies the local directory to clone this repository into,
+  # in the same way projects can specify their paths. For example, the
+  # following would cause the manifest repository to be checked out into local
+  # path "project-path":
+  #
+  # Example:
+  #
+  #   self:
+  #     path: project-path
+  #
+  # If the path key is missing, the basename of the path component in the
+  # manifest repository URL will be used by default.
+  # For example, if the URL is https://example.com/project-repo, the
+  # manifest repository would be cloned to the directory "project-repo".
+  self:
+    required: false
+    type: map
+    mapping:
+      path:
+        required: false
+        type: str

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -41,7 +41,7 @@ def default_path():
     '''Return the path to the default manifest in the west directory.
 
     Raises WestNotFound if called from outside of a west working directory.'''
-    return os.path.join(util.west_dir(), 'manifest', 'default.yml')
+    return os.path.join(util.west_dir(), 'manifest', 'west.yml')
 
 
 class Manifest:

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -40,13 +40,16 @@ be used to name a project in the manifest file.'''
 MANIFEST_SECTIONS = ['manifest', 'west']
 '''Sections in the manifest file'''
 
+MANIFEST_PROJECT_INDEX = 0
+'''Index in projects where the project with contains project manifest file is
+located.'''
 
 def default_path():
     '''Return the path to the default manifest in the west directory.
 
     Raises WestNotFound if called from outside of a west working directory.'''
     return os.path.join(util.west_topdir(),
-                        config.get('manifest', 'path', fallback='manifest'),
+                        config.get('manifest', 'path'),
                         'west.yml')
 
 
@@ -144,7 +147,10 @@ class Manifest:
         projects.
 
         Each element's values are fully initialized; there is no need
-        to consult the defaults field to supply missing values.'''
+        to consult the defaults field to supply missing values.
+
+        Note: The index MANIFEST_PROJECT_INDEX in sequence will hold the
+        project which contains the project manifest file.'''
 
         self.west_project = None
         '''west.manifest.SpecialProject object representing the west meta
@@ -199,7 +205,7 @@ class Manifest:
             path = self_tag.get('path')
 
         project = SpecialProject(name, revision=revision, path=path, url=url)
-        projects.append(project)
+        projects.insert(MANIFEST_PROJECT_INDEX, project)
 
         # Map from each remote's name onto that remote's data in the manifest.
         remotes = tuple(Remote(r['name'], r['url-base']) for r in

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -171,7 +171,7 @@ class Manifest:
             self.west_project = SpecialProject('west',
                                                url=url,
                                                revision=revision,
-                                               path=os.path.join('west',
+                                               path=os.path.join('.west',
                                                                  'west'))
 
         # Next is the manifest section

--- a/src/west/util.py
+++ b/src/west/util.py
@@ -36,12 +36,12 @@ def west_dir(start=None):
 
     Raises WestNotFound if no west top-level directory is found.
     '''
-    return os.path.join(west_topdir(start), 'west')
+    return os.path.join(west_topdir(start), '.west')
 
 
 def west_topdir(start=None):
     '''
-    Like west_dir(), but returns the path to the parent directory of the west/
+    Like west_dir(), but returns the path to the parent directory of the .west/
     directory instead, where project repositories are stored
     '''
     # If you change this function, make sure to update the bootstrap
@@ -53,7 +53,7 @@ def west_topdir(start=None):
         cur_dir = start
 
     while True:
-        if os.path.isfile(os.path.join(cur_dir, 'west', '.west_topdir')):
+        if os.path.isfile(os.path.join(cur_dir, '.west', '.west_topdir')):
             return cur_dir
 
         parent_dir = os.path.dirname(cur_dir)

--- a/src/west/util.py
+++ b/src/west/util.py
@@ -53,7 +53,7 @@ def west_topdir(start=None):
         cur_dir = start
 
     while True:
-        if os.path.isfile(os.path.join(cur_dir, '.west', '.west_topdir')):
+        if os.path.isdir(os.path.join(cur_dir, '.west')):
             return cur_dir
 
         parent_dir = os.path.dirname(cur_dir)

--- a/tests/west/manifest/invalid_reserved_name_manifest.yml
+++ b/tests/west/manifest/invalid_reserved_name_manifest.yml
@@ -1,8 +1,0 @@
-manifest:
-  remotes:
-    - name: testremote
-      url-base: https://example.com
-
-  projects:
-    - name: manifest
-      remote: testremote

--- a/tests/west/project/test_project.py
+++ b/tests/west/project/test_project.py
@@ -476,24 +476,24 @@ def test_update(west_init_tmpdir):
     cmd('clone net-tools')
 
     net_tools_prev = head_subject('net-tools')
-    west_prev = head_subject('west/west')
-    manifest_prev = head_subject('west/manifest')
+    west_prev = head_subject('.west/west')
+    manifest_prev = head_subject('.west/manifest')
 
     # Add commits to the local repos. We need to reconfigure
     # explicitly as these are clones, and west doesn't handle that for
     # us.
-    for path in 'west/manifest', 'west/west', 'net-tools':
+    for path in '.west/manifest', '.west/west', 'net-tools':
         add_commit(path, 'test-update-local', reconfigure=True)
 
     # Check that resetting the manifest repository removes the local commit
     cmd('update --reset-manifest')
-    assert head_subject('west/manifest') == manifest_prev
-    assert head_subject('west/west') == 'test-update-local'  # Unaffected
+    assert head_subject('.west/manifest') == manifest_prev
+    assert head_subject('.west/west') == 'test-update-local'  # Unaffected
     assert head_subject('net-tools') == 'test-update-local'  # Unaffected
 
     # Check that resetting the west repository removes the local commit
     cmd('update --reset-west')
-    assert head_subject('west/west') == west_prev
+    assert head_subject('.west/west') == west_prev
     assert head_subject('net-tools') == 'test-update-local'  # Unaffected
 
     # Check that resetting projects removes the local commit
@@ -507,8 +507,8 @@ def test_update(west_init_tmpdir):
 
     # Check that updating the manifest repository gets the upstream commit
     cmd('update --update-manifest')
-    assert head_subject('west/manifest') == 'test-update-upstream'
-    assert head_subject('west/west') == west_prev  # Unaffected
+    assert head_subject('.west/manifest') == 'test-update-upstream'
+    assert head_subject('.west/west') == west_prev  # Unaffected
 
 
 def test_init_again(west_init_tmpdir):

--- a/tests/west/project/test_project.py
+++ b/tests/west/project/test_project.py
@@ -38,7 +38,7 @@ def repos_tmpdir(tmpdir):
     ├── west (branch: master)
     │   └── (contains this west's worktree contents)
     ├── manifest (branch: master)
-    │   └── default.yml
+    │   └── west.yml
     ├── Kconfiglib (branch: zephyr)
     │   └── kconfiglib.py
     ├── net-tools (branch: master)
@@ -51,7 +51,7 @@ def repos_tmpdir(tmpdir):
             └── bluetooth
                 └── code.c
 
-    The contents of default.yml are:
+    The contents of west.yml are:
 
     west:
       url: file://<tmpdir>/west
@@ -86,7 +86,7 @@ def repos_tmpdir(tmpdir):
 
     # Initialize the manifest repository.
     add_commit(rp['manifest'], 'test manifest',
-               files={'default.yml': textwrap.dedent('''\
+               files={'west.yml': textwrap.dedent('''\
                       west:
                         url: file://{west}
                       manifest:


### PR DESCRIPTION
This PR includes the following:

- Ability to have manifest file inside a project repository
- `self` tag introduced in manifest
- Renaming of `default.yml` to `manifest.yml`
- Folder `west` renamed to `.west`
- `west init` is now continued inside `west` repository after bootstrapper has cloned manifest repository

A branch of Zephyr with `manifest.yml` is available for testing:
https://github.com/tejlmand/zephyr/tree/manifest-branch

To test:
`west init -m https://github.com/tejlmand/zephyr --mr manifest-branch`