### PR TITLE
Manifest version check

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setuptools.setup(
         'pykwalify',
         'configobj',
         'setuptools>=v40.1.0',  # for find_namespace_packages
+        'packaging',
     ],
     python_requires='>=3.4',
     entry_points={'console_scripts': ('west = west.main:main',)},

--- a/src/west/commands/__init__.py
+++ b/src/west/commands/__init__.py
@@ -50,10 +50,10 @@ class ExtensionCommandError(CommandError):
 _NO_TOPDIR_MSG_FMT = '''\
 no west installation found from "{}"; "west {}" requires one.
 Things to try:
- - Change directory to a west installation and retry.
- - Set ZEPHYR_BASE to a zephyr repository path in a west installation.
- - Run "west init" to set up an installation here.
- - Run "west init -h" for additional information.
+  - Change directory to a west installation and retry.
+  - Set ZEPHYR_BASE to a zephyr repository path in a west installation.
+  - Run "west init" to set up an installation here.
+  - Run "west init -h" for additional information.
 '''
 
 class WestCommand(ABC):

--- a/src/west/main.py
+++ b/src/west/main.py
@@ -582,7 +582,7 @@ def main(argv=None):
     # re-parsed.
     if topdir:
         try:
-            manifest = Manifest.from_file()
+            manifest = Manifest.from_file(topdir=topdir)
             extensions = get_extension_commands(manifest)
         except (MalformedManifest, MalformedConfig, FileNotFoundError):
             manifest = None

--- a/src/west/manifest-schema.yml
+++ b/src/west/manifest-schema.yml
@@ -17,6 +17,20 @@
 
 type: map
 mapping:
+  # The "version" key is optional, and specifies a minimum version of
+  # west (in semantic versioning, so X.Y <= X.Y.0 < X.Y.1 < (X+1).Y,
+  # etc.) that is required to correctly parse the manifest data.
+  #
+  # This is supported starting with west v0.7 (i.e. it was added after
+  # 0.6 was released). Earlier versions of west will treat manifest
+  # data with a version key as malformed, so it can reliably be used
+  # to prevent parsing on west v0.5 and v0.6 as well, though the error
+  # messages users will receive will be a bit more confusing in that
+  # case.
+  version:
+    required: false
+    type: text
+
   # The "defaults" key specifies some default values used in the
   # rest of the manifest.
   defaults:

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -142,7 +142,8 @@ class Manifest:
     def from_data(source_data, manifest_path=None, topdir=None):
         '''Create and return a new Manifest object given parsed YAML data.
 
-        :param source_data: Parsed YAML data as a Python object.
+        :param source_data: Parsed YAML data as a Python object,
+                            or a string with YAML data inside.
         :param manifest_path: fallback ManifestProject path attribute
         :param topdir: If given, absolute paths in the result will be
                        rooted here.
@@ -163,6 +164,8 @@ class Manifest:
 
         Raises MalformedManifest in case of validation errors.
         '''
+        if isinstance(source_data, str):
+            source_data = yaml.safe_load(source_data)
         return Manifest(source_data=source_data, topdir=topdir,
                         manifest_path=manifest_path)
 

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -17,17 +17,17 @@ such as the default project revision, may be supplied by this module
 if they are not present in the manifest data.'''
 
 import collections
+import configparser
 import errno
 from functools import lru_cache
 import os
+from pathlib import PurePath
 import shutil
 import shlex
 import subprocess
 
-import configparser
 import pykwalify.core
 import yaml
-from pathlib import PurePath
 
 from west import util, log
 from west.backports import CompletedProcess

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -757,6 +757,17 @@ def test_get_projects_unknown():
     with pytest.raises(ValueError):
         manifest.get_projects(['unknown'])
 
+def test_load_str():
+    # We can load manifest data as a string.
+
+    manifest = Manifest.from_data('''\
+    manifest:
+      projects:
+        - name: foo
+          url: https://foo.com
+    ''')
+    assert manifest.projects[-1].name == 'foo'
+
 
 # Invalid manifests should raise MalformedManifest.
 @pytest.mark.parametrize('invalid',


### PR DESCRIPTION
Fixes: #126 

The main point of this is to add support for a version field in the manifest:

```
manifest:
     version: 1.0
```

And have west fail unless it's version 1.0 or later in the above example.

I'm really not happy with `commands: handle errors if minimum manifest version is unmet` yet, though.

It gets the job done, but leads to weird output like this:

```
$ west init
WARNING: manifest "/home/mbolivar/zp/zephyr/west.yml" requires west v0.7; you have v0.6.99.
  This will fail if manifest data is required.
  Upgrade west to silence this warning.
FATAL ERROR: already initialized in /home/mbolivar/zp, aborting.

$ west manifest --validate
WARNING: manifest "/home/mbolivar/zp/zephyr/west.yml" requires west v0.7; you have v0.6.99.
  This will fail if manifest data is required.
  Upgrade west to silence this warning.
FATAL ERROR: you must upgrade to west v0.7 or later

$ west list
WARNING: manifest "/home/mbolivar/zp/zephyr/west.yml" requires west v0.7; you have v0.6.99.
  This will fail if manifest data is required.
  Upgrade west to silence this warning.
FATAL ERROR: can't run west list: the manifest was required but could not be read.
  You must upgrade west to run this command.
```

I think this should get cleaned up a bit but thought I'd ask for feedback.