### PR TITLE
manifest: don't use realpath for abspath; prefer PWD for west_top

### DIFF
--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -650,7 +650,7 @@ class Project:
         self.topdir = topdir
         '''Root directory of the west installation this project is inside,
         or None.'''
-        self.abspath = (os.path.realpath(os.path.join(topdir, self.path))
+        self.abspath = (os.path.abspath(os.path.join(topdir, self.path))
                         if topdir else None)
         '''Absolute path to the project on disk, or None.'''
         self.posixpath = (PurePath(self.abspath).as_posix()
@@ -904,7 +904,7 @@ class ManifestProject(Project):
         installation, or None.'''
         self.topdir = topdir
         '''Root directory of the west installation, or None.'''
-        self.abspath = (os.path.realpath(os.path.join(topdir, self.path))
+        self.abspath = (os.path.abspath(os.path.join(topdir, self.path))
                         if topdir and path else None)
         '''Absolute path to the manifest repository, or None.'''
         self.posixpath = (PurePath(self.abspath).as_posix()


### PR DESCRIPTION
This is enough to make "west list" and "west topdir" not resolve
symbolic links in a number of cases, for instance this has been
successfully tested with symbolic links in
-fmacro-prefix-map=${WEST_TOPDIR}=WEST_TOPDIR as implemented in
https://github.com/zephyrproject-rtos/zephyr/pull/19440

This is enough to avoid too many double dots in module names generated
when ZEPHYR_BASE has symbolic links, e.g. from:

  build/modules/stuff/CMakeFiles/..__..__..__zephyrproject__modules_etc

to:

  build/modules/stuff/CMakeFiles/modules_etc

While successfully tested on very large sanitycheck samples and enough
to make them reproducible, this will likely never support every single
possible use of symbolic links.  See one exception described in the code
comments where "make" is invoked directly. However this makes no
difference when not using symbolic links.

TODO: add a Linux test, skipped on Windows with
https://docs.pytest.org/en/latest/skipping.html#skip-all-test-functions-of-a-class-or-module

Signed-off-by: Marc Herbert <marc.herbert@intel.com>