### PR TITLE
manifest: improve Manifest.as_frozen_dict robustness

### DIFF
--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -340,7 +340,13 @@ class Manifest:
             if not project.is_cloned():
                 raise RuntimeError('cannot freeze; project {} is uncloned'.
                                    format(project.name))
-            sha = project.sha(QUAL_MANIFEST_REV_BRANCH)
+            try:
+                sha = project.sha(QUAL_MANIFEST_REV_BRANCH)
+            except subprocess.CalledProcessError as e:
+                raise RuntimeError('cannot freeze; project {} ref {} '
+                                   'cannot be resolved to a SHA'.
+                                   format(project.name,
+                                          QUAL_MANIFEST_REV_BRANCH)) from e
             d = project.as_dict()
             d['revision'] = sha
             frozen_projects.append(d)


### PR DESCRIPTION
cc: @skelliam

In certain situations, such as if the project remote is an empty
repository or otherwise prevents 'west update' from setting up the
manifest-rev branch, we can't freeze the manifest even though a
project has been cloned.

Handle that by raising RuntimeError, so that higher layers know what
went wrong and can print a sensible error message instead of dumping
stack.

Fixes: #314
Signed-off-by: Marti Bolivar <marti.bolivar@nordicsemi.no>