### PR TITLE
add 'west topdir' command

### DIFF
--- a/src/west/commands/__init__.py
+++ b/src/west/commands/__init__.py
@@ -50,6 +50,7 @@ class ExtensionCommandError(CommandError):
 _NO_TOPDIR_MSG_FMT = '''\
 no west installation found from "{}"; "west {}" requires one.
 Things to try:
+ - Change directory to a west installation and retry.
  - Set ZEPHYR_BASE to a zephyr repository path in a west installation.
  - Run "west init" to set up an installation here.
  - Run "west init -h" for additional information.

--- a/src/west/commands/project.py
+++ b/src/west/commands/project.py
@@ -691,6 +691,25 @@ class ForAll(_ProjectCommand):
         self._handle_failed(args, failed)
 
 
+class Topdir(_ProjectCommand):
+    def __init__(self):
+        super().__init__(
+            'topdir',
+            'print the top level directory of the installation',
+            textwrap.dedent('''\
+            Prints the absolute path of the current west installation's
+            top directory.
+
+            This is the directory containing .west. All project
+            paths in the manifest are relative to this top directory.'''))
+
+    def do_add_parser(self, parser_adder):
+        return self._parser(parser_adder)
+
+    def do_run(self, args, user_args):
+        log.inf(self.topdir)
+
+
 class SelfUpdate(_ProjectCommand):
     def __init__(self):
         super().__init__(

--- a/src/west/main.py
+++ b/src/west/main.py
@@ -168,8 +168,10 @@ class WestArgumentParser(argparse.ArgumentParser):
                     if not specs:
                         continue
 
-                    append('commands from project at "{}":'.
-                           format(path))
+                    project = specs[0].project  # they're all from this project
+                    append(project.format(
+                        'extension commands from project '
+                        '{name} (path: {path}):'))
 
                     for spec in specs:
                         self.format_extension_spec(append, spec, width)

--- a/src/west/main.py
+++ b/src/west/main.py
@@ -29,14 +29,14 @@ from west import configuration as config
 from west.commands import extension_commands, \
     CommandError, CommandContextError, ExtensionCommandError
 from west.commands.project import List, ManifestCommand, Diff, Status, \
-    SelfUpdate, ForAll, Init, Update
+    SelfUpdate, ForAll, Init, Update, Topdir
 from west.commands.config import Config
 from west.manifest import Manifest, MalformedConfig, MalformedManifest
 from west.util import quote_sh_list, west_topdir, WestNotFound
 from west.version import __version__
 
 BUILTIN_COMMANDS = {
-    'commands for managing multiple git repositories': [
+    'built-in commands for managing git repositories': [
         Init(),
         Update(),
         List(),
@@ -46,7 +46,10 @@ BUILTIN_COMMANDS = {
         ForAll(),
     ],
 
-    'configuring west': [Config()],
+    'other built-in commands': [
+        Config(),
+        Topdir(),
+    ],
 
     # None is for hidden commands we don't want to show to the user.
     None: [SelfUpdate()]

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -362,11 +362,11 @@ def test_extension_command_multiproject(repos_tmpdir):
     # The newline shenanigans are for Windows.
     help_text = '\n'.join(cmd('-h').splitlines())
     expected = '\n'.join([
-        'commands from project at "{}":'.format(os.path.join('subdir',
-                                                             'Kconfiglib')),
+        'extension commands from project Kconfiglib (path: {}):'.
+        format(os.path.join('subdir', 'Kconfiglib')),
         '  kconfigtest:          (no help provided; try "west kconfigtest -h")',  # noqa: E501
         '',
-        'commands from project at "net-tools":',
+        'extension commands from project net-tools (path: net-tools):',
         '  test-extension:       test-extension-help'])
     assert expected in help_text, help_text
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -447,6 +447,31 @@ def test_extension_command_duplicate(repos_tmpdir):
 
     assert actual == expected
 
+def test_topdir_none(tmpdir):
+    # Running west topdir outside of any installation ought to fail.
+
+    tmpdir.chdir()
+    with pytest.raises(subprocess.CalledProcessError):
+        cmd('topdir')
+
+def test_topdir_in_installation(west_init_tmpdir):
+    # Running west topdir anywhere inside of an installation ought to
+    # work, and return the same thing.
+
+    expected = str(west_init_tmpdir)
+
+    # This should be available immediately after west init.
+    assert cmd('topdir').strip() == expected
+
+    # After west update, it should continue to work, and return the
+    # same thing (not getting confused when called from within a
+    # project directory or a random user-created subdirectory, e.g.)
+    cmd('update')
+    assert cmd('topdir', cwd=str(west_init_tmpdir / 'subdir' /
+                                 'Kconfiglib')).strip() == expected
+    west_init_tmpdir.mkdir('pytest-foo')
+    assert cmd('topdir', cwd=str(west_init_tmpdir /
+                                 'pytest-foo')).strip() == expected
 
 #
 # Helper functions used by the test cases and fixtures.


### PR DESCRIPTION
This new command will just print the root or top level directory of the west installation (or an error if none is found). We also tweak some of the help text while we're here to keep 'west help' nice and clean.

cc: @marc-hb @bjda

Discussion in https://github.com/zephyrproject-rtos/west/issues/310 brought up a request for a way to print the installation top level directory. We've been discussing whether or not to add this for quite some time now. It's clearly useful to some users, so let's just add it.