### PR TITLE
main.py: clarify warning when ZEPHYR_BASE != west config

### DIFF
--- a/src/west/main.py
+++ b/src/west/main.py
@@ -399,9 +399,11 @@ def set_zephyr_base(args):
         zb_env = os.environ.get('ZEPHYR_BASE')
         zb_prefer = config.config.get('zephyr', 'base-prefer',
                                       fallback=None)
-        zb_config = config.config.get('zephyr', 'base', fallback=None)
-        if zb_config is not None:
-            zb_config = os.path.join(west_topdir(), zb_config)
+        rel_zb_config = config.config.get('zephyr', 'base', fallback=None)
+        if rel_zb_config is not None:
+            zb_config = os.path.join(west_topdir(), rel_zb_config)
+        else:
+            zb_config = None
 
         if zb_prefer == 'env' and zb_env is not None:
             zb = zb_env
@@ -427,9 +429,11 @@ def set_zephyr_base(args):
                 # zephyr-env.sh/cmd was run in some other zephyr installation,
                 # and the user forgot about that.
                 log.wrn('ZEPHYR_BASE={}'.format(zb_env),
-                        'in the calling environment will be used, but was set '
-                        'to', zb_config, 'in west config.\n To disable this '
-                        'warning, execute '
+                        'in the calling environment will be used,\n'
+                        'but the zephyr.base config option in {} is "{}"\n'
+                        'which implies ZEPHYR_BASE={}'
+                        '\n'.format(west_topdir(), rel_zb_config, zb_config) +
+                        'To disable this warning, execute '
                         '\'west config --global zephyr.base-prefer env\'')
         elif zb_config is not None:
             zb = zb_config


### PR DESCRIPTION
Every time ZEPHYR_BASE and west config clashed with each other it's been
because I moved across _several_ west installations and forgot to
adjust ZEPHYR_BASE. Fix the warning message so:

- it doesn't refer to the "west config" like there's only one!
- it shows which exact west topdir it got a west config from;
- it shows the actual value in west config and not a construction.

Before:
```
  WARNING: ZEPHYR_BASE=/home/john/west1/zephyr in the calling
  environment will be used, but was set to
  /home/john/west2/zephyr in west config.
```
After:
```
  WARNING: ZEPHYR_BASE=/home/john/west1/zephyr in the calling
  environment will be used, but was set to
  "zephyr" subdirectory in [west config of] /home/john/west2
```
When something goes wrong, the user unfortunately needs the "raw" /
low-level data; synthetized information only obscures what's going on
and may even be incorrect in case of a corner case / bug.

PS: the previous message was especially confusing when the current
directory includes some symbolic link(s) hence doesn't match anything in
the warning. In that (admittedly unsupported) case, pointing straight at
the specific west config helps even more.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>