### PR TITLE
git: git fetch now uses -f

### DIFF
--- a/src/west/_bootstrap/version.py
+++ b/src/west/_bootstrap/version.py
@@ -2,4 +2,4 @@
 #
 # This is the Python 3 version of option 3 in:
 # https://packaging.python.org/guides/single-sourcing-package-version/#single-sourcing-the-version
-__version__ = '0.5.5'
+__version__ = '0.5.6'

--- a/src/west/commands/project.py
+++ b/src/west/commands/project.py
@@ -628,10 +628,11 @@ def _fetch(project):
     # --tags is required to get tags when the remote is specified as an URL.
     if _is_sha(project.revision):
         # Don't fetch a SHA directly, as server may restrict from doing so.
-        _git(project, fetch_cmd + ' --tags -- {url} refs/heads/*:refs/west/*')
+        _git(project, fetch_cmd + ' -f --tags '
+             '-- {url} refs/heads/*:refs/west/*')
         _git(project, 'update-ref ' + QUAL_MANIFEST_REV + ' {revision}')
     else:
-        _git(project, fetch_cmd + ' --tags -- {url} {revision}')
+        _git(project, fetch_cmd + ' -f --tags -- {url} {revision}')
         _git(project,
              'update-ref ' + QUAL_MANIFEST_REV + ' FETCH_HEAD^{{commit}}')
 

--- a/tests/west/commands/conftest.py
+++ b/tests/west/commands/conftest.py
@@ -316,3 +316,8 @@ def add_commit(repo, msg, files=None, reconfigure=True):
     subprocess.check_call(
         [GIT, 'commit', '-a', '--allow-empty', '-m', msg, '--no-verify',
          '--no-gpg-sign', '--no-post-rewrite'], cwd=repo)
+
+
+def rev_parse(repo, revision):
+    out = subprocess.check_output([GIT, 'rev-parse', revision], cwd=repo)
+    return out.decode(sys.getdefaultencoding())


### PR DESCRIPTION
It has been discovered that in the event that a different remote is
added to manifest file which contains same branches but cannot be
fast forwarded into the local refs space, then a west update will fail
with the error:
 ! [rejected] <branch> -> refs/west/<branch> (non-fast-forward)

This commit fixes this issue by introducing '-f' when fetching.

This commit has additional test for verifying the fix.

Fixes: #236 

Signed-off-by: Torsten Rasmussen <torsten.rasmussen@nordicsemi.no>