### PR TITLE
commands: allow extension commands to provide help strings

### DIFF
--- a/src/west/commands/command.py
+++ b/src/west/commands/command.py
@@ -121,12 +121,15 @@ class WestCommand(ABC):
 class WestExtCommandSpec:
     '''An object which allows instantiating an external west command.'''
 
-    def __init__(self, name, project, factory):
+    def __init__(self, name, project, help, factory):
         self.name = name
         '''Command name, as known to the user.'''
 
         self.project = project
         '''west.manifest.Project instance which defined the command.'''
+
+        self.help = help
+        '''Help string in west-commands.yml, or a default value.'''
 
         self.factory = factory
         '''"Factory" callable for the command.
@@ -207,8 +210,12 @@ def _ext_specs_from_desc(project, commands_desc):
     for command_desc in commands_desc['commands']:
         name = command_desc['name']
         attr = command_desc.get('class', name)
+        help = command_desc.get(
+            'help',
+            '(no help provided; try "west {} -h")'.
+            format(name))
         factory = _ExtFactory(py_file, name, attr)
-        thunks.append(WestExtCommandSpec(name, project, factory))
+        thunks.append(WestExtCommandSpec(name, project, help, factory))
 
     # Return the thunks for this project.
     return thunks

--- a/src/west/commands/west-commands-schema.yml
+++ b/src/west/commands/west-commands-schema.yml
@@ -16,11 +16,14 @@
 #   - file: foo.py
 #     commands:
 #       - name: foo1
+#         help: one-line help for foo1 command in "west --help"
 #       - name: foo2
 #         class: FooTwo
+#         help: help for foo2 in "west --help"
 #   - file: bar.py
 #     commands:
 #       - name: baz
+#         help: help for baz in "west --help"
 #
 # The meaning of the above example is:
 #
@@ -38,6 +41,14 @@
 #
 # - the file bar.py contains a command named "baz", whose class is
 #   bar.baz.
+#
+# - the "help" fields are collected into the top-level help seen by
+#   the user who runs "west --help". They should match the strings in
+#   the help argument passed to WestCommand.__init__().  (This
+#   redundancy exists because extension command modules are not
+#   imported until the user specifically runs "west
+#   some-extension-command", so any help text in the python source
+#   code is not available to "west --help".)
 type: map
 mapping:
   west-commands:
@@ -59,5 +70,8 @@ mapping:
                     required: false
                     type: str
                   class:
+                    required: false
+                    type: str
+                  help:
                     required: false
                     type: str

--- a/src/west/main.py
+++ b/src/west/main.py
@@ -189,7 +189,8 @@ class WestArgumentParser(argparse.ArgumentParser):
         self.format_thing_and_help(append, thing, command.help, width)
 
     def format_external_spec(self, append, spec, width):
-        self.format_thing_and_help(append, '  ' + spec.name, None, width)
+        self.format_thing_and_help(append, '  ' + spec.name + ':',
+                                   spec.help, width)
 
     def format_thing_and_help(self, append, thing, help, width):
         # Format help for some "thing" (arbitrary text) and its
@@ -378,7 +379,7 @@ def parse_args(argv, externals):
     # showing up when West is run via the wrapper
     west_parser = WestArgumentParser(
         prog='west', description='The Zephyr RTOS meta-tool.',
-        epilog='Run "west <command> -h" for help on each command.',
+        epilog='Run "west <command> -h" for detailed help on each command.',
         add_help=False)
 
     # Remember to update scripts/west-completion.bash if you add or remove

--- a/tests/west/project/test_project.py
+++ b/tests/west/project/test_project.py
@@ -123,6 +123,7 @@ def repos_tmpdir(tmpdir):
                           commands:
                             - name: test
                               class: Test
+                              help: test-help
                       '''),
                       'scripts/test.py': textwrap.dedent('''\
                       from west.commands import WestCommand
@@ -494,12 +495,11 @@ def test_extension_command_multiproject(repos_tmpdir):
     help_text = cmd('-h')
     expected = textwrap.dedent('''\
         commands from project at "subdir/Kconfiglib":
-          kconfigtest
+          kconfigtest:          (no help provided; try "west kconfigtest -h")
 
         commands from project at "net-tools":
-          test
-
-        Run "west <command> -h" for help on each command.''')
+          test:                 test-help
+        ''')
 
     assert expected in help_text
 


### PR DESCRIPTION
For various reasons, we don't load extension command modules until the
user has requested that we run a particular extension command.

As is, this limits the "west -h" output to the extension command names
and the projects which define them, which isn't as nice as what
built-in commands get.

Allow extension commands to provide help text by extending the schema
for each command entry with an optional "help" key, and display it in
the output. If it is missing, a default is provided which recommends
just running "west $EXTENSION_COMMAND_NAME -h".

Fix the help formatting by adding a colon after each extension command
name to match the style used for built-ins while we are here.
