### PR TITLE
Extension commands

### DIFF
--- a/src/west/_bootstrap/main.py
+++ b/src/west/_bootstrap/main.py
@@ -244,13 +244,13 @@ def bootstrap(args):
         print('=== Initial configuration written to {} ==='
               .format(config_path))
 
-        # Wrap west init with --cached:
-        # i.e. `west init <options> --use-cache `
+        # Call `west post-init <options> --use-cache <tempdir>` to finish up.
+        #
         # Note: main west will try to discover zephyr base and fail, as it is
         # not fully initialized at this time.
         # Thus a dummy zephyr_base is provided.
         os.chdir(directory)
-        cmd = ['--zephyr-base', directory, 'init', '--manifest-url',
+        cmd = ['--zephyr-base', directory, 'post-init', '--manifest-url',
                manifest_url, '--manifest-rev', manifest_rev, '--use-cache',
                tempdir]
         wrap(cmd)

--- a/src/west/_bootstrap/main.py
+++ b/src/west/_bootstrap/main.py
@@ -171,7 +171,11 @@ to handle any resetting yourself.
 
     try:
         reinit(os.path.join(west_dir(args.directory), 'config'), args)
+        bootstrapping = False
     except WestNotFound:
+        bootstrapping = True
+
+    if bootstrapping:
         bootstrap(args)
 
 

--- a/src/west/commands/__init__.py
+++ b/src/west/commands/__init__.py
@@ -1,73 +1,23 @@
 # Copyright 2018 Open Source Foundries Limited.
+# Copyright 2019 Foundries.io Limited.
 #
 # SPDX-License-Identifier: Apache-2.0
 
-'''West's commands subpackage.
+'''west.commands
 
-All commands should be implemented within modules in this package.
+This provides WestCommand, which is the common abstraction all west
+command-line commands implement.
+
+All built-in west commands should be implemented in modules in this
+package. To use them, import them from the modules which contain them.
+
+west.commands also includes support for discovering external commands
+based on configuration in the manifest.
+
 '''
 
-from abc import ABC, abstractmethod
+from west.commands.command import CommandContextError, WestCommand, \
+    external_commands, WestExtCommandSpec
 
-__all__ = ['CommandContextError', 'WestCommand']
-
-
-class CommandContextError(RuntimeError):
-    '''Indicates that a context-dependent command could not be run.'''
-
-
-class WestCommand(ABC):
-    '''Abstract superclass for a west command.
-
-    All top-level commands supported by west implement this interface.'''
-
-    def __init__(self, name, help, description, accepts_unknown_args=False):
-        '''Create a command instance.
-
-        :param name: the command's name, as entered by the user
-        :param help: one-line command help text
-        :param description: multi-line command description
-
-        :param accepts_unknown_args: if true, the command can handle
-                                     arbitrary unknown command line arguments
-                                     in its run() method. Otherwise, passing
-                                     unknown arguments will cause
-                                     UnknownArgumentsError to be raised.'''
-        self.name = name
-        self.help = help
-        self.description = description
-        self._accept_unknown = accepts_unknown_args
-
-    def run(self, args, unknown):
-        '''Run the command.
-
-        :param args: known arguments parsed via `register_arguments()`
-        :param unknown: unknown arguments present on the command line '''
-        if unknown and not self._accept_unknown:
-            self.parser.error('unexpected arguments: {}'.format(unknown))
-        self.do_run(args, unknown)
-
-    def add_parser(self, parser_adder):
-        '''Registers a parser for this command, and returns it.'''
-        self.parser = self.do_add_parser(parser_adder)
-        return self.parser
-
-    #
-    # Mandatory subclass hooks
-    #
-
-    @abstractmethod
-    def do_add_parser(self, parser_adder):
-        '''Subclass method for registering command line arguments.
-
-        :param parser_adder: is an argparse argument subparsers adder.'''
-
-    @abstractmethod
-    def do_run(self, args, unknown):
-        '''Subclasses must implement; called when the command is run.
-
-        :param args: is the namespace of parsed known arguments.
-        :param unknown: If `accepts_unknown_args` was False when constructing
-                        this object, this paramter is an empty sequence.
-                        Otherwise, it is an iterable containing all unknown
-                        arguments present on the command line.'''
+__all__ = ['CommandContextError', 'WestCommand', 'external_commands',
+           'WestExtCommandSpec']

--- a/src/west/commands/__init__.py
+++ b/src/west/commands/__init__.py
@@ -21,34 +21,34 @@ class WestCommand(ABC):
 
     All top-level commands supported by west implement this interface.'''
 
-    def __init__(self, name, description, accepts_unknown_args=False):
+    def __init__(self, name, help, description, accepts_unknown_args=False):
         '''Create a command instance.
 
-        `name`: the command's name, as entered by the user.
-        `description`: one-line command description to show to the user.
+        :param name: the command's name, as entered by the user
+        :param help: one-line command help text
+        :param description: multi-line command description
 
-        `accepts_unknown_args`: if true, the command can handle
-        arbitrary unknown command line arguments in its run()
-        method. Otherwise, passing unknown arguments will cause
-        UnknownArgumentsError to be raised.
-        '''
+        :param accepts_unknown_args: if true, the command can handle
+                                     arbitrary unknown command line arguments
+                                     in its run() method. Otherwise, passing
+                                     unknown arguments will cause
+                                     UnknownArgumentsError to be raised.'''
         self.name = name
+        self.help = help
         self.description = description
         self._accept_unknown = accepts_unknown_args
 
     def run(self, args, unknown):
         '''Run the command.
 
-        `args`: known arguments parsed via `register_arguments()`
-        `unknown`: unknown arguments present on the command line
-        '''
+        :param args: known arguments parsed via `register_arguments()`
+        :param unknown: unknown arguments present on the command line '''
         if unknown and not self._accept_unknown:
             self.parser.error('unexpected arguments: {}'.format(unknown))
         self.do_run(args, unknown)
 
     def add_parser(self, parser_adder):
-        '''Registers a parser for this command, and returns it.
-        '''
+        '''Registers a parser for this command, and returns it.'''
         self.parser = self.do_add_parser(parser_adder)
         return self.parser
 
@@ -60,15 +60,14 @@ class WestCommand(ABC):
     def do_add_parser(self, parser_adder):
         '''Subclass method for registering command line arguments.
 
-        `parser_adder` is an argparse argument subparsers adder.'''
+        :param parser_adder: is an argparse argument subparsers adder.'''
 
     @abstractmethod
     def do_run(self, args, unknown):
         '''Subclasses must implement; called when the command is run.
 
-        `args` is the namespace of parsed known arguments.
-
-        If `accepts_unknown_args` was False when constructing this
-        object, `unknown` will be empty. Otherwise, it is an iterable
-        containing all unknown arguments present on the command line.
-        '''
+        :param args: is the namespace of parsed known arguments.
+        :param unknown: If `accepts_unknown_args` was False when constructing
+                        this object, this paramter is an empty sequence.
+                        Otherwise, it is an iterable containing all unknown
+                        arguments present on the command line.'''

--- a/src/west/commands/build.py
+++ b/src/west/commands/build.py
@@ -11,7 +11,7 @@ from west.build import DEFAULT_BUILD_DIR, DEFAULT_CMAKE_GENERATOR, \
     is_zephyr_build
 from west.commands import WestCommand
 
-BUILD_HELP = '''\
+BUILD_DESCRIPTION = '''\
 Convenience wrapper for building Zephyr applications.
 
 This command attempts to do what you mean when run from a Zephyr
@@ -45,7 +45,8 @@ class Build(WestCommand):
     def __init__(self):
         super(Build, self).__init__(
             'build',
-            BUILD_HELP,
+            'compile a Zephyr application',
+            BUILD_DESCRIPTION,
             accepts_unknown_args=False)
 
         self.source_dir = None
@@ -70,6 +71,7 @@ class Build(WestCommand):
     def do_add_parser(self, parser_adder):
         parser = parser_adder.add_parser(
             self.name,
+            help=self.help,
             formatter_class=argparse.RawDescriptionHelpFormatter,
             description=self.description)
 

--- a/src/west/commands/command.py
+++ b/src/west/commands/command.py
@@ -1,0 +1,297 @@
+# Copyright 2018 Open Source Foundries Limited.
+# Copyright 2019 Foundries.io Limited.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from abc import ABC, abstractmethod
+from collections import OrderedDict
+import importlib
+from keyword import iskeyword
+import os
+import sys
+
+import pykwalify
+import yaml
+
+from west.manifest import Manifest
+from west.util import escapes_directory
+
+
+class CommandContextError(RuntimeError):
+    '''Indicates that a context-dependent command could not be run.'''
+
+
+class BadExternalCommand(Exception):
+    '''Exception class indicating an external command was badly
+    defined and could not be created.'''
+
+
+class WestCommand(ABC):
+    '''Abstract superclass for a west command.
+
+    All top-level commands supported by west implement this interface.'''
+
+    def __init__(self, name, help, description, accepts_unknown_args=False):
+        '''Create a command instance.
+
+        Some of the fields in a WestCommand (such as `name`, `help`, and
+        `description`) overlap with kwargs that should be passed to the
+        argparse.ArgumentParser which should be added in the
+        `add_parser()` method. This wart is by design: argparse
+        doesn't make many API stability guarantees, so some of this
+        information must be duplicated to work reliably in the future.
+
+        :param name: the command's name, as entered by the user
+        :param help: one-line command help text
+        :param description: multi-line command description
+        :param accepts_unknown_args: if true, the command can handle
+                                     arbitrary unknown command line arguments
+                                     in its run() method. Otherwise, passing
+                                     unknown arguments will cause
+                                     UnknownArgumentsError to be raised.
+        '''
+        self.name = name
+        self.help = help
+        self.description = description
+        self._accept_unknown = accepts_unknown_args
+
+    def run(self, args, unknown):
+        '''Run the command.
+
+        This raises CommandContextError if the command cannot be run
+        due to a context mismatch. Other exceptions may be raised as
+        well.
+
+        :param args: known arguments parsed via `add_parser()`.
+        :param unknown: unknown arguments present on the command line;
+                        this must be empty if the constructor
+                        was passed accepts_unknown_args=False.
+        '''
+        if unknown and not self._accept_unknown:
+            self.parser.error('unexpected arguments: {}'.format(unknown))
+        self.do_run(args, unknown)
+
+    def add_parser(self, parser_adder):
+        '''Registers a parser for this command, and returns it.
+
+        The parser object is stored in the `parser` attribute of this
+        WestCommand.
+
+        :param parser_adder: The return value of a call to
+                             argparse.ArgumentParser.add_subparsers()
+        '''
+        self.parser = self.do_add_parser(parser_adder)
+
+        if self.parser is None:
+            raise ValueError('no parser was returned')
+
+        return self.parser
+
+    #
+    # Mandatory subclass hooks
+    #
+
+    @abstractmethod
+    def do_add_parser(self, parser_adder):
+        '''Subclass method for registering command line arguments.
+
+        This is called by WestCommand.add_parser() to do the work of
+        adding the parser itself.
+
+        The subclass should call parser_adder.add_parser() to add an
+        ArgumentParser for that subcommand, then add any
+        arguments. The final parser must be returned.
+
+        :param parser_adder: The return value of a call to
+                             argparse.ArgumentParser.add_subparsers()
+
+        '''
+
+    @abstractmethod
+    def do_run(self, args, unknown):
+        '''Subclasses must implement; called when the command is run.
+
+        :param args: is the namespace of parsed known arguments.
+        :param unknown: If `accepts_unknown_args` was False when constructing
+                        this object, this parameter is an empty sequence.
+                        Otherwise, it is an iterable containing all unknown
+                        arguments present on the command line.'''
+
+
+class WestExtCommandSpec:
+    '''An object which allows instantiating an external west command.'''
+
+    def __init__(self, name, project, factory):
+        self.name = name
+        '''Command name, as known to the user.'''
+
+        self.project = project
+        '''west.manifest.Project instance which defined the command.'''
+
+        self.factory = factory
+        '''"Factory" callable for the command.
+
+        This returns a WestCommand instance when called.
+        It may do some additional steps (like importing the definition of
+        the command) before constructing it, however.'''
+
+
+def external_commands(manifest=None):
+    '''Get descriptions of available external commands.
+
+    The return value is an ordered map from project paths to lists of
+    WestExtCommandSpec objects, for projects which define external
+    commands. The map's iteration order matches the manifest.projects
+    order.
+
+    :param manifest: a parsed `west.manifest.Manifest` object, or None
+                     to reload a new one.
+    '''
+    if manifest is None:
+        manifest = Manifest.from_file()
+
+    specs = OrderedDict()
+    for project in manifest.projects:
+        if project.west_commands:
+            specs[project.path] = _ext_specs(project)
+    return specs
+
+
+def _ext_specs(project):
+    # Get a list of WestExtCommandSpec objects for the given
+    # west.manifest.Project.
+
+    spec_file = os.path.join(project.abspath, project.west_commands)
+
+    # Verify project.west_commands isn't trying a directory traversal
+    # outside of the project.
+    if escapes_directory(spec_file, project.abspath):
+        raise BadExternalCommand(
+            'west-commands file {} escapes project path {}'.
+            format(project.west_commands, project.path))
+
+    # Load the spec file and check the schema.
+    with open(spec_file, 'r') as f:
+        try:
+            commands_spec = yaml.safe_load(f.read())
+        except yaml.YAMLError as e:
+            raise BadExternalCommand from e
+    try:
+        pykwalify.core.Core(
+            source_data=commands_spec,
+            schema_files=[_EXT_SCHEMA_PATH]).validate()
+    except pykwalify.errors.SchemaError as e:
+        raise BadExternalCommand from e
+
+    ret = []
+    for commands_desc in commands_spec['west-commands']:
+        ret.extend(_ext_specs_from_desc(project, commands_desc))
+    return ret
+
+
+def _ext_specs_from_desc(project, commands_desc):
+    py_file = os.path.join(project.abspath, commands_desc['file'])
+
+    # Verify the YAML's python file doesn't escape the project directory.
+    if escapes_directory(py_file, project.abspath):
+        raise BadExternalCommand(
+            'external command python file "{}" escapes project path {}'.
+            format(commands_desc['file'], project.path))
+
+    # Create the command thunks.
+    thunks = []
+    for command_desc in commands_desc['commands']:
+        name = command_desc['name']
+        attr = command_desc.get('class', name)
+        factory = _ExtFactory(py_file, name, attr)
+        thunks.append(WestExtCommandSpec(name, project, factory))
+
+    # Return the thunks for this project.
+    return thunks
+
+
+def _commands_module_from_file(command_name, file):
+    # Python magic for importing a module containing west extension
+    # commands. To avoid polluting the sys.modules key space, we put
+    # these modules in an (otherwise unpopulated) west.commands.ext
+    # package.
+    #
+    # The file is imported as a module named
+    # west.commands.ext.<command_name>, so the name must be a
+    # non-keyword identifier. This module object is returned from a
+    # cache if the same file is ever imported again, to avoid a double
+    # import in case the file maintains module-level state.
+    #
+    # (This shouldn't be a problem for west itself since main.py
+    # executes at most one WestCommand -- and creates at most one
+    # external command -- per process, but better safe than sorry in
+    # case this code gets called from elsewhere.)
+    #
+    # If we ever try to re-use a command_name, a ValueError() is
+    # raised; this prevents the import machinery from returning a
+    # previously cached module from sys.modules for an unrelated file,
+    # and is a decent sanity check against two providers of the same
+    # command.
+    global _EXT_MODULES_CACHE
+    mod_name = 'west.commands.ext.{}'.format(command_name)
+
+    if not command_name.isidentifier() or iskeyword(command_name):
+        raise ValueError('bad command name "{}"'.format(command_name))
+    elif mod_name in sys.modules:
+        raise ValueError('command {} is already defined'.format(
+            mod_name.rsplit('.', 1)[-1]))
+
+    file = os.path.normcase(os.path.realpath(file))
+
+    if file in _EXT_MODULES_CACHE:
+        return _EXT_MODULES_CACHE[file]
+
+    # The Python 3.4 way to import a module given its file got deprecated
+    # later on, but we still need to support 3.4. If that requirement ever
+    # gets dropped, this code can be simplified.
+    if (3, 4) <= sys.version_info < (3, 5):
+        def _import_mod_from(mod_name, file):
+            from importlib.machinery import SourceFileLoader
+            return SourceFileLoader(mod_name, file).load_module()
+    else:
+        def _import_mod_from(mod_name, file):
+            spec = importlib.util.spec_from_file_location(mod_name, file)
+            mod = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(mod)
+            return mod
+
+    mod = _import_mod_from(mod_name, file)
+    _EXT_MODULES_CACHE[file] = mod
+
+    return mod
+
+
+_EXT_SCHEMA_PATH = os.path.join(os.path.dirname(__file__),
+                                'west-commands-schema.yml')
+
+
+_EXT_MODULES_CACHE = {}
+
+
+class _ExtFactory:
+
+    def __init__(self, py_file, name, attr):
+        self.py_file = py_file
+        self.name = name
+        self.attr = attr
+
+    def __call__(self):
+        # Load the module containing the command. Convert only
+        # expected exceptions to BadExternalCommand.
+        try:
+            mod = _commands_module_from_file(self.name, self.py_file)
+        except ValueError as ve:
+            raise BadExternalCommand from ve
+        except ImportError as ie:
+            raise BadExternalCommand from ie
+
+        # Get the attribute which provides the WestCommand subclass.
+        cls = getattr(mod, self.attr)
+
+        # Create the command instance and return it.
+        return cls()

--- a/src/west/commands/debug.py
+++ b/src/west/commands/debug.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2018 Open Source Foundries Limited.
+# Copyright 2019 Foundries.io
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -16,6 +17,7 @@ class Debug(WestCommand):
     def __init__(self):
         super(Debug, self).__init__(
             'debug',
+            'flash and interactively debug a Zephyr application',
             dedent('''
             Connect to the board, program the flash, and start a
             debugging session.\n\n''') +
@@ -35,8 +37,10 @@ class DebugServer(WestCommand):
     def __init__(self):
         super(DebugServer, self).__init__(
             'debugserver',
+            'connect to board and launch a debug server',
             dedent('''
-            Connect to the board and accept debug networking connections.
+            Connect to the board and launch a debug server which accepts
+            incoming connections for debugging the connected board.
 
             The debug server binds to a known port, and allows client software
             started elsewhere to connect to it and debug the running
@@ -56,9 +60,10 @@ class Attach(WestCommand):
     def __init__(self):
         super(Attach, self).__init__(
             'attach',
+            'interactively debug a board',
             dedent('''
-            Connect to the board without programming the flash, and
-            start a debugging session.\n\n''') +
+            Like 'debug', this connects to the board and starts a debugging
+            session, but it doesn't reflash the program on the board.\n\n''') +
             desc_common('attach'),
             accepts_unknown_args=True)
 

--- a/src/west/commands/flash.py
+++ b/src/west/commands/flash.py
@@ -1,8 +1,11 @@
 # Copyright (c) 2018 Open Source Foundries Limited.
+# Copyright 2019 Foundries.io
 #
 # SPDX-License-Identifier: Apache-2.0
 
 '''west "flash" command'''
+
+from textwrap import dedent
 
 from west.commands.run_common import desc_common, add_parser_common, \
     do_run_common
@@ -14,7 +17,9 @@ class Flash(WestCommand):
     def __init__(self):
         super(Flash, self).__init__(
             'flash',
-            'Flash and run a binary on a board.\n\n' +
+            'flash and run a binary on a board',
+            dedent('''
+            Connects to the board and reprograms it with a new binary\n\n''') +
             desc_common('flash'),
             accepts_unknown_args=True)
 

--- a/src/west/commands/project.py
+++ b/src/west/commands/project.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2018, Nordic Semiconductor ASA
+# Copyright 2018, 2019 Foundries.io
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -23,15 +24,16 @@ from west.manifest import Manifest, MalformedManifest, MANIFEST_PROJECT_INDEX
 # branch.
 _MANIFEST_REV_BRANCH = 'manifest-rev'
 
-class Init(WestCommand):
+class PostInit(WestCommand):
     def __init__(self):
         super().__init__(
-            'init',
+            'post-init',
+            'finish init tasks (do not use)',
             _wrap('''
-            Initialize projects.
+            Finish initializing projects.
 
             Continue the initialization of the project containing the manifest
-            file.
+            file. You should never need to call this.
             '''))
 
     def do_add_parser(self, parser_adder):
@@ -81,6 +83,7 @@ class List(WestCommand):
     def __init__(self):
         super().__init__(
             'list',
+            'print information about projects in the west manifest',
             _wrap('''
             List projects.
 
@@ -163,6 +166,7 @@ class Clone(WestCommand):
     def __init__(self):
         super().__init__(
             'clone',
+            'clone remote projects into local installation',
             _wrap('''
             Clone projects.
 
@@ -217,6 +221,7 @@ class Fetch(WestCommand):
     def __init__(self):
         super().__init__(
             'fetch',
+            '"git fetch" changes from project remotes',
             _wrap('''
             Fetch projects.
 
@@ -244,6 +249,7 @@ class Pull(WestCommand):
     def __init__(self):
         super().__init__(
             'pull',
+            '"git pull" changes from project remotes',
             _wrap('''
             Clone/fetch and rebase projects.
 
@@ -275,6 +281,7 @@ class Rebase(WestCommand):
     def __init__(self):
         super().__init__(
             'rebase',
+            '"git rebase" local projects onto manifest versions',
             _wrap('''
             Rebase projects.
 
@@ -296,6 +303,7 @@ class Branch(WestCommand):
     def __init__(self):
         super().__init__(
             'branch',
+            'create a branch in one or more local projects',
             _wrap('''
             Create a branch or list branches, in multiple projects.
 
@@ -335,6 +343,7 @@ class Checkout(WestCommand):
     def __init__(self):
         super().__init__(
             'checkout',
+            'check out a branch in one or more local projects',
             _wrap('''
             Check out local branch.
 
@@ -385,6 +394,7 @@ class Diff(WestCommand):
     def __init__(self):
         super().__init__(
             'diff',
+            '"git diff" for one or more projects',
             _wrap('''
             'git diff' projects.
 
@@ -410,6 +420,7 @@ class Status(WestCommand):
     def __init__(self):
         super().__init__(
             'status',
+            '"git status" for one or more projects',
             _wrap('''
             Runs 'git status' for each of the specified projects (default: all
             cloned projects). Extra arguments are passed as-is to 'git status'.
@@ -429,6 +440,7 @@ class Update(WestCommand):
     def __init__(self):
         super().__init__(
             'update',
+            'update the manifest and west repositories',
             _wrap('''
             Updates the manifest repository and/or the West source code
             repository. The remote to update from is taken from the
@@ -491,6 +503,7 @@ class ForAll(WestCommand):
     def __init__(self):
         super().__init__(
             'forall',
+            'run a command in one or more local projects',
             _wrap('''
             Runs a shell (Linux) or batch (Windows) command within the
             repository of each of the specified projects (default: all cloned
@@ -551,6 +564,8 @@ def _add_parser(parser_adder, cmd, *extra_args, **kwargs):
     # Adds and returns a subparser for the project-related WestCommand 'cmd'.
     # Any defaults can be overridden with kwargs.
 
+    if 'help' not in kwargs:
+        kwargs['help'] = cmd.help
     if 'description' not in kwargs:
         kwargs['description'] = cmd.description
     if 'formatter_class' not in kwargs:

--- a/src/west/commands/run_common.py
+++ b/src/west/commands/run_common.py
@@ -27,6 +27,7 @@ def add_parser_common(parser_adder, command):
     parser = parser_adder.add_parser(
         command.name,
         formatter_class=argparse.RawDescriptionHelpFormatter,
+        help=command.help,
         description=command.description)
 
     # Remember to update scripts/west-completion.bash if you add or remove

--- a/src/west/commands/west-commands-schema.yml
+++ b/src/west/commands/west-commands-schema.yml
@@ -1,0 +1,63 @@
+## A pykwalify schema for basic validation of the structure of a west
+## commands YAML file. This allows projects managed by west to provide
+## additional commands.
+##
+## By convention, this file is named west-commands.yml.
+
+# The top-level of the file is a map with a 'west-commands:' key.  The
+# west-commands key's value is a sequence of "command descriptors".
+# Each command descriptor gives the location of a file containing west
+# commands, along with the names of the commands provided by the file
+# (and optionally the names of the classes which define them).
+#
+# Here is an example west-commands.yml file:
+#
+# west-commands:
+#   - file: foo.py
+#     commands:
+#       - name: foo1
+#       - name: foo2
+#         class: FooTwo
+#   - file: bar.py
+#     commands:
+#       - name: baz
+#
+# The meaning of the above example is:
+#
+# - the file foo.py defines commands named "foo1" and "foo2".
+#
+# - the "foo1" WestCommand implementation is just foo.foo1, but the
+#   "foo2" command class is named "FooTwo". That is, foo.py contains
+#   some code that looks like this:
+#
+#   class foo1(WestCommand):
+#       [...]
+#
+#   class FooTwo(WestCommand):
+#       [...]
+#
+# - the file bar.py contains a command named "baz", whose class is
+#   bar.baz.
+type: map
+mapping:
+  west-commands:
+    type: seq
+
+    sequence:
+      - type: map
+        mapping:
+          file:
+            required: true
+            type: str
+          commands:
+            required: true
+            type: seq
+            sequence:
+              - type: map
+                mapping:
+                  name:
+                    required: false
+                    type: str
+                  class:
+                    required: false
+                    type: str

--- a/src/west/main.py
+++ b/src/west/main.py
@@ -23,7 +23,7 @@ from west.commands.flash import Flash
 from west.commands.debug import Debug, DebugServer, Attach
 from west.commands.project import List, Clone, Fetch, Pull, Rebase, Branch, \
                              Checkout, Diff, Status, Update, ForAll, \
-                             WestUpdated, Init
+                             WestUpdated, PostInit
 from west.manifest import Manifest, MalformedConfig
 from west.util import quote_sh_list, in_multirepo_install, west_dir
 
@@ -38,7 +38,7 @@ BUILD_FLASH_COMMANDS = [
 ]
 
 PROJECT_COMMANDS = [
-    Init(),
+    PostInit(),
     List(),
     Clone(),
     Fetch(),
@@ -174,7 +174,7 @@ def parse_args(argv):
 
     west_parser.add_argument('-V', '--version', action='store_true')
 
-    subparser_gen = west_parser.add_subparsers(title='commands',
+    subparser_gen = west_parser.add_subparsers(metavar='<command>',
                                                dest='command')
 
     for command in COMMANDS:

--- a/src/west/main.py
+++ b/src/west/main.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 # Copyright 2018 Open Source Foundries Limited.
+# Copyright 2019 Foundries.io Limited.
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -11,9 +12,13 @@
 import argparse
 import colorama
 from functools import partial
+from io import StringIO
+import itertools
 import os
+import shutil
 import sys
 from subprocess import CalledProcessError, check_output, DEVNULL
+import textwrap
 
 from west import log
 from west import config
@@ -25,44 +30,214 @@ from west.commands.project import List, Clone, Fetch, Pull, Rebase, Branch, \
                              Checkout, Diff, Status, Update, ForAll, \
                              WestUpdated, PostInit
 from west.manifest import Manifest, MalformedConfig
-from west.util import quote_sh_list, in_multirepo_install, west_dir
+from west.util import quote_sh_list, in_multirepo_install
 
 IN_MULTIREPO_INSTALL = in_multirepo_install(os.path.dirname(__file__))
 
-BUILD_FLASH_COMMANDS = [
-    Build(),
-    Flash(),
-    Debug(),
-    DebugServer(),
-    Attach(),
-]
+RUNNER_COMMANDS = {
+    'building and running zephyr': [
+        Build(),
+        Flash(),
+        Debug(),
+        DebugServer(),
+        Attach()
+    ]
+}
 
-PROJECT_COMMANDS = [
-    PostInit(),
-    List(),
-    Clone(),
-    Fetch(),
-    Pull(),
-    Rebase(),
-    Branch(),
-    Checkout(),
-    Diff(),
-    Status(),
-    Update(),
-    ForAll(),
-]
+PROJECT_COMMANDS = {
+    'managing multiple repositories in the installation': [
+        List(),
+        Clone(),
+        Fetch(),
+        Pull(),
+        Rebase(),
+        Branch(),
+        Checkout(),
+        Diff(),
+        Status(),
+        Update(),
+        ForAll()
+    ]
+}
+
+# Commands we don't want to show to the user. For now, this is PostInit.
+HIDDEN_COMMANDS = {None: [PostInit()]}
 
 # Built-in commands in this West. For compatibility with monorepo
 # installations of West within the Zephyr tree, we only expose the
 # project commands if this is a multirepo installation.
-COMMANDS = BUILD_FLASH_COMMANDS
+COMMANDS = dict(RUNNER_COMMANDS)
 
 if IN_MULTIREPO_INSTALL:
-    COMMANDS += PROJECT_COMMANDS
+    COMMANDS.update(PROJECT_COMMANDS)
+    COMMANDS.update(HIDDEN_COMMANDS)
 
 
 class InvalidWestContext(RuntimeError):
     pass
+
+
+class WestHelpAction(argparse.Action):
+
+    def __init__(self, option_strings, dest, **kwargs):
+        kwargs['nargs'] = 0
+        super(WestHelpAction, self).__init__(option_strings, dest,
+                                             **kwargs)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        parser.print_help(top_level=True)
+        parser.exit()
+
+
+class WestArgumentParser(argparse.ArgumentParser):
+    # The argparse module is infuriatingly coy about its parser and
+    # help formatting APIs, marking almost everything you need to
+    # customize help output an "implementation detail". Even accessing
+    # the parser's description and epilog attributes as we do here is
+    # technically breaking the rules.
+    #
+    # Even though the implementation details have been pretty stable
+    # since the module was first introduced in Python 3.2, let's avoid
+    # possible headaches by overriding some "proper" argparse APIs
+    # here instead of monkey-patching the module or breaking
+    # abstraction barriers. This is duplicative but more future-proof.
+
+    def __init__(self, *args, **kwargs):
+        # The super constructor calls add_argument(), so this has to
+        # come first as our override of that method relies on it.
+        self.west_optionals = []
+
+        super(WestArgumentParser, self).__init__(*args, **kwargs)
+
+    def print_help(self, file=None, top_level=False):
+        print(self.format_help(top_level=top_level),
+              file=file or sys.stdout)
+
+    def format_help(self, top_level=False):
+        # When top_level is True, we override the parent method to
+        # produce more readable output, which separates commands into
+        # logical groups. In order to print optionals, we rely on the
+        # data available in our add_argument() override below.
+        #
+        # If top_level is False, it's because we're being called from
+        # one of the subcommand parsers, and we delegate to super.
+
+        if not top_level:
+            return super(WestArgumentParser, self).format_help()
+
+        # Format the help to be at most 75 columns wide, the maximum
+        # generally recommended by typographers for readability.
+        #
+        # If the terminal width (COLUMNS) is less than 75, use width
+        # (COLUMNS - 2) instead, unless that is less than 30 columns
+        # wide, which we treat as a hard minimum.
+        width = min(75, max(shutil.get_terminal_size().columns - 2, 30))
+
+        with StringIO() as sio:
+
+            def append(*strings):
+                for s in strings:
+                    print(s, file=sio)
+
+            append(self.format_usage(),
+                   self.description,
+                   '')
+
+            append('optional arguments:')
+            for wo in self.west_optionals:
+                self.format_west_optional(append, wo, width)
+
+            append('',
+                   'west commands used in various situations:')
+            for group, commands in COMMANDS.items():
+                if group is None:
+                    # Skip hidden commands.
+                    continue
+
+                append(' ' + group + ':')
+                for command in commands:
+                    self.format_command(append, command, width)
+                append('')
+
+            append(self.epilog)
+
+            return sio.getvalue()
+
+    def format_west_optional(self, append, wo, width):
+        metavar = wo['metavar']
+        options = wo['options']
+        help = wo.get('help')
+
+        # Join the various options together as a comma-separated list,
+        # with the metavar if there is one. That's our "thing".
+        if metavar is not None:
+            opt_str = '  ' + ', '.join('{} {}'.format(o, metavar)
+                                       for o in options)
+        else:
+            opt_str = '  ' + ', '.join(options)
+
+        # Delegate to the generic formatter.
+        self.format_thing_and_help(append, opt_str, help, width)
+
+    def format_command(self, append, command, width):
+        thing = '     {}:'.format(command.name)
+        self.format_thing_and_help(append, thing, command.help, width)
+
+    def format_thing_and_help(self, append, thing, help, width):
+        # Format help for some "thing" (arbitrary text) and its
+        # corresponding help text an argparse-like way.
+        help_offset = min(max(10, width - 20), 24)
+        help_indent = ' ' * help_offset
+
+        thinglen = len(thing)
+
+        if help is None:
+            # If there's no help string, just print the thing.
+            append(thing)
+        else:
+            # Reflow the lines in help to the desired with, using
+            # the help_offset as an initial indent.
+            help = ' '.join(help.split())
+            help_lines = textwrap.wrap(help, width=width,
+                                       initial_indent=help_indent,
+                                       subsequent_indent=help_indent)
+
+            if thinglen > help_offset - 1:
+                # If the "thing" (plus room for a space) is longer
+                # than the initial help offset, print it on its own
+                # line, followed by the help on subsequent lines.
+                append(thing)
+                append(*help_lines)
+            else:
+                # The "thing" is short enough that we can start
+                # printing help on the same line without overflowing
+                # the help offset, so combine the "thing" with the
+                # first line of help.
+                help_lines[0] = thing + help_lines[0][thinglen:]
+                append(*help_lines)
+
+    def add_argument(self, *args, **kwargs):
+        # Track information we want for formatting help.  The argparse
+        # module calls kwargs.pop(), so can't call super first without
+        # losing data.
+        optional = {'options': [], 'metavar': kwargs.get('metavar', None)}
+        need_metavar = (optional['metavar'] is None and
+                        kwargs.get('action') in (None, 'store'))
+        for arg in args:
+            if not arg.startswith('-'):
+                break
+            optional['options'].append(arg)
+            # If no metavar was given, the last option name is
+            # used. By convention, long options go last, so this
+            # matches the default argparse behavior.
+            if need_metavar:
+                optional['metavar'] = arg.lstrip('-').translate(
+                    {ord('-'): '_'}).upper()
+        optional['help'] = kwargs.get('help')
+        self.west_optionals.append(optional)
+
+        # Let argparse handle the actual argument.
+        super(WestArgumentParser, self).add_argument(*args, **kwargs)
 
 
 def command_handler(command, known_args, unknown_args):
@@ -156,12 +331,16 @@ def print_version_info():
 def parse_args(argv):
     # The prog='west' override avoids the absolute path of the main.py script
     # showing up when West is run via the wrapper
-    west_parser = argparse.ArgumentParser(
+    west_parser = WestArgumentParser(
         prog='west', description='The Zephyr RTOS meta-tool.',
-        epilog='Run "west <command> -h" for help on each command.')
+        epilog='Run "west <command> -h" for help on each command.',
+        add_help=False)
 
     # Remember to update scripts/west-completion.bash if you add or remove
     # flags
+
+    west_parser.add_argument('-h', '--help', action=WestHelpAction,
+                             help='show this help message and exit')
 
     west_parser.add_argument('-z', '--zephyr-base', default=None,
                              help='''Override the Zephyr base directory. The
@@ -172,12 +351,13 @@ def parse_args(argv):
                              help='''Display verbose output. May be given
                              multiple times to increase verbosity.''')
 
-    west_parser.add_argument('-V', '--version', action='store_true')
+    west_parser.add_argument('-V', '--version', action='store_true',
+                             help='print the program version and exit')
 
     subparser_gen = west_parser.add_subparsers(metavar='<command>',
                                                dest='command')
 
-    for command in COMMANDS:
+    for command in itertools.chain(*COMMANDS.values()):
         parser = command.add_parser(subparser_gen)
         parser.set_defaults(handler=partial(command_handler, command))
 
@@ -196,12 +376,7 @@ def parse_args(argv):
         set_zephyr_base(args)
 
     if 'handler' not in args:
-        if IN_MULTIREPO_INSTALL:
-            log.err('west installation found (in {}), but no command given'.
-                    format(west_dir()))
-        else:
-            log.err('no west command given')
-        west_parser.print_help(file=sys.stderr)
+        west_parser.print_help(file=sys.stderr, top_level=True)
         sys.exit(1)
 
     return args, unknown

--- a/src/west/manifest-schema.yml
+++ b/src/west/manifest-schema.yml
@@ -91,6 +91,11 @@ mapping:
   # - clone-depth: if given, it is a number which creates a shallow
   #   history in the cloned repository limited to the given number
   #   of commits.
+  # - west-commands: if given, it is a relative path to a YAML file
+  #   within the project which describes additional west commands
+  #   provided by that project. See west-commands-schema.yml for
+  #   details on the format. By convention, this file should be named
+  #   west-commands.yml.
   #
   # Example, using default and non-default remotes:
   #
@@ -130,9 +135,12 @@ mapping:
           clone-depth:
             required: false
             type: int
+          west-commands:
+            required: false
+            type: str
 
   # The "self" key specifies values for the project containing the manifest
-  # file.
+  # file (the "manifest repository").
   #
   # The path key specifies the local directory to clone this repository into,
   # in the same way projects can specify their paths. For example, the
@@ -153,5 +161,10 @@ mapping:
     type: map
     mapping:
       path:
+        required: false
+        type: str
+      # The manifest repository may also contain additional west
+      # commands. See the above comment for details.
+      west-commands:
         required: false
         type: str

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -41,8 +41,8 @@ MANIFEST_PROJECT_INDEX = 0
 '''Index in projects where the project with contains project manifest file is
 located.'''
 
-def default_path():
-    '''Return the path to the default manifest in the west directory.
+def manifest_path():
+    '''Return the path to the manifest file.
 
     Raises WestNotFound if called from outside of a west working directory.'''
     try:
@@ -68,13 +68,13 @@ class Manifest:
         :param sections: Only parse specified sections from YAML file,
                          default: all sections are parsed.
 
-        If source_file is None, the value returned by default_path()
+        If source_file is None, the value returned by manifest_path()
         is used.
 
         Raises MalformedManifest in case of validation errors.
         Raises MalformedConfig in case of missing configuration settings.'''
         if source_file is None:
-            source_file = default_path()
+            source_file = manifest_path()
         return Manifest(source_file=source_file, sections=sections)
 
     @staticmethod
@@ -117,6 +117,10 @@ class Manifest:
         else:
             self._data = source_data
             path = None
+
+        for section in sections:
+            if section not in MANIFEST_SECTIONS:
+                raise ValueError('invalid section {}'.format(section))
 
         self.path = path
         '''Path to the file containing the manifest, or None if created

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -34,10 +34,6 @@ WEST_URL_DEFAULT = 'https://github.com/zephyrproject-rtos/west'
 # Default revision to check out of the west repository.
 WEST_REV_DEFAULT = 'master'
 
-META_NAMES = ['west']
-'''Names of the special "meta-projects", which are reserved and cannot
-be used to name a project in the manifest file.'''
-
 MANIFEST_SECTIONS = ['manifest', 'west']
 '''Sections in the manifest file'''
 
@@ -249,9 +245,8 @@ class Manifest:
         for mp in manifest['projects']:
             # Validate the project name.
             name = mp['name']
-            if name in META_NAMES:
-                self._malformed('the name "{}" is reserved and cannot '.
-                                format(name) +
+            if name == 'west':
+                self._malformed('the name "west" is reserved and cannot '
                                 'be used to name a manifest project')
 
             # Validate the project remote.

--- a/src/west/util.py
+++ b/src/west/util.py
@@ -6,8 +6,29 @@
 '''
 
 import os
+import pathlib
 import shlex
 import textwrap
+
+
+def escapes_directory(path, directory):
+    '''Returns True if `path` escapes parent directory `directory`.
+
+    :param path: path to check is inside `directory`
+    :param directory: parent directory to check
+
+    Verifies `path` is inside of `directory`, after computing
+    normalized real paths for both.'''
+    # It turns out not to be easy to implement this without using
+    # pathlib.
+    p = pathlib.Path(os.path.normcase(os.path.realpath(path)))
+    d = pathlib.Path(os.path.normcase(os.path.realpath(directory)))
+    try:
+        p.relative_to(d)
+        ret = False
+    except ValueError:
+        ret = True
+    return ret
 
 
 def quote_sh_list(cmd):

--- a/tests/west/manifest/invalid_west_commands_1.yml
+++ b/tests/west/manifest/invalid_west_commands_1.yml
@@ -1,0 +1,10 @@
+manifest:
+  remotes:
+    - name: testremote
+      url-base: https://example.com
+
+  projects:
+    - name: testproject
+      remote: testremote
+      west-commands:
+        this-key-is-invalid: so-is-this-value

--- a/tests/west/manifest/invalid_west_commands_2.yml
+++ b/tests/west/manifest/invalid_west_commands_2.yml
@@ -1,0 +1,10 @@
+manifest:
+  remotes:
+    - name: testremote
+      url-base: https://example.com
+
+  projects:
+    - name: testproject
+      remote: testremote
+      west-commands:
+        - this-should-be-a-string-not-a-sequence

--- a/tests/west/manifest/invalid_west_commands_3.yml
+++ b/tests/west/manifest/invalid_west_commands_3.yml
@@ -1,0 +1,10 @@
+manifest:
+  remotes:
+    - name: testremote
+      url-base: https://example.com
+
+  projects:
+    - name: testproject
+      remote: testremote
+
+  west-commands: this-is-a-per-project-attribute

--- a/tests/west/manifest/test_manifest.py
+++ b/tests/west/manifest/test_manifest.py
@@ -41,6 +41,7 @@ def deep_eq_check(actual, expected):
     assert actual.abspath == expected.abspath
     assert actual.clone_depth == expected.clone_depth
     assert actual.revision == expected.revision
+    assert actual.west_commands == expected.west_commands
 
 
 def test_no_defaults(config_file_project_setup):

--- a/tests/west/manifest/test_manifest.py
+++ b/tests/west/manifest/test_manifest.py
@@ -243,6 +243,28 @@ def test_sections():
     assert manifest.west_project.revision == 'abranch'
 
 
+def test_west_commands():
+    # Projects may specify subdirectories containing west commands.
+    content = '''\
+    manifest:
+      remotes:
+        - name: testremote
+          url-base: https://example.com
+
+      projects:
+        - name: zephyr
+          remote: testremote
+          west-commands: some-path/west-commands.yml
+    '''
+    with patch('west.util.west_topdir',
+               return_value=os.path.realpath('/west_top')):
+        # Parsing manifest only, no exception raised
+        manifest = Manifest.from_data(yaml.safe_load(content),
+                                      sections=['manifest'])
+    assert len(manifest.projects) == 2
+    assert manifest.projects[-1].west_commands == 'some-path/west-commands.yml'
+
+
 # Invalid manifests should raise MalformedManifest.
 @pytest.mark.parametrize('invalid',
                          glob(os.path.join(THIS_DIRECTORY, 'invalid_*.yml')))

--- a/tests/west/manifest/test_manifest.py
+++ b/tests/west/manifest/test_manifest.py
@@ -216,7 +216,7 @@ def test_sections():
                return_value=os.path.realpath('/west_top')):
         # Parsing manifest only, no exception raised
         manifest = Manifest.from_data(yaml.safe_load(content_wrong_west),
-                                      'manifest')
+                                      sections=['manifest'])
     assert manifest.projects[1].path == 'sub/directory'
     assert manifest.projects[1].abspath == \
         os.path.realpath('/west_top/sub/directory')
@@ -237,7 +237,7 @@ def test_sections():
                return_value=os.path.realpath('/west_top')):
         # Parsing west section only, no exception raised
         manifest = Manifest.from_data(yaml.safe_load(content_wrong_manifest),
-                                      'west')
+                                      sections=['west'])
     assert manifest.west_project.url == 'https://example.com'
     assert manifest.west_project.revision == 'abranch'
 


### PR DESCRIPTION
Add support for discovering and executing out-of-tree commands. I've also added some follow-on patches to the major changes just merged allowing arbitrary projects to contain the manifest.

I need to finish writing test cases, which no doubt means there are still a few silly bugs in addition to the one minor issue I'm aware of [1], but this passes all our existing tests plus a couple of sanity checks on my machine.

I've also verified some basic operation with the following external tests module. (Put it in manifest/test.py to test at home.)

```
from west.commands import WestCommand

TEST1_HELP = 'test one help'
TEST1_DESC = 'test one description'

TEST2_HELP = 'test two help'
TEST2_DESC = 'test two description'


class test1(WestCommand):

    def __init__(self):
        super(test1, self).__init__(
            'test1',
            TEST1_HELP,
            TEST1_DESC,
            accepts_unknown_args=True)

    def do_add_parser(self, parser_adder):
        return parser_adder.add_parser(self.name,
                                       description=self.description)

    def do_run(self, args, unknown):
        print('test1 args:', args)
        print('test1 unknown:', unknown)


class TestTwo(WestCommand):

    def __init__(self):
        super(TestTwo, self).__init__(
            'test2',
            TEST2_HELP,
            TEST2_DESC,
            accepts_unknown_args=False)

    def do_add_parser(self, parser_adder):
        return parser_adder.add_parser(self.name,
                                       description=self.description)

    def do_run(self, args, unknown):
        print('test2 args:', args)
        print('test2 unknown:', unknown)
```

Then, add this to west.yml:

```
  self:
    west-commands: west-commands.yml
```

And this in manifest/west-commands.yml:

```
west-commands:
  - file: test.py
    commands:
      - name: test1
      - name: test2
        class: TestTwo
```

You'll then see test1 and test2 in the `west -h` output, and you can do things like run `west test1 -h`.

[1] Currently, the name of any external commands are being added as the first unknown argument. I think this is due to how I ended up handling deferred argument parsing. I should have caught this earlier but I wasn't testing hard enough. Sorry about that. Will fix ASAP.