### PR TITLE
manifest: new Project.west_top to reduce west_topdir() frequency

### DIFF
--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -215,7 +215,8 @@ def test_no_defaults(config_file_project_setup):
     with patch('west.util.west_topdir', return_value='/west_top'):
         manifest = Manifest.from_data(yaml.safe_load(content))
 
-        expected = [ManifestProject(path='manifestproject'),
+        expected = [ManifestProject(west_top="/west_top",
+                                    path='manifestproject'),
                     Project('testproject1', None, path='testproject1',
                             clone_depth=None, revision='rev1', remote=r1),
                     Project('testproject2', None, path='testproject2',
@@ -256,7 +257,8 @@ def test_self_tag(project_setup):
     with patch('west.util.west_topdir', return_value='/west_top'):
         manifest = Manifest.from_data(yaml.safe_load(content))
 
-        expected = [ManifestProject(path='mainproject'),
+        expected = [ManifestProject(west_top="/west_top",
+                                    path='mainproject'),
                     Project('testproject1', None, path='testproject1',
                             clone_depth=None, revision='rev1', remote=r1),
                     Project('testproject2', None, path='testproject2',
@@ -299,7 +301,8 @@ def test_default_clone_depth(config_file_project_setup):
     with patch('west.util.west_topdir', return_value='/west_top'):
         manifest = Manifest.from_data(yaml.safe_load(content))
 
-        expected = [ManifestProject(path='manifestproject'),
+        expected = [ManifestProject(west_top="/west_top",
+                                    path='manifestproject'),
                     Project('testproject1', d, path='testproject1',
                             clone_depth=None, revision=d.revision, remote=r1),
                     Project('testproject2', d, path='testproject2',


### PR DESCRIPTION
On a current and standard Zephyr configuration with 12 projects, a
single 'west list' invocation performs 31, non-recursive invocations of
west_topdir(). Each west_topdir() call invokes os.path.isdir() a few
times (how many varies depending on where west is called from).

Add a new, optional Project.west_top field. Compute it only once and
re-use it when constructing the list of Project objects. In my
configuration this gets the number of west_topdir() invocations down
from 31 to 7.

On local storage the speed improvement is only a couple percents. It
takes barely longer to just load all imports and exit immediately than
actually run the 'west list' command anyway. The goal here is not
performance but the ability to trace and/or debug west_topdir() without
being drowned in noise.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>