### PR TITLE
Prep work improvements

### DIFF
--- a/src/west/commands/project.py
+++ b/src/west/commands/project.py
@@ -934,9 +934,6 @@ def _git(project, cmd, extra_args=(), capture_stdout=False, check=True,
          cwd=None):
     # Wrapper for project.git() that by default calls log.die() with a
     # message about the command that failed if CalledProcessError is raised.
-    #
-    # If the global error context value is set, it is appended to the
-    # message.
 
     try:
         res = project.git(cmd, extra_args=extra_args,
@@ -945,9 +942,6 @@ def _git(project, cmd, extra_args=(), capture_stdout=False, check=True,
         msg = project.format(
             "Command '{c}' failed with code {rc} for {name_and_path}",
             c=cmd, rc=e.returncode)
-
-        if _error_context_msg:
-            msg += _error_context_msg.replace('\n', ' ')
 
         log.die(msg)
 
@@ -963,34 +957,6 @@ def _git(project, cmd, extra_args=(), capture_stdout=False, check=True,
             res.stdout.decode('utf-8').splitlines()).rstrip("\n")
 
     return res
-
-
-# Some Python shenanigans to be able to set up a context with
-#
-#   with _error_context("Doing stuff"):
-#       Do the stuff
-#
-# The _error_context() argument is extra text that gets printed in the
-# log.die() call made by _git() in case of errors.
-#
-# Note: If we ever need to support nested contexts, _error_context_msg could be
-# turned into a stack.
-
-_error_context_msg = None
-
-
-class _error_context:
-    def __init__(self, msg):
-        self.msg = msg
-
-    def __enter__(self):
-        global _error_context_msg
-        _error_context_msg = self.msg
-
-    def __exit__(self, *args):
-        global _error_context_msg
-        _error_context_msg = None
-
 
 def _banner(msg):
     # Prints "msg" as a "banner", i.e. prefixed with '=== ' and colorized.

--- a/src/west/commands/project.py
+++ b/src/west/commands/project.py
@@ -439,7 +439,8 @@ class ManifestCommand(_ProjectCommand):
             The --freeze operation outputs the manifest with all
             project-related values fully specified: defaults are
             applied, and all revisions are converted to SHAs based on
-            the current manifest-rev branches.
+            the current manifest-rev branches. Note that all projects
+            must be cloned for this to work.
 
             The --validate operation validates the current manifest,
             printing an error if it cannot be successfully parsed.'''),
@@ -469,9 +470,10 @@ class ManifestCommand(_ProjectCommand):
             Manifest.from_file()
 
     def _freeze(self, args):
-        # We assume --freeze here. Future extensions to the group
-        # --freeze is part of can move this code around.
-        frozen = Manifest.from_file().as_frozen_dict()
+        try:
+            frozen = Manifest.from_file().as_frozen_dict()
+        except RuntimeError as re:
+            log.die(*(list(re.args) + ['(run "west update" and retry)']))
 
         # This is a destructive operation, so it's done here to avoid
         # impacting code which doesn't expect this representer to be

--- a/src/west/commands/project.py
+++ b/src/west/commands/project.py
@@ -9,8 +9,7 @@ import argparse
 import collections
 from functools import partial
 import os
-from os.path import join, abspath, relpath, realpath, normpath, \
-    basename, dirname, normcase, exists, isdir
+from os.path import join, relpath, basename, dirname, exists, isdir
 import shutil
 import subprocess
 import sys
@@ -90,12 +89,6 @@ class _ProjectCommand(WestCommand):
         # Listed but missing projects. Used for error reporting.
         missing_projects = []
 
-        def normalize(path):
-            # Returns a case-normalized canonical absolute version of
-            # 'path', for comparisons. The normcase() is a no-op on
-            # platforms on case-sensitive filesystems.
-            return normcase(realpath(path))
-
         res = []
         uncloned = []
         for proj_id in ids:
@@ -109,9 +102,9 @@ class _ProjectCommand(WestCommand):
             else:
                 # The argument is not a project name. See if it specifies
                 # an absolute or relative path to a project.
-                proj_arg_norm = normalize(proj_id)
+                proj_arg_norm = util.canon_path(proj_id)
                 for project in projects:
-                    if proj_arg_norm == normalize(project.abspath):
+                    if proj_arg_norm == util.canon_path(project.abspath):
                         res.append(project)
                         break
                 else:
@@ -249,7 +242,7 @@ class Init(_ProjectCommand):
         if args.manifest_rev is not None:
             log.die('--mr cannot be used with -l')
 
-        manifest_dir = canonical(args.directory or os.getcwd())
+        manifest_dir = util.canon_path(args.directory or os.getcwd())
         manifest_file = join(manifest_dir, 'west.yml')
         topdir = dirname(manifest_dir)
         rel_manifest = basename(manifest_dir)
@@ -276,7 +269,7 @@ class Init(_ProjectCommand):
     def bootstrap(self, args):
         manifest_url = args.manifest_url or MANIFEST_URL_DEFAULT
         manifest_rev = args.manifest_rev or MANIFEST_REV_DEFAULT
-        topdir = canonical(args.directory or os.getcwd())
+        topdir = util.canon_path(args.directory or os.getcwd())
         west_dir = join(topdir, WEST_DIR)
 
         _banner('Initializing in ' + topdir)
@@ -955,9 +948,6 @@ def _msg(msg):
     # Prints "msg" as a smaller banner, i.e. prefixed with '-- ' and
     # not colorized.
     log.inf('--- ' + msg, colorize=False)
-
-def canonical(path):
-    return normpath(abspath(path))
 
 
 #

--- a/src/west/log.py
+++ b/src/west/log.py
@@ -78,6 +78,19 @@ def inf(*args, colorize=False):
         _reset_colors(sys.stdout)
 
 
+def banner(*args):
+    '''Prints args as a "banner" at inf() level.
+
+    The args are prefixed with '=== ' and colorized by default.'''
+    inf('===', *args, colorize=True)
+
+
+def small_banner(*args):
+    '''Prints args as a smaller banner(), i.e. prefixed with '-- ' and
+    not colorized.'''
+    inf('---', *args, colorize=False)
+
+
 def wrn(*args):
     '''Print a warning.
 

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -249,6 +249,9 @@ class Manifest:
         del projects[MANIFEST_PROJECT_INDEX]
         frozen_projects = []
         for project in projects:
+            if not project.is_cloned():
+                raise RuntimeError('cannot freeze; project {} is uncloned'.
+                                   format(project.name))
             sha = project.sha(QUAL_MANIFEST_REV_BRANCH)
             d = project.as_dict()
             d['revision'] = sha

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -34,12 +34,6 @@ from west.backports import CompletedProcess
 from west.configuration import config
 
 
-# Todo: take from _bootstrap?
-# Default west repository URL.
-WEST_URL_DEFAULT = 'https://github.com/zephyrproject-rtos/west'
-# Default revision to check out of the west repository.
-WEST_REV_DEFAULT = 'master'
-
 #: Index in projects where the project with contains project manifest file is
 #: located
 MANIFEST_PROJECT_INDEX = 0

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -650,6 +650,23 @@ class Project:
         '''Returns is_up_to_date_with(self.revision).'''
         return self.is_up_to_date_with(self.revision)
 
+    def is_cloned(self):
+        '''Returns True if the project's path is a directory that looks
+        like the top-level directory of a Git repository, and False
+        otherwise.'''
+        if not os.path.isdir(self.abspath):
+            return False
+
+        # --is-inside-work-tree doesn't require that the directory is
+        # the top-level directory of a Git repository. Use --show-cdup
+        # instead, which prints an empty string (i.e., just a newline,
+        # which we strip) for the top-level directory.
+        res = self.git('rev-parse --show-cdup', check=False,
+                       capture_stderr=True, capture_stdout=True)
+
+        return not (res.returncode or res.stdout.strip())
+
+
 class ManifestProject(Project):
     '''Represents the manifest as a project.'''
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -127,7 +127,6 @@ def test_diff(west_init_tmpdir):
     cmd('diff')
 
     cmd('update Kconfiglib')
-    cmd('diff --cached')  # Pass a custom flag too
 
 
 def test_status(west_init_tmpdir):
@@ -143,7 +142,6 @@ def test_status(west_init_tmpdir):
     cmd('status')
 
     cmd('update Kconfiglib')
-    cmd('status --long')  # Pass a custom flag too
 
 
 def test_forall(west_init_tmpdir):


### PR DESCRIPTION
This is a bunch of cleanup and prep work patches I think should be sent on their own (since they're already quite a lot of commits).

It's a basis for two lines of development going on in semi-parallel:

- add a smarter project fetching strategy that avoids fetching projects when the revisions are definitely already available locally
- some downstream-specific extension commands that want to use some of the code that's currently hidden in private project.py methods

I should add:

Fixes: #242 

By removing the unsupported behavior from the test cases and help strings.