### PR TITLE
fetch: With revision as a SHA west will fetch default ref-space

### DIFF
--- a/src/west/commands/project.py
+++ b/src/west/commands/project.py
@@ -628,7 +628,8 @@ def _fetch(project):
     # --tags is required to get tags when the remote is specified as an URL.
     if _is_sha(project.revision):
         # Don't fetch a SHA directly, as server may restrict from doing so.
-        _git(project, fetch_cmd + ' --tags -- {url}')
+        _git(project, fetch_cmd + ' --tags -- {url} '
+             'refs/heads/*:refs/west/*')
         _git(project, 'update-ref {qual_manifest_rev_branch} {revision}')
     else:
         _git(project, fetch_cmd + ' --tags -- {url} {revision}')


### PR DESCRIPTION
This fixes an issue where west update could fail to checkout a SHA as
revision if that SHA was located on a branch that was not being
fetched.

This should address the issue discover by @nashif 

> playing with adding a new repo into west.yml

```
From https://github.com/zephyrproject-rtos/tinycbor
 * branch            HEAD       -> FETCH_HEAD
fatal: update_ref failed for ref 'refs/heads/manifest-rev': cannot update ref 'refs/heads/manifest-rev': trying to write ref f
FATAL ERROR: Command 'git update-ref refs/heads/manifest-rev 3ef9fedf6d4872a374a0d58f6d207ccbfee670ff' failed for tinycbor (t)
```

> I just added:

  ```projects:
    - name: net-tools
      revision: 30b7efa827b04d2e47840716b0372737fe7d6c92
    - name: tinycbor
      revision: 3ef9fedf6d4872a374a0d58f6d207ccbfee670ff```
