### PR TITLE
Flesh out west config command and west.configuration API

### DIFF
--- a/src/west/commands/command.py
+++ b/src/west/commands/command.py
@@ -45,7 +45,8 @@ class ExtensionCommandError(CommandError):
         super(ExtensionCommandError, self).__init__(**kwargs)
 
 
-_NO_TOPDIR_MSG_FMT = '''Error: "{}" is not in a west installation.
+_NO_TOPDIR_MSG_FMT = '''\
+no west installation found from "{}"; "west {}" requires one.
 Things to try:
  - Set ZEPHYR_BASE to a zephyr repository path in a west installation.
  - Run "west init" to set up an installation here.
@@ -106,7 +107,7 @@ class WestCommand(ABC):
         if unknown and not self._accept_unknown:
             self.parser.error('unexpected arguments: {}'.format(unknown))
         if not topdir and self.requires_installation:
-            log.die(_NO_TOPDIR_MSG_FMT.format(os.getcwd()))
+            log.die(_NO_TOPDIR_MSG_FMT.format(os.getcwd(), self.name))
         self.topdir = topdir
         self.do_run(args, unknown)
 

--- a/src/west/commands/config.py
+++ b/src/west/commands/config.py
@@ -10,7 +10,7 @@ import configparser
 from west import log
 from west import configuration
 from west.configuration import ConfigFile
-from west.commands import WestCommand
+from west.commands import WestCommand, CommandError
 
 CONFIG_DESCRIPTION = '''\
 West configuration file handling.
@@ -125,6 +125,9 @@ class Config(WestCommand):
             value = config_settings.get(section, key, fallback=None)
             if value is not None:
                 log.inf(value)
+            else:
+                log.dbg('{} is unset'.format(args.name))
+                raise CommandError(returncode=1)
         else:
             if configfile == ConfigFile.ALL:
                 # No file given, thus writing defaults to LOCAL

--- a/src/west/commands/config.py
+++ b/src/west/commands/config.py
@@ -37,6 +37,9 @@ Local files:
 
 - Linux, macOS, Windows: <installation-root-directory>/.west/config
 
+You can override these files' locations with the WEST_CONFIG_SYSTEM,
+WEST_CONFIG_GLOBAL, and WEST_CONFIG_LOCAL environment variables.
+
 Configuration values from later configuration files override configuration
 from earlier ones. Local values have highest precedence, and system values
 lowest.

--- a/src/west/commands/config.py
+++ b/src/west/commands/config.py
@@ -121,4 +121,11 @@ class Config(WestCommand):
             if configfile == ConfigFile.ALL:
                 # No file given, thus writing defaults to LOCAL
                 configfile = ConfigFile.LOCAL
-            configuration.update_config(section, key, args.value, configfile)
+            try:
+                configuration.update_config(section, key, args.value,
+                                            configfile)
+            except PermissionError as pe:
+                log.die("can't set {}.{}: permission denied when writing {}{}".
+                        format(section, key, pe.filename,
+                               ('; are you root/administrator?'
+                                if configfile == ConfigFile.SYSTEM else '')))

--- a/src/west/configuration.py
+++ b/src/west/configuration.py
@@ -27,6 +27,9 @@ Local files:
 
 - Linux, macOS, Windows: ``<installation-root-directory>/.west/config``
 
+You can override these files' locations with the ``WEST_CONFIG_SYSTEM``,
+``WEST_CONFIG_GLOBAL``, and ``WEST_CONFIG_LOCAL`` environment variables.
+
 Configuration values from later configuration files override configuration
 from earlier ones. Local values have highest precedence, and system values
 lowest.
@@ -142,6 +145,9 @@ def _location(cfg):
     if cfg == ConfigFile.ALL:
         raise ValueError('ConfigFile.ALL has no location')
     elif cfg == ConfigFile.SYSTEM:
+        if 'WEST_CONFIG_SYSTEM' in os.environ:
+            return os.environ['WEST_CONFIG_SYSTEM']
+
         plat = platform.system()
         if plat == 'Linux':
             return '/etc/westconfig'
@@ -154,14 +160,19 @@ def _location(cfg):
         else:
             raise ValueError('unsupported platform ' + plat)
     elif cfg == ConfigFile.GLOBAL:
-        if platform.system() == 'Linux' and 'XDG_CONFIG_HOME' in env:
+        if 'WEST_CONFIG_GLOBAL' in os.environ:
+            return os.environ['WEST_CONFIG_GLOBAL']
+        elif platform.system() == 'Linux' and 'XDG_CONFIG_HOME' in env:
             return os.path.join(env['XDG_CONFIG_HOME'], 'west', 'config')
         else:
             return canon_path(
                 os.path.join(os.path.expanduser('~'), '.westconfig'))
     elif cfg == ConfigFile.LOCAL:
-        # Might raise WestNotFound!
-        return os.path.join(west_dir(), 'config')
+        if 'WEST_CONFIG_LOCAL' in os.environ:
+            return os.environ['WEST_CONFIG_LOCAL']
+        else:
+            # Might raise WestNotFound!
+            return os.path.join(west_dir(), 'config')
     else:
         raise ValueError('invalid configuration file {}'.format(cfg))
 

--- a/src/west/configuration.py
+++ b/src/west/configuration.py
@@ -246,8 +246,3 @@ def _ensure_config(configfile):
 
     path.touch(exist_ok=True)
     return canon_path(str(path))
-
-
-def use_colors():
-    # Convenience function for reading the color.ui setting
-    return config.getboolean('color', 'ui', fallback=True)

--- a/src/west/configuration.py
+++ b/src/west/configuration.py
@@ -40,13 +40,8 @@ import os
 import pathlib
 import platform
 from enum import Enum
-try:
-    # Try to import configobj.
-    # If not available we fallback to simple configparser
-    import configobj
-    use_configobj = True
-except ImportError:
-    use_configobj = False
+
+import configobj
 
 from west.util import west_dir, WestNotFound, canon_path
 
@@ -117,22 +112,11 @@ def update_config(section, key, value, configfile=ConfigFile.LOCAL):
         raise ValueError('invalid configfile: {}'.format(configfile))
 
     filename = _ensure_config(configfile)
-
-    if use_configobj:
-        updater = configobj.ConfigObj(filename)
-    else:
-        updater = configparser.ConfigParser()
-        read_config(configfile, updater)
-
+    updater = configobj.ConfigObj(filename)
     if section not in updater:
         updater[section] = {}
     updater[section][key] = value
-
-    if use_configobj:
-        updater.write()
-    else:
-        with open(filename, 'w') as f:
-            updater.write(f)
+    updater.write()
 
 def _location(cfg):
     # Making this a function that gets called each time you ask for a

--- a/src/west/log.py
+++ b/src/west/log.py
@@ -57,7 +57,7 @@ def inf(*args, colorize=False):
                      the message is printed in green.
     '''
 
-    if not config.use_colors():
+    if not _use_colors():
         colorize = False
 
     # This approach colorizes any sep= and end= text too, as expected.
@@ -83,13 +83,13 @@ def wrn(*args):
     If this is True, the configuration option ``color.ui`` is undefined or
     true, and stdout is a terminal, then the message is printed in yellow.'''
 
-    if config.use_colors():
+    if _use_colors():
         print(colorama.Fore.LIGHTYELLOW_EX, end='', file=sys.stderr)
 
     print('WARNING: ', end='', file=sys.stderr)
     print(*args, file=sys.stderr)
 
-    if config.use_colors():
+    if _use_colors():
         _reset_colors(sys.stderr)
 
 
@@ -105,13 +105,13 @@ def err(*args, fatal=False):
     If this is True, the configuration option ``color.ui`` is undefined or
     true, and stdout is a terminal, then the message is printed in red.'''
 
-    if config.use_colors():
+    if _use_colors():
         print(colorama.Fore.LIGHTRED_EX, end='', file=sys.stderr)
 
     print('FATAL ERROR: ' if fatal else 'ERROR: ', end='', file=sys.stderr)
     print(*args, file=sys.stderr)
 
-    if config.use_colors():
+    if _use_colors():
         _reset_colors(sys.stderr)
 
 
@@ -125,6 +125,23 @@ def die(*args, exit_code=1):
     abort.'''
     err(*args, fatal=True)
     sys.exit(exit_code)
+
+
+_COLOR_UI_WARNED = False
+
+def _use_colors():
+    # Convenience function for reading the color.ui setting
+    try:
+        return config.config.getboolean('color', 'ui', fallback=True)
+    except ValueError as e:
+        global _COLOR_UI_WARNED
+        if not _COLOR_UI_WARNED:
+            print("WARNING: invalid color.ui value: {}.".format(e),
+                  file=sys.stderr)
+            print('         To fix, run: "west config color.ui <true|false>"',
+                  file=sys.stderr)
+            _COLOR_UI_WARNED = True
+        return False
 
 
 def _reset_colors(file):

--- a/src/west/main.py
+++ b/src/west/main.py
@@ -427,24 +427,26 @@ def set_zephyr_base(args):
             # 'zephyr' for fallback.
             try:
                 manifest = Manifest.from_file()
+                for project in manifest.projects:
+                    if project.path == 'zephyr':
+                        zb = project.abspath
+                        zb_origin = 'manifest file {}'.format(manifest.path)
+                        break
+                else:
+                    log.err('no --zephyr-base given, ZEPHYR_BASE is unset,',
+                            'west config contains no zephyr.base setting,',
+                            'and no manifest project has path "zephyr"')
             except MalformedConfig as e:
-                log.die('Parsing of manifest file failed during command',
+                log.wrn("Can't set ZEPHYR_BASE:",
+                        'parsing of manifest file failed during command',
                         args.command, ':', *e.args)
-            for project in manifest.projects:
-                if project.path == 'zephyr':
-                    zb = project.abspath
-                    zb_origin = 'manifest file {}'.format(manifest.path)
-                    break
-
-            if zb_origin is None:
-                log.err('no --zephyr-base given, ZEPHYR_BASE is unset,',
-                        'west config contains no zephyr.base setting, and no',
-                        'manifest project has path "zephyr"')
+            except WestNotFound:
+                log.wrn("Can't set ZEPHYR_BASE:",
+                        'not currently in a west installation')
 
     if zb is not None:
         os.environ['ZEPHYR_BASE'] = zb
-
-    log.dbg('ZEPHYR_BASE={} (origin: {})'.format(zb, zb_origin))
+        log.dbg('ZEPHYR_BASE={} (origin: {})'.format(zb, zb_origin))
 
 
 def parse_args(argv, extensions, topdir):

--- a/src/west/util.py
+++ b/src/west/util.py
@@ -92,13 +92,13 @@ class WestNotFound(RuntimeError):
 
 
 def west_dir(start=None):
-    '''Returns the absolute path of the west/ top level directory.
+    '''Returns the absolute path of the installation's .west directory.
 
     Starts the search from the start directory, and goes to its
     parents. If the start directory is not specified, the current
     directory is used.
 
-    Raises WestNotFound if no west top-level directory is found.
+    Raises WestNotFound if no .west directory is found.
     '''
     return os.path.join(west_topdir(start), '.west')
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2019, Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import os
 import platform
 import shlex

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -97,7 +97,7 @@ def _session_repos():
 
 @pytest.fixture
 def repos_tmpdir(tmpdir, _session_repos):
-    '''Fixture for tmpdir with "remote" repositories, manifest, and west.
+    '''Fixture for tmpdir with "remote" repositories.
 
     These can then be used to bootstrap an installation and run
     project-related commands on it with predictable results.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -193,7 +193,7 @@ def check_output(*args, **kwargs):
         raise
     return out_bytes.decode(sys.getdefaultencoding())
 
-def cmd(cmd, cwd=None, stderr=None):
+def cmd(cmd, cwd=None, stderr=None, env=None):
     # Run a west command in a directory (cwd defaults to os.getcwd()).
     #
     # This helper takes the command as a string.
@@ -209,8 +209,16 @@ def cmd(cmd, cwd=None, stderr=None):
     if platform.system() != 'Windows':
         cmd = shlex.split(cmd)
     print('running:', cmd)
+    if env:
+        print('with non-default environment:')
+        for k in env:
+            if k not in os.environ or env[k] != os.environ[k]:
+                print('\t{}={}'.format(k, env[k]))
+        for k in os.environ:
+            if k not in env:
+                print('\t{}: deleted, was: {}'.format(k, os.environ[k]))
     try:
-        return check_output(cmd, cwd=cwd, stderr=stderr)
+        return check_output(cmd, cwd=cwd, stderr=stderr, env=env)
     except subprocess.CalledProcessError:
         print('cmd: west:', shutil.which('west'), file=sys.stderr)
         raise

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,10 +13,13 @@
 #
 
 import os
-import pytest
 import subprocess
+
+import pytest
+
 from west import configuration as config
 from west.util import canon_path
+
 from conftest import cmd
 
 
@@ -59,7 +62,6 @@ def test_config_global(west_init_tmpdir):
     # one set) should be returned.
     testkey_value = cmd('config pytest.testkey_global')
     assert testkey_value.rstrip() == 'foo'
-
 
 def test_config_local(west_init_tmpdir):
     if not os.path.exists(os.path.expanduser('~')):
@@ -105,13 +107,12 @@ def test_config_local(west_init_tmpdir):
     testkey_value = cmd('config pytest.testkey_local')
     assert testkey_value.rstrip() == 'foo2'
 
-
 # We skip this test if executed directly using pytest, to avoid modifying
 # user's real ~/.westconfig.
 # We want to ensure HOME is pointing inside TOX temp dir before continuing.
 @pytest.mark.skipif(os.environ.get('TOXTEMPDIR') is None,
                     reason="This test requires to be executed using tox")
-def test_config_precendence(west_init_tmpdir):
+def test_config_precedence(west_init_tmpdir):
     if not os.path.exists(os.path.expanduser('~')):
         os.mkdir(os.path.expanduser('~'))
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -44,11 +44,12 @@ def config_tmpdir(tmpdir):
     assert 'TOXTEMPDIR' in os.environ, 'you must run tests using tox'
     toxtmp = os.environ['TOXTEMPDIR']
     toxhome = canon_path(os.path.join(toxtmp, 'pytest-home'))
+    global_loc = canon_path(config._location(GLOBAL))
     assert canon_path(os.path.expanduser('~')) == toxhome
-    assert canon_path(GLOBAL.value) == os.path.join(toxhome, '.westconfig')
+    assert global_loc == os.path.join(toxhome, '.westconfig')
     os.makedirs(toxhome, exist_ok=True)
-    if os.path.exists(GLOBAL.value):
-        os.remove(GLOBAL.value)
+    if os.path.exists(global_loc):
+        os.remove(global_loc)
     tmpdir.mkdir('.west')
     tmpdir.chdir()
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -270,3 +270,10 @@ def test_config_missing_key():
         cmd('config pytest')
         assert str(e) == 'west config: error: missing key, please invoke ' \
             'as: west config <section>.<key>\n'
+
+def test_unset_config():
+    # Getting unset configuration options should raise an error.
+    # With verbose output, the exact missing option should be printed.
+    with pytest.raises(subprocess.CalledProcessError) as e:
+        cmd('-v config pytest.missing')
+        assert 'pytest.missing is unset' in str(e)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -146,6 +146,41 @@ def test_config_local():
     assert lcl['pytest']['local2'] == 'foo2'
 
 @patch('west.configuration._location', new=tstloc)
+def test_config_system():
+    # Basic test of system-level configuration.
+    #
+    # Since we use tstloc(), we can't call cmd('config ...') here.
+
+    config.update_config('pytest', 'key', 'val', configfile=SYSTEM)
+    assert cfg(f=ALL)['pytest']['key'] == 'val'
+    assert cfg(f=SYSTEM)['pytest']['key'] == 'val'
+    assert 'pytest' not in cfg(f=GLOBAL)
+    assert 'pytest' not in cfg(f=LOCAL)
+
+    config.update_config('pytest', 'key', 'val2', configfile=SYSTEM)
+    assert cfg(f=SYSTEM)['pytest']['key'] == 'val2'
+
+@patch('west.configuration._location', new=tstloc)
+def test_config_system_precedence():
+    # Test precedence rules, including system level.
+    #
+    # Since we use tstloc(), we can't call cmd('config ...') here.
+    config.update_config('pytest', 'key', 'sys', configfile=SYSTEM)
+    assert cfg(f=SYSTEM)['pytest']['key'] == 'sys'
+    assert cfg(f=ALL)['pytest']['key'] == 'sys'
+
+    config.update_config('pytest', 'key', 'glb', configfile=GLOBAL)
+    assert cfg(f=SYSTEM)['pytest']['key'] == 'sys'
+    assert cfg(f=GLOBAL)['pytest']['key'] == 'glb'
+    assert cfg(f=ALL)['pytest']['key'] == 'glb'
+
+    config.update_config('pytest', 'key', 'lcl', configfile=LOCAL)
+    assert cfg(f=SYSTEM)['pytest']['key'] == 'sys'
+    assert cfg(f=GLOBAL)['pytest']['key'] == 'glb'
+    assert cfg(f=LOCAL)['pytest']['key'] == 'lcl'
+    assert cfg(f=ALL)['pytest']['key'] == 'lcl'
+
+@patch('west.configuration._location', new=tstloc)
 def test_system_creation():
     # Test that the system file -- and just that file -- is created on
     # demand.


### PR DESCRIPTION
The goal of this pull request is to add all the features I would like `west config` to have for 1.0.

(I'm not 100% happy with the user friendliness of the `west.configuration` API, though, so I might want to send a follow-up with some deprecations and cleanups.)

The configuration API currently only allows getting and setting individual config options. The test cases are a great starting point for validating this, but they work only at the command level and do not test the underlying APIs, or that the command-line interface and module APIs work together as expected.

To flesh out the interface for both, this:

- adds `west config --list` to print all options and their values
- adds `west config -d [--global | --system | --local] foo.bar` to delete `foo.bar` from an individual file, or the *first* global or local file with a value where it is set
- adds `west config -D foo.bar` to delete `foo.bar` everywhere (including the system file)

It also includes these new features and fixes:

- fixes the behavior  when `XDG_CONFIG_HOME` is set to match the XDG Desktop Specification.
- adds configuration support for BSD operating systems (see #259)
- adds `WEST_CONFIG_SYSTEM`, `WEST_CONFIG_GLOBAL`, and `WEST_CONFIG_LOCAL` environment variables for setting config file locations
- always creates configuration files if they do not exist

Finally, it extends the test coverage quite a bit.

The first patch is a minor behavioral change I needed to make the test updates work nicely.