### PR TITLE
tox: Fix .ini file on macOS

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ exclude = setup.py,.tox,build
 
 [testenv]
 deps = -rtox_deps.txt
-platform = posix: (linux|macos)
+platform = posix: (linux|darwin)
            windows: win32
 whitelist_externals =
   py.test


### PR DESCRIPTION
sys.platform returns "darwin" on macOS. Fix the .ini file so that tests
actually run on macOS.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>