### PR TITLE
West version 0.6.1

### DIFF
--- a/src/west/version.py
+++ b/src/west/version.py
@@ -2,4 +2,4 @@
 #
 # This is the Python 3 version of option 3 in:
 # https://packaging.python.org/guides/single-sourcing-package-version/#single-sourcing-the-version
-__version__ = '0.6.0'
+__version__ = '0.6.1'


### PR DESCRIPTION
Compared to v0.6.0, the user-visible features in this point release are:

- an optimized west update via its new --fetch command line flag and
  update.fetch config option. The default value, "smart", skips fetching
  SHAs and tags which are available locally.
- better and more consistent error-handling in the manifest, diff, status,
  forall, and update commands.
- the west list command now accepts uncloned projects unless its
  format string requires data that must be obtained from the project
  repository.
- multi-repo commands now accept partial SHAs in more cases. For
  example, "west init --mr SHA_PREFIX" works now.

The developer-visible additions to the west APIs are:

- west.log.banner(): new
- west.log.small_banner(): new
- west.manifest.Manifest.get_projects(): new
- west.manifest.Project.is_cloned(): new
- west.commands.WestCommand instances can now access the parsed
  Manifest object via a new self.manifest property during the
  do_run() call. If read, it returns the Manifest object or
  aborts the command if it could not be parsed.
- west.manifest.Project.git() now has a capture_stderr kwarg
