### PR TITLE
selfupdate: Fix for west selfupdate mechanism

### DIFF
--- a/src/west/main.py
+++ b/src/west/main.py
@@ -503,7 +503,7 @@ def main(argv=None):
     except WestUpdated:
         # West has been automatically updated. Restart ourselves to run the
         # latest version, with the same arguments that we were given.
-        os.execv(sys.executable, [sys.executable] + argv)
+        os.execv(sys.executable, [sys.executable] + [sys.argv[0]] + argv)
     except KeyboardInterrupt:
         sys.exit(0)
     except CalledProcessError as cpe:


### PR DESCRIPTION
Fixes: #173

This commit adds sys.argv[0] when restarting west after an update.

Signed-off-by: Torsten Rasmussen <torsten.rasmussen@nordicsemi.no>