### PR TITLE
bootstrap: allow bootstrapping a manifest repository using ref to a pr

### DIFF
--- a/src/west/_bootstrap/main.py
+++ b/src/west/_bootstrap/main.py
@@ -97,7 +97,26 @@ def clone(desc, url, rev, dest, exist_ok=False):
 
     print('=== Cloning {} from {}, rev. {} into {} ==='.format(desc, url, rev,
                                                                dest))
-    subprocess.check_call(('git', 'clone', '-b', rev, '--', url, dest))
+    branch = False
+    subprocess.check_call(('git', 'init', dest))
+    os.chdir(dest)
+    subprocess.check_call(('git', 'remote', 'add', 'origin', '--', url))
+    subprocess.check_call(('git', 'fetch', 'origin', '--', rev))
+
+    try:
+        # Using show-ref to determine if rev is identical to a branch
+        subprocess.check_call(('git', 'show-ref', '--', rev))
+        branch = True
+    except subprocess.CalledProcessError:
+        pass
+
+    if branch:
+        subprocess.check_call(('git', 'checkout', rev))
+    else:
+        subprocess.check_call(('git', 'checkout', 'FETCH_HEAD'))
+
+    # Fetch the rest of the ref-space, similar to git clone
+    subprocess.check_call(('git', 'fetch', '--tags', 'origin'))
 
 
 #


### PR DESCRIPTION
The current west bootstrapping does not support:
```
west init --mr pull/<pr>/head
```
as example:
```
west init --mr pull/12666/head
```
fails with error:
```
fatal: Remote branch pull/12666/head not found in upstream origin
Traceback (most recent call last):
```

this PR allows to do `west init` on a pr.


Changing `west init` into using
- git init
- git fetch
- git checkout
as this allows users to specify other refs, such as pull/<no>/head
which is not possible with git clone on github.

Signed-off-by: Torsten Rasmussen <torsten.rasmussen@nordicsemi.no>