### PR TITLE
log: Use yellow for warnings

### DIFF
--- a/src/west/log.py
+++ b/src/west/log.py
@@ -70,7 +70,7 @@ def wrn(*args):
     '''Print a warning.'''
 
     if config.use_colors():
-        print(colorama.Fore.LIGHTRED_EX, end='', file=sys.stderr)
+        print(colorama.Fore.LIGHTYELLOW_EX, end='', file=sys.stderr)
 
     print('WARNING: ', end='', file=sys.stderr)
     print(*args, file=sys.stderr)


### PR DESCRIPTION
Red is too aggressive for warnings, switch to yellow instead.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>