### PR TITLE
init: Change west init to clone manifest repo inside .west

### DIFF
--- a/src/west/_bootstrap/main.py
+++ b/src/west/_bootstrap/main.py
@@ -13,7 +13,6 @@ import pykwalify.core
 import subprocess
 import sys
 import yaml
-import tempfile
 import shutil
 
 import west._bootstrap.version as version
@@ -285,7 +284,8 @@ def bootstrap(args):
 
     # Clone the west source code and the manifest into west/. Git will create
     # the west/ directory if it does not exist.
-    tempdir = tempfile.mkdtemp(prefix='manifest_')
+    tempdir = os.path.join(os.path.abspath(directory),
+                           WEST_DIR, 'tmp')
     try:
         clone('manifest repository', manifest_url, manifest_rev, tempdir,
               exist_ok=True)


### PR DESCRIPTION
Fixes: #186

Instead of cloning manifest repo into temp directory, which can be a
disk different from final destination, then the manifest repo is now
cloned into .west, and from there, moved to its final location.

Signed-off-by: Torsten Rasmussen <torsten.rasmussen@nordicsemi.no>