### PR TITLE
Misc fixes and `west update` with `--keep-descendants` and `--rebase`

### DIFF
--- a/src/west/commands/__init__.py
+++ b/src/west/commands/__init__.py
@@ -16,8 +16,9 @@ based on configuration in the manifest.
 
 '''
 
-from west.commands.command import CommandContextError, WestCommand, \
+from west.commands.command import WestCommand, \
+    CommandContextError, CommandError, \
     external_commands, WestExtCommandSpec
 
-__all__ = ['CommandContextError', 'WestCommand', 'external_commands',
-           'WestExtCommandSpec']
+__all__ = ['CommandContextError', 'CommandError', 'WestCommand',
+           'external_commands', 'WestExtCommandSpec']

--- a/src/west/commands/command.py
+++ b/src/west/commands/command.py
@@ -17,7 +17,16 @@ from west.manifest import Manifest
 from west.util import escapes_directory
 
 
-class CommandContextError(RuntimeError):
+class CommandError(RuntimeError):
+    '''Indicates that a command failed. The return code attribute
+    specifies the error code to return to the system'''
+
+    def __init__(self, returncode=1):
+        super().__init__()
+        self.returncode = returncode
+
+
+class CommandContextError(CommandError):
     '''Indicates that a context-dependent command could not be run.'''
 
 

--- a/src/west/commands/project.py
+++ b/src/west/commands/project.py
@@ -462,14 +462,11 @@ def _projects(args, listed_must_be_cloned=True, include_west=False,
                     uncloned.append(project.name)
                 break
         else:
-            # The argument is not a project name. See if it is a project
-            # (sub)path.
+            # The argument is not a project name. See if it specifies
+            # an absolute or relative path to a project.
+            proj_arg_norm = normalize(project_arg)
             for project in projects:
-                # The startswith() means we also detect subdirectories of
-                # project repositories. Giving a plain file in the repo will
-                # work here too, but that probably doesn't hurt.
-                if normalize(project_arg).startswith(
-                        normalize(project.abspath)):
+                if proj_arg_norm == normalize(project.abspath):
                     res.append(project)
                     break
             else:

--- a/src/west/commands/project.py
+++ b/src/west/commands/project.py
@@ -345,7 +345,7 @@ _no_update_arg = _arg(
     '--no-update',
     dest='update',
     action='store_false',
-    help='do not update the manifest or West before fetching project data')
+    help='do not self-update West')
 
 # List of projects
 _project_list_arg = _arg('projects', metavar='PROJECT', nargs='*')
@@ -376,12 +376,6 @@ def _wrap(s):
     paragraphs = textwrap.dedent(s[1:]).split("\n\n")
 
     return "\n\n".join(textwrap.fill(paragraph) for paragraph in paragraphs)
-
-
-_NO_UPDATE_HELP = """
-Unless --no-update is passed, the manifest and West source code repositories
-are updated prior to cloning. See the 'update' command.
-"""[1:].replace('\n', ' ')
 
 
 _MANIFEST_REV_HELP = """

--- a/src/west/main.py
+++ b/src/west/main.py
@@ -22,7 +22,7 @@ import textwrap
 
 from west import log
 from west import config
-from west.commands import CommandContextError, external_commands
+from west.commands import CommandError, CommandContextError, external_commands
 from west.commands.project import List, Diff, Status, SelfUpdate, ForAll, \
                              WestUpdated, PostInit, Update
 from west.manifest import Manifest, MalformedConfig
@@ -510,8 +510,11 @@ def main(argv=None):
         else:
             log.inf(for_stack_trace)
     except CommandContextError as cce:
-        log.die('command', args.command, 'cannot be run in this context:',
+        log.err('command', args.command, 'cannot be run in this context:',
                 *cce.args)
+        sys.exit(cce.returncode)
+    except CommandError as ce:
+        sys.exit(ce.returncode)
 
 
 if __name__ == "__main__":

--- a/tests/west/project/test_project.py
+++ b/tests/west/project/test_project.py
@@ -220,6 +220,30 @@ def test_list(west_update_tmpdir):
                 'net-tools master net-tools (cloned) None']
     assert actual.splitlines() == expected
 
+    # We should be able to find projects by absolute or relative path
+    # when outside any project. Invalid projects should error out.
+    klib_rel = os.path.join('subdir', 'Kconfiglib')
+    klib_abs = str(west_update_tmpdir.join('subdir', 'Kconfiglib'))
+
+    rel_outside = cmd('list -f "{{name}}" {}'.format(klib_rel)).strip()
+    assert rel_outside == 'Kconfiglib'
+
+    abs_outside = cmd('list -f "{{name}}" {}'.format(klib_abs)).strip()
+    assert abs_outside == 'Kconfiglib'
+
+    rel_inside = cmd('list -f "{name}" .', cwd=klib_abs).strip()
+    assert rel_inside == 'Kconfiglib'
+
+    abs_inside = cmd('list -f "{{name}}" {}'.format(klib_abs),
+                     cwd=klib_abs).strip()
+    assert abs_inside == 'Kconfiglib'
+
+    with pytest.raises(subprocess.CalledProcessError):
+        cmd('list NOT_A_PROJECT', cwd=klib_abs)
+
+    with pytest.raises(subprocess.CalledProcessError):
+        cmd('list NOT_A_PROJECT')
+
 
 def test_diff(west_init_tmpdir):
     # FIXME: Check output


### PR DESCRIPTION
This series is mostly fixes.

The last patch contains a couple of new options for `west update`:

- `--keep-descendants` (or `-k`): if a project has a local branch checked out that is a descendant of the new `manifest-rev`, don't leave my branch behind
- `--rebase` (or `-r`): if a project has a local branch checked out, rebase it onto the new `manifest-rev`

This is a first step towards generalizing this command to support common use cases.

I can split the fixes up into their own PR, but I'm hoping that these options -- since they are opt in and apply only to projects, not the manifest repository -- will be uncontroversial.