### PR TITLE
bootstrapper: Ignore errors on temp folder cleanup

### DIFF
--- a/src/west/_bootstrap/main.py
+++ b/src/west/_bootstrap/main.py
@@ -251,7 +251,7 @@ def bootstrap(args):
                tempdir]
         wrap(cmd)
     finally:
-        shutil.rmtree(tempdir)
+        shutil.rmtree(tempdir, ignore_errors=True)
 
     print('=== West initialized. Now run "west clone" in {}. ==='.
           format(directory))


### PR DESCRIPTION
A git clone of manifest repository into temporary folder on windows
will contain read-only files.

This will cause shutil.rmtree to fail and abort bootstrapping.
Current fix is to ignore such errors on windows and rely on windows
temp folder cleanup.

Signed-off-by: Torsten Rasmussen <torsten.rasmussen@nordicsemi.no>