### PR TITLE
extension_commands: Added test and allow for projects not cloned

### DIFF
--- a/src/west/commands/command.py
+++ b/src/west/commands/command.py
@@ -170,6 +170,10 @@ def _ext_specs(project):
             'west-commands file {} escapes project path {}'.
             format(project.west_commands, project.path))
 
+    # Project may not be cloned yet.
+    if not os.path.exists(spec_file):
+        return []
+
     # Load the spec file and check the schema.
     with open(spec_file, 'r') as f:
         try:


### PR DESCRIPTION
This pr rebases nicely onto PR/156

Added tests to ensure missing extension files (in case a project in
not cloned) will not cause west built-in commands to fail.

Signed-off-by: Torsten Rasmussen <torsten.rasmussen@nordicsemi.no>