### PR TITLE
zephyr base: fixed west config zephyr.base when relative

### DIFF
--- a/src/west/main.py
+++ b/src/west/main.py
@@ -30,7 +30,7 @@ from west.commands.project import List, ManifestCommand, Diff, Status, \
     SelfUpdate, ForAll, WestUpdated, PostInit, Update
 from west.commands.config import Config
 from west.manifest import Manifest, MalformedConfig
-from west.util import quote_sh_list
+from west.util import quote_sh_list, west_topdir
 
 PROJECT_COMMANDS = {
     'commands for managing multiple git repositories': [
@@ -390,6 +390,8 @@ def set_zephyr_base(args):
         zb_prefer = config.config.get('zephyr', 'base-prefer',
                                       fallback=None)
         zb_config = config.config.get('zephyr', 'base', fallback=None)
+        if zb_config is not None:
+            zb_config = os.path.join(west_topdir(), zb_config)
 
         if zb_prefer == 'env' and zb_env is not None:
             zb = zb_env
@@ -439,7 +441,7 @@ def set_zephyr_base(args):
                         'manifest project has path "zephyr"')
 
     if zb is not None:
-        os.environ['ZEPHYR_BASE'] = os.path.abspath(zb)
+        os.environ['ZEPHYR_BASE'] = zb
 
     log.dbg('ZEPHYR_BASE={} (origin: {})'.format(zb, zb_origin))
 


### PR DESCRIPTION
This commit ensures that zephyr.base will be joined with west_topdir()
when a relative path is used in west config.

The previous solution was using os.path.abspath which would give
different results depending on current location when invoking west
command.

The advantage of allowing relative path in .west/config over requiring
an absolute path, is that it allows a user to rename a project's parent
folders without having to update zephyr.base.

Fixes #231 

Signed-off-by: Torsten Rasmussen <torsten.rasmussen@nordicsemi.no>