### PR TITLE
list: updated abspath to use PurePath.as_posix()

### DIFF
--- a/src/west/commands/project.py
+++ b/src/west/commands/project.py
@@ -121,6 +121,8 @@ class List(WestCommand):
             - path: the relative path to the project from the top level,
               as specified in the manifest where applicable
             - abspath: absolute and normalized path to the project
+            - posixpath: like abspath, but in posix style, that is, with '/'
+              as the separator character instead of '\\'
             - revision: project's manifest revision
             - cloned: "(cloned)" if the project has been cloned, "(not cloned)"
               otherwise
@@ -144,6 +146,7 @@ class List(WestCommand):
                     url=project.url,
                     path=project.path,
                     abspath=project.abspath,
+                    posixpath=project.posixpath,
                     revision=project.revision,
                     cloned="(cloned)" if _cloned(project) else "(not cloned)",
                     clone_depth=project.clone_depth or "None")

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -21,6 +21,7 @@ import os
 import configparser
 import pykwalify.core
 import yaml
+from pathlib import PurePath
 
 from west import util, log
 from west.config import config
@@ -356,7 +357,7 @@ class Project:
 
     Projects are neither comparable nor hashable.'''
 
-    __slots__ = ('name remote url path abspath clone_depth '
+    __slots__ = ('name remote url path abspath posixpath clone_depth '
                  'revision west_commands').split()
 
     def __init__(self, name, remote, defaults, path=None, clone_depth=None,
@@ -388,6 +389,7 @@ class Project:
         self.path = os.path.normpath(path or name)
         self.abspath = os.path.realpath(os.path.join(util.west_topdir(),
                                                      self.path))
+        self.posixpath = PurePath(self.abspath).as_posix()
         self.clone_depth = clone_depth
         self.revision = revision or defaults.revision
         self.west_commands = west_commands
@@ -431,6 +433,7 @@ class SpecialProject(Project):
         self.path = path or name
         self.abspath = os.path.realpath(os.path.join(util.west_topdir(),
                                                      self.path))
+        self.posixpath = PurePath(self.abspath).as_posix()
         self.revision = revision
         self.remote = None
         self.clone_depth = None


### PR DESCRIPTION
west list --format={abspath} is intended to use with Zephyr's CMake
build system. In order for CMake not escape path, such as `C:\<path>`
PurePath.as_posix() is used to ensure forward slashes when printing
abspath.

Signed-off-by: Torsten Rasmussen <torsten.rasmussen@nordicsemi.no>