### PR TITLE
West 0.6.0 rc2

### DIFF
--- a/src/west/manifest-schema.yml
+++ b/src/west/manifest-schema.yml
@@ -56,15 +56,23 @@ mapping:
     sequence:
       - type: map
         mapping:
-          # remote.url-base + / + name is the fetch URL
+          # Project's unique name.
           name:
             required: true
             type: str
-          # Name of the project remote
+          # Name of the project's remote. May not be combined with "url".
           remote:
             required: false
             type: str
-          # Explicit project URL (may not be given with a remote as well)
+          # If a remote is given, the project is fetched from this URL:
+          #
+          # remote.url-base + / + repo-path
+          #
+          # "repo-path" defaults to "name".
+          repo-path:
+            required: false
+            type: str
+          # Explicit project fetch URL. May not be combined with "remote".
           url:
             required: false
             type: str

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -256,11 +256,15 @@ class Manifest:
             name = mp['name']
 
             # Validate the project remote or URL.
-            remote_name = mp.get('remote', default_remote_name)
+            remote_name = mp.get('remote')
             url = mp.get('url')
             if remote_name is None and url is None:
-                self._malformed('project {} does not specify a remote or URL'.
-                                format(name))
+                if default_remote_name is None:
+                    self._malformed(
+                        'project {} has no remote or URL (no default is set)'.
+                        format(name))
+                else:
+                    remote_name = default_remote_name
             if remote_name:
                 if remote_name not in remotes_dict:
                     self._malformed('project {} remote {} is not defined'.

--- a/src/west/version.py
+++ b/src/west/version.py
@@ -2,4 +2,4 @@
 #
 # This is the Python 3 version of option 3 in:
 # https://packaging.python.org/guides/single-sourcing-package-version/#single-sourcing-the-version
-__version__ = '0.6.0rc1'
+__version__ = '0.6.0rc2'

--- a/tests/manifests/invalid_repo_path_and_url.yml
+++ b/tests/manifests/invalid_repo_path_and_url.yml
@@ -1,0 +1,11 @@
+# No project element may explicitly specify both a URL and a repo-name.
+manifest:
+  defaults:
+    remote: remote1
+  remotes:
+    - name: remote1
+      url-base: https://example.com
+  projects:
+    - name: project1
+      repo-path: explicit-project-url
+      url: https://example.com/explicit-project-url

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -105,6 +105,24 @@ def test_no_remote_ok(west_topdir):
     manifest = Manifest.from_data(yaml.safe_load(content))
     assert manifest.projects[1].url == 'https://example.com/my-project'
 
+@patch('west.util.west_topdir', return_value='/west_top')
+def test_defaults_and_url(west_topdir):
+    # an explicit URL overrides the defaults attribute.
+
+    content = '''\
+    manifest:
+      defaults:
+        remote: remote1
+      remotes:
+        - name: remote1
+          url-base: https://url1.com/
+      projects:
+        - name: testproject
+          url: https://url2.com/testproject
+    '''
+    manifest = Manifest.from_data(yaml.safe_load(content))
+    assert manifest.projects[1].url == 'https://url2.com/testproject'
+
 def test_no_defaults(config_file_project_setup):
     # Manifests with no defaults should work.
     content = '''\


### PR DESCRIPTION
Compared to rc1, this adds a bugfix and a new feature, the project 'repo-path' attribute, to allow continuing use of remotes with non-unique project names.

Fixes: #283 