### PR TITLE
West v0.5.2.

### DIFF
--- a/src/west/_bootstrap/main.py
+++ b/src/west/_bootstrap/main.py
@@ -407,10 +407,6 @@ def wrap(argv):
                   file=sys.stderr)
             print(' - Run "west init -h" for additional information.',
                   file=sys.stderr)
-            print(file=sys.stderr)
-            print('For more information, see:',
-                  'https://docs.zephyrproject.org/latest/tools/west/repo-tool.html',  # noqa: E501
-                  file=sys.stderr)
             sys.exit(1)
 
     west_git_repo = os.path.join(topdir, WEST_DIR, WEST)

--- a/src/west/_bootstrap/version.py
+++ b/src/west/_bootstrap/version.py
@@ -2,4 +2,4 @@
 #
 # This is the Python 3 version of option 3 in:
 # https://packaging.python.org/guides/single-sourcing-package-version/#single-sourcing-the-version
-__version__ = '0.5.1'
+__version__ = '0.5.2'


### PR DESCRIPTION
Cut a point release to incorporate bootstrapper fixes. We need this to get the fix for #175 into the hands of users.