### PR TITLE
Extension command fixes

### DIFF
--- a/src/west/commands/__init__.py
+++ b/src/west/commands/__init__.py
@@ -18,7 +18,7 @@ based on configuration in the manifest.
 
 from west.commands.command import WestCommand, \
     CommandContextError, CommandError, \
-    external_commands, WestExtCommandSpec
+    external_commands, WestExtCommandSpec, BadExternalCommand
 
 __all__ = ['CommandContextError', 'CommandError', 'WestCommand',
-           'external_commands', 'WestExtCommandSpec']
+           'external_commands', 'WestExtCommandSpec', 'BadExternalCommand']

--- a/src/west/commands/__init__.py
+++ b/src/west/commands/__init__.py
@@ -18,7 +18,7 @@ based on configuration in the manifest.
 
 from west.commands.command import WestCommand, \
     CommandContextError, CommandError, \
-    external_commands, WestExtCommandSpec, BadExternalCommand
+    external_commands, WestExtCommandSpec, ExtensionCommandError
 
 __all__ = ['CommandContextError', 'CommandError', 'WestCommand',
-           'external_commands', 'WestExtCommandSpec', 'BadExternalCommand']
+           'external_commands', 'WestExtCommandSpec', 'ExtensionCommandError']

--- a/src/west/main.py
+++ b/src/west/main.py
@@ -22,7 +22,8 @@ import textwrap
 
 from west import log
 from west import config
-from west.commands import CommandError, CommandContextError, external_commands
+from west.commands import CommandError, CommandContextError, \
+    external_commands, BadExternalCommand
 from west.commands.project import List, Diff, Status, SelfUpdate, ForAll, \
                              WestUpdated, PostInit, Update
 from west.manifest import Manifest, MalformedConfig
@@ -519,6 +520,14 @@ def main(argv=None):
         sys.exit(cce.returncode)
     except CommandError as ce:
         sys.exit(ce.returncode)
+    except BadExternalCommand:
+        log.err('external command', args.command,
+                'was improperly defined and could not be run')
+        if args.verbose:
+            raise
+        else:
+            log.inf(for_stack_trace)
+            sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
A couple of trivial fixes:

- fix the error handling when we get a BadExternalCommand exception
- remove a stupid and unnecessary restriction on the names of extension commands