### PR TITLE
West v0.5.4

### DIFF
--- a/src/west/_bootstrap/version.py
+++ b/src/west/_bootstrap/version.py
@@ -2,4 +2,4 @@
 #
 # This is the Python 3 version of option 3 in:
 # https://packaging.python.org/guides/single-sourcing-package-version/#single-sourcing-the-version
-__version__ = '0.5.3'
+__version__ = '0.5.4'


### PR DESCRIPTION
I screwed up the 0.5.3 upload to PyPI. Then I tried to delete it and
re-upload. This turns out to be impossible -- file names can't be
reused even if the package has been deleted.

So 0.5.3 is the point release that never was, unfortunately. 0.5.4
will be the same, but with a different number. Fun times / whoops.
