### PR TITLE
bootstrap: Use normpath() to avoid initializing in wrong folder

### DIFF
--- a/src/west/_bootstrap/main.py
+++ b/src/west/_bootstrap/main.py
@@ -228,7 +228,8 @@ to handle any resetting yourself.
 
 def initialize_west(args):
     '''Initialize a West installation in existing project.'''
-    manifest_dir = os.path.abspath(args.directory or os.getcwd())
+    manifest_dir = os.path.normpath(os.path.abspath(args.directory or
+                                                    os.getcwd()))
     directory = os.path.dirname(manifest_dir)
 
     manifest_file = os.path.join(manifest_dir, 'west.yml')


### PR DESCRIPTION
On Windows 10, with Python 3.7.1, the following was not working:

west init -l zephyr/
or
west init -l zephyr\

because of the trailing (back)slash being interpreted as an additional
folder and west initializing itself inside the zephyr folder instead of
doing it in the enclosing one.

By normalizing the path we avoid this issue entirely.
Note that this is actually due to a regression that was fixed:
https://bugs.python.org/issue31047

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>