### PR TITLE
project: rephrase message "branch left behind, to fast forward... "

### DIFF
--- a/src/west/commands/project.py
+++ b/src/west/commands/project.py
@@ -902,8 +902,8 @@ def _post_checkout_help(project, branch, sha, is_ancestor):
         # print a message that makes it easy to get back,
         # no matter where in the installation os.getcwd() is.
         log.wrn(project.format(
-            'left behind {name} branch "{b}"; '
-            'to fast forward back, use: git -C {rp} checkout {b}',
+            'left behind {name} branch "{b}"; to switch '
+            'back to it (fast forward), use: git -C {rp} checkout {b}',
             b=branch, rp=rel))
         log.dbg('(To do this automatically in the future,',
                 'use "west update --keep-descendants".)')


### PR DESCRIPTION
Invoking 'west update' without the '-r' (rebase) option typically causes
messages like this to be issued:

WARNING: left behind ci-tools branch "mybranch"; to fast forward back,
         use: git -C ../tools/ci-tools checkout mybranch

This is actually two messages somewhat confusingly compressed into one:
 1. How to switch back to "mybranch",
 2. "mybranch" is head of manifest-rev and doesn't need to be rebased.

Some issues:
- While 2. is secondary, it fills most of the space and draws most of the
  attention.
- Whenever plain git uses "fast forward" there doesn't seem to ever be
  any branch switching involved. Yet switching branch is the main
  message here.
- The unfortunate "forward back" sequence sounds weird when parsed too
  quickly.

As discussed and agreed with Marti on Slack, isolate and "downgrade"
the fast forward part of the message like this:

  to switch back to it (fast-forward), use: git checkout...

Signed-off-by: Marc Herbert <marc.herbert@intel.com>