### PR TITLE
manifest: error if self.path doesn't match directory name

### DIFF
--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -220,6 +220,15 @@ class Manifest:
         self_tag = manifest.get('self')
         if path is None:
             path = self_tag.get('path') if self_tag else ''
+
+        # Both are named "self.path" depending on where you look at.
+        if path and self.path:
+            realpath = os.path.dirname(self.path)
+            realdir = os.path.basename(realpath)
+            if realdir not in [os.path.basename(path), 'manifest-tmp']:
+                raise MalformedManifest("""Manifest self.path is '{}' \
+but located in directory '{}'""".format(path, realpath))
+
         west_commands = self_tag.get('west-commands') if self_tag else None
 
         project = ManifestProject(path=path, west_commands=west_commands)

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -21,7 +21,7 @@ def config_file_project_setup(tmpdir):
     tmpdir.join('.west/.west_topdir').ensure()
     tmpdir.join('.west/config').write('''
 [manifest]
-path = manifestproject
+path = manifests
 ''')
 
     # Switch to the top-level West installation directory
@@ -128,7 +128,7 @@ def test_no_defaults(config_file_project_setup):
     with patch('west.util.west_topdir', return_value='/west_top'):
         manifest = Manifest.from_data(yaml.safe_load(content))
 
-        expected = [ManifestProject(path='manifestproject'),
+        expected = [ManifestProject(path='manifests'),
                     Project('testproject1', None, path='testproject1',
                             clone_depth=None, revision='rev1', remote=r1),
                     Project('testproject2', None, path='testproject2',
@@ -161,7 +161,7 @@ def test_self_tag(project_setup):
           remote: testremote2
 
       self:
-        path: mainproject
+        path: manifests
     '''
     r1 = Remote('testremote1', 'https://example1.com')
     r2 = Remote('testremote2', 'https://example2.com')
@@ -169,7 +169,7 @@ def test_self_tag(project_setup):
     with patch('west.util.west_topdir', return_value='/west_top'):
         manifest = Manifest.from_data(yaml.safe_load(content))
 
-        expected = [ManifestProject(path='mainproject'),
+        expected = [ManifestProject(path='manifests'),
                     Project('testproject1', None, path='testproject1',
                             clone_depth=None, revision='rev1', remote=r1),
                     Project('testproject2', None, path='testproject2',
@@ -212,7 +212,7 @@ def test_default_clone_depth(config_file_project_setup):
     with patch('west.util.west_topdir', return_value='/west_top'):
         manifest = Manifest.from_data(yaml.safe_load(content))
 
-        expected = [ManifestProject(path='manifestproject'),
+        expected = [ManifestProject(path='manifests'),
                     Project('testproject1', d, path='testproject1',
                             clone_depth=None, revision=d.revision, remote=r1),
                     Project('testproject2', d, path='testproject2',


### PR DESCRIPTION
As an example, the "Clone the Zephyr Repositories" section of Zephyr's
Getting Started Guide provides the following command to wrap a west
installation around an already cloned, standalone zephyr repository:

  west init -l zephyr/

It feels natural to use the same command with some alternative
zephyr-blue/ or zephyr-red/ directory name, however that's not
compatible with the zephyr-blue/west.wml manifest which has its
self.path hardcoded to "zephyr". Hardcoding self.path is not a issue,
the problem is that the inconsistency is not caught and west pretends
the init command was successful. It's then much more difficult to
understand later why the build fails to find some file(s).

Implement a sanity check which make west init "fail fast" like this:

  FATAL ERROR: Manifest self.path is 'zephyr' but located in \
               directory '/home/marc/work/zephyr-blue'

Fixes #267

Signed-off-by: Marc Herbert <marc.herbert@intel.com>