### PR TITLE
init: Init will allow cloning a project when ZEPHYR_BASE is set.

### DIFF
--- a/src/west/_bootstrap/main.py
+++ b/src/west/_bootstrap/main.py
@@ -66,7 +66,7 @@ def west_dir(start=None):
 
     Raises WestNotFound if no west directory is found.
     '''
-    return os.path.join(west_topdir(start), WEST_DIR)
+    return os.path.join(west_topdir(start, False), WEST_DIR)
 
 
 def west_topdir(start=None, fall_back=True):


### PR DESCRIPTION
Fixes: #212

If ZEPHYR_BASE was set in environment, `west init` fails.
This commit ensures `west init` can still run, as long as it is
invoked outside of a west managed project tree.

Signed-off-by: Torsten Rasmussen <torsten.rasmussen@nordicsemi.no>