### PR TITLE
manifest: Serialize remote[url-base] properly

### DIFF
--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -359,14 +359,14 @@ class Remote:
         return self.name == other.name and self.url_base == other.url_base
 
     def __repr__(self):
-        return 'Remote(name={}, url_base={})'.format(repr(self.name),
+        return 'Remote(name={}, url-base={})'.format(repr(self.name),
                                                      repr(self.url_base))
 
     def as_dict(self):
         '''Return a representation of this object as a dict, as it would be
         parsed from an equivalent YAML manifest.'''
         return collections.OrderedDict(
-            ((s, getattr(self, s)) for s in self.__slots__))
+            ((s.replace('_', '-'), getattr(self, s)) for s in self.__slots__))
 
 
 class Project:

--- a/tests/west/project/test_project.py
+++ b/tests/west/project/test_project.py
@@ -266,7 +266,7 @@ def test_manifest_freeze(west_update_tmpdir):
                     '^    revision: master$',
                     '^  remotes:$',
                     '^  - name: test-local$',
-                    '^    url_base: .*$',
+                    '^    url-base: .*$',
                     '^  projects:$',
                     '^  - name: Kconfiglib$',
                     '^    remote: test-local$',


### PR DESCRIPTION
Since the python object is named url_base, this field is getting
frozen via as_dict with an underscore rather than the dash required
by the schema.

Signed-off-by: Andy Doan <andy@foundries.io>