### PR TITLE
Fix west update in new v0.6 branch

### DIFF
--- a/src/west/commands/project.py
+++ b/src/west/commands/project.py
@@ -727,6 +727,8 @@ def _update(project, fetch, rebase, keep_descendants):
         _fetch(project)
     else:
         log.dbg('skipping unnecessary fetch')
+        project.git('update-ref ' + QUAL_MANIFEST_REV +
+                    ' {revision}^{{commit}}')
 
     try:
         sha = project.sha(QUAL_MANIFEST_REV)

--- a/src/west/version.py
+++ b/src/west/version.py
@@ -2,4 +2,4 @@
 #
 # This is the Python 3 version of option 3 in:
 # https://packaging.python.org/guides/single-sourcing-package-version/#single-sourcing-the-version
-__version__ = '0.6.1'
+__version__ = '0.6.2'


### PR DESCRIPTION
Fix a critical west update issue in a new v0.6 branch. I'm cutting a branch because master's west APIs have diverged to the point that I think the next west should be v0.7, and we're not ready to cut a release yet on those changes.

Fixes #298 