### PR TITLE
manifest: fix get_projects() for unknown projects

### DIFF
--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -222,8 +222,8 @@ class Manifest:
             else:
                 ret.append(project)
 
-            if only_cloned and not project.is_cloned():
-                uncloned.append(project)
+                if only_cloned and not project.is_cloned():
+                    uncloned.append(project)
 
         if unknown or (only_cloned and uncloned):
             raise ValueError(unknown, uncloned)

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -403,6 +403,19 @@ def test_west_is_ok():
     assert manifest.projects[1].name == 'west'
 
 
+def test_get_projects_unknown():
+    content = '''\
+    manifest:
+      projects:
+        - name: foo
+          url: https://foo.com
+    '''
+    with patch('west.util.west_topdir', return_value='/west_top'):
+        manifest = Manifest.from_data(yaml.safe_load(content))
+        with pytest.raises(ValueError):
+            manifest.get_projects(['unknown'])
+
+
 # Invalid manifests should raise MalformedManifest.
 @pytest.mark.parametrize('invalid',
                          glob(os.path.join(THIS_DIRECTORY, 'manifests',


### PR DESCRIPTION
The control flow when there is an unknown project is wrong: this is
calling is_cloned() on None. Indent it properly and add a regression
test.

Signed-off-by: Marti Bolivar <marti.bolivar@nordicsemi.no>