### PR TITLE
West v0.5.8

### DIFF
--- a/src/west/_bootstrap/main.py
+++ b/src/west/_bootstrap/main.py
@@ -96,6 +96,18 @@ def west_topdir(start=None, fall_back=True):
         cur_dir = parent_dir
 
 
+def have_git():
+    # Windows users often end up in a situation where 'git' is
+    # installed, but not on PATH.
+    return shutil.which('git') is not None
+
+
+def ensure_git():
+    if not have_git():
+        sys.exit('Error: cannot find a git executable. '
+                 'Please install git or ensure the binary is on your PATH.')
+
+
 def _is_sha(s):
     try:
         int(s, 16)
@@ -235,6 +247,7 @@ to handle any resetting yourself.
     except WestNotFound:
         pass
 
+    ensure_git()
     if args.local:
         if args.manifest_rev is not None:
             sys.exit('west init: error: argument --mr/--manifest-rev: not '
@@ -438,6 +451,10 @@ def wrap(argv):
 
     west_git_repo = os.path.join(topdir, WEST_DIR, WEST)
     if printing_version:
+        if not have_git():
+            print('West repository version: unknown; git was not found')
+            sys.exit(0)
+
         try:
             git_describe = subprocess.check_output(
                 ['git', 'describe', '--tags'],

--- a/src/west/_bootstrap/main.py
+++ b/src/west/_bootstrap/main.py
@@ -478,7 +478,10 @@ def wrap(argv):
     # Put this at position 1 to make sure it comes before random stuff
     # that might be on a developer's PYTHONPATH in the import order.
     sys.path.insert(1, os.path.join(west_git_repo, 'src'))
-    import west.main
+    try:
+        import west.main
+    except ImportError:
+        sys.exit('Error: no west.main in ' + west_git_repo)
     west.main.main(argv)
 
 

--- a/src/west/_bootstrap/version.py
+++ b/src/west/_bootstrap/version.py
@@ -2,4 +2,4 @@
 #
 # This is the Python 3 version of option 3 in:
 # https://packaging.python.org/guides/single-sourcing-package-version/#single-sourcing-the-version
-__version__ = '0.5.7'
+__version__ = '0.5.8'


### PR DESCRIPTION
Two bootstrapper fixes:

- check for git with shutil and print a sensible message if it's not found and is needed
- print a better error message if west.main can't be imported

