### PR TITLE
Incompatible list improvements

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -9,6 +9,7 @@ python:
 
 build:
   ci:
+    - pip install --upgrade pip
     - pip install tox
     - mkdir -p shippable/{testresults,codecoverage}
     - tox -- --junitxml=$PWD/shippable/testresults/nosetests.xml --cov=west --cov-report=xml:$PWD/shippable/codecoverage/coverage.xml tests

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -622,15 +622,15 @@ class Project:
 class ManifestProject(Project):
     '''Represents the manifest as a project.'''
 
-    def __init__(self, path=None, revision='(not set)', url='(not set)',
+    def __init__(self, path=None, revision=None, url=None,
                  west_commands=None):
         '''Specify a Special Project by name, and url, and optional information.
 
         :param path: Relative path to the project in the west
                      installation, if present in the manifest. If None,
                      the project's ``name`` is used.
-        :param revision: Project revision as given in the manifest, if present.
-        :param url: Complete URL for special project.
+        :param revision: manifest project revision, or None
+        :param url: Complete URL for the manifest project, or None
         :param west_commands: path to a YAML file in the project containing
                               a description of west extension commands provided
                               by the project, if given. This obviously only

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -48,10 +48,10 @@ def test_list(west_update_tmpdir):
     # Projects shall be listed in the order they appear in the manifest.
     # Check the behavior for some format arguments of interest as well.
     actual = cmd('list -f "{name} {revision} {path} {cloned} {clone_depth}"')
-    expected = ['zephyr (not set) zephyr (cloned) None',
-                'Kconfiglib zephyr {} (cloned) None'.format(
+    expected = ['zephyr N/A zephyr cloned None',
+                'Kconfiglib zephyr {} cloned None'.format(
                     os.path.join('subdir', 'Kconfiglib')),
-                'net-tools master net-tools (cloned) None']
+                'net-tools master net-tools cloned None']
     assert actual.splitlines() == expected
 
     # We should be able to find projects by absolute or relative path


### PR DESCRIPTION
- The default west list format string is not particularly readable
  most of the time. Tweak it so it's better.

- replace multi-word strings like "(not set)" with single word
  equivalents like "N/A", which are easier to deal with in pipelines
  to cut, awk, etc.

- add a new {sha} format specifier that always produces a 40-character
  SHA, or the string N/A padded to the correct length.