### PR TITLE
main.py: fix extra newline in west --help

### DIFF
--- a/src/west/main.py
+++ b/src/west/main.py
@@ -171,7 +171,7 @@ class WestArgumentParser(argparse.ArgumentParser):
 
             append(self.epilog)
 
-            return sio.getvalue()
+            return sio.getvalue().rstrip()
 
     def format_west_optional(self, append, wo, width):
         metavar = wo['metavar']


### PR DESCRIPTION
Remove trailing whitespace from the format_help() return value. This prevents an extra blank line from appearing in the west --help output.
