### PR TITLE
[RFC][DNM] manifest: project metadata extenstion

### DIFF
--- a/src/west/commands/project.py
+++ b/src/west/commands/project.py
@@ -11,6 +11,7 @@ import os
 import shutil
 import subprocess
 import textwrap
+import yaml
 
 from west.config import config
 from west import log
@@ -91,7 +92,7 @@ class List(WestCommand):
             by default. Use --all or the name "west" to include it.'''))
 
     def do_add_parser(self, parser_adder):
-        default_fmt = '{name:14} {path:18} {revision:13} {url} {cloned}'
+        default_fmt = '{name:14} {path:18} {revision:13} {url} {cloned} {metadata}'
         return _add_parser(
             parser_adder, self,
             _arg('-a', '--all', action='store_true',
@@ -135,6 +136,12 @@ class List(WestCommand):
             if project.name == 'west' and not list_west:
                 continue
 
+            settings = None
+            if project.metadata is not None:
+                meta_file = os.path.join(project.abspath, project.metadata)
+                with open(meta_file, 'r') as f:
+                    settings = yaml.safe_load(f.read()).get('settings')
+
             # Spelling out the format keys explicitly here gives us
             # future-proofing if the internal Project representation
             # ever changes.
@@ -146,6 +153,7 @@ class List(WestCommand):
                     abspath=project.abspath,
                     revision=project.revision,
                     cloned="(cloned)" if _cloned(project) else "(not cloned)",
+                    metadata=settings or "",
                     clone_depth=project.clone_depth or "None")
             except KeyError as e:
                 # The raised KeyError seems to just put the first

--- a/src/west/manifest-schema.yml
+++ b/src/west/manifest-schema.yml
@@ -138,6 +138,9 @@ mapping:
           west-commands:
             required: false
             type: str
+          metadata:
+            required: false
+            type: text
 
   # The "self" key specifies values for the project containing the manifest
   # file (the "manifest repository").

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -260,7 +260,8 @@ class Manifest:
                               path=mp.get('path'),
                               clone_depth=mp.get('clone-depth'),
                               revision=mp.get('revision'),
-                              west_commands=mp.get('west-commands'))
+                              west_commands=mp.get('west-commands'),
+                              metadata=mp.get('metadata'))
 
             # Two projects cannot have the same path. We use absolute
             # paths to check for collisions to ensure paths are
@@ -357,10 +358,10 @@ class Project:
     Projects are neither comparable nor hashable.'''
 
     __slots__ = ('name remote url path abspath clone_depth '
-                 'revision west_commands').split()
+                 'revision west_commands metadata').split()
 
     def __init__(self, name, remote, defaults, path=None, clone_depth=None,
-                 revision=None, west_commands=None):
+                 revision=None, west_commands=None, metadata=None):
         '''Specify a Project by name, Remote, and optional information.
 
         :param name: Project's user-defined name in the manifest.
@@ -391,6 +392,7 @@ class Project:
         self.clone_depth = clone_depth
         self.revision = revision or defaults.revision
         self.west_commands = west_commands
+        self.metadata = metadata
 
     def __eq__(self, other):
         return NotImplemented
@@ -409,7 +411,7 @@ class SpecialProject(Project):
     Projects are neither comparable nor hashable.'''
 
     def __init__(self, name, path=None, revision='(not set)', url='(not set)',
-                 west_commands=None):
+                 west_commands=None, metadata=None):
         '''Specify a Special Project by name, and url, and optional information.
 
         :param name: Special Project's user-defined name in the manifest
@@ -435,6 +437,7 @@ class SpecialProject(Project):
         self.remote = None
         self.clone_depth = None
         self.west_commands = west_commands
+        self.metadata = metadata
 
 def _wrn_if_not_remote(remote):
     if not isinstance(remote, Remote):


### PR DESCRIPTION
RFC for showing principle from slack discussion.
Of course output formatting, etc. should be cleaned up.
This RFC is just to have a  prototype from where discussions can continue.

`west.yml` content
```
....
- name: <project>
  metadata: meta-test.yml
....
```
`meta-test.yml` content:
```
settings:
  - cmake: CMakeLists.txt
  - kconfig: KConfig
  - otherkey: value
```

result in `west list`
```
<project>  <sha> <url> (cloned) [{'cmake': 'CMakeLists.txt'}, {'kconfig': 'KConfig'}, {'otherkey': 'value'}]
```

Signed-off-by: Torsten Rasmussen <torsten.rasmussen@nordicsemi.no>