### PR TITLE
Non zephyr projects

### DIFF
--- a/src/west/main.py
+++ b/src/west/main.py
@@ -389,7 +389,8 @@ class WestApp:
         #   (controversial)
         # - make zephyr extensions that need ZEPHYR_BASE just set it
         #   themselves (easy if above is OK, unnecessary if it isn't)
-        set_zephyr_base(args, self.manifest, self.topdir)
+        if not config.config.getboolean("zephyr", "disabled", fallback=False):
+            set_zephyr_base(args, self.manifest, self.topdir)
 
         command.run(args, unknown, self.topdir, manifest=self.manifest)
 

--- a/src/west/manifest-schema.yml
+++ b/src/west/manifest-schema.yml
@@ -127,3 +127,8 @@ mapping:
       import:
         required: false
         type: any
+
+  configs:
+    required: false
+    type: map
+    allowempty: true

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -375,6 +375,9 @@ class Manifest:
 
         self.has_imports = False
 
+        self.configs = None
+        '''Map with default configuration values.'''
+
         # Set up the public attributes documented above, as well as
         # any internal attributes needed to implement the public API.
         self._importer = importer or _default_importer
@@ -473,6 +476,7 @@ class Manifest:
         r['manifest'] = collections.OrderedDict()
         r['manifest']['projects'] = frozen_projects
         r['manifest']['self'] = self.projects[MANIFEST_PROJECT_INDEX].as_dict()
+        r['manifest']['configs'] = self.configs
 
         return r
 
@@ -532,6 +536,8 @@ class Manifest:
                     # can have a topdir but no path, and thus no abspath.
                     continue
                 self._projects_by_cpath[util.canon_path(p.abspath)] = p
+
+        self.configs = manifest.get('configs', dict())
 
     def _load_self(self, manifest, path_hint, projects):
         # Handle the "self:" section in the manifest data.


### PR DESCRIPTION
With west you got quite a genius tool and zephyr shouldn't be the only use-case.
this adds support for setting config default values in the manifest and adds the `zephyr.disabled` config to make this possible.

fixes #246