### PR TITLE
commands: trivial west list error handling fix

### DIFF
--- a/src/west/commands/project.py
+++ b/src/west/commands/project.py
@@ -304,6 +304,9 @@ class List(WestCommand):
                 # how many unrecognizable keys there were.
                 log.die('unknown key "{}" in format string "{}"'.
                         format(e.args[0], args.format))
+            except IndexError:
+                self.parser.print_usage()
+                log.die('invalid format string', args.format)
 
             log.inf(result, colorize=False)  # don't use _msg()!
 


### PR DESCRIPTION
format() throws IndexError on some invalid format strings. Handle that
rather than dumping stack.
