### PR TITLE
README.rst: correct URL to west documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@ This is the Zephyr RTOS meta tool, ``west``.
 
 For more information about west, see:
 
-https://docs.zephyrproject.org/latest/west/index.html
+https://docs.zephyrproject.org/latest/tools/west/index.html
 
 Installation
 ------------


### PR DESCRIPTION
URL to west doc points to non-existent page (missing tools/ in URL).