### PR TITLE
Manifest version check

### DIFF
--- a/src/west/manifest-schema.yml
+++ b/src/west/manifest-schema.yml
@@ -11,22 +11,18 @@
 
 # --------------------------------------------------------------
 #
-#  DO NOT CHANGE THIS FILE WITHOUT UPDATING THE DOCUMENTATION!
+#  DO NOT CHANGE THIS FILE WITHOUT:
+#
+#  - updating west.manifest.SCHEMA_VERSION
+#  - updating test_version_check_success() in test_manifest.py
+#  - reviewing and updating sphinx documentation
 #
 # --------------------------------------------------------------
 
 type: map
 mapping:
-  # The "version" key is optional, and specifies a minimum version of
-  # west (in semantic versioning, so X.Y <= X.Y.0 < X.Y.1 < (X+1).Y,
-  # etc.) that is required to correctly parse the manifest data.
-  #
-  # This is supported starting with west v0.7 (i.e. it was added after
-  # 0.6 was released). Earlier versions of west will treat manifest
-  # data with a version key as malformed, so it can reliably be used
-  # to prevent parsing on west v0.5 and v0.6 as well, though the error
-  # messages users will receive will be a bit more confusing in that
-  # case.
+  # The "version" key is optional. It's the minimum version manifest
+  # schema that is required to correctly parse the manifest data.
   version:
     required: false
     type: text

--- a/src/west/version.py
+++ b/src/west/version.py
@@ -2,4 +2,11 @@
 #
 # This is the Python 3 version of option 3 in:
 # https://packaging.python.org/guides/single-sourcing-package-version/#single-sourcing-the-version
+
+
+# MAINTAINERS:
+#
+# DO NOT RELEASE 0.7 without updating west.manifest.SCHEMA_VERSION to
+# 0.7 also. There are schema changes since 0.6 (including the addition
+# of the manifest version key itself)
 __version__ = '0.6.99'

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -807,14 +807,22 @@ def test_version_check_failure():
     with pytest.raises(ManifestVersionError):
         Manifest.from_data(invalid_fmt.format('99.0'))
 
-@pytest.mark.parametrize(
-    'ver', ['0.6', '0.6.2', '0.6.0.dev1', '0.6.0rc1', '0.6.99'])
+    # Manifest versions below 0.6.99 are definitionally invalid,
+    # because we added the version feature itself after 0.6.
+    with pytest.raises(MalformedManifest):
+        Manifest.from_data(invalid_fmt.format('0.0.1'))
+    with pytest.raises(MalformedManifest):
+        Manifest.from_data(invalid_fmt.format('0.5.0'))
+    with pytest.raises(MalformedManifest):
+        Manifest.from_data(invalid_fmt.format('0.6'))
+    with pytest.raises(MalformedManifest):
+        Manifest.from_data(invalid_fmt.format('0.6.9'))
+    with pytest.raises(MalformedManifest):
+        Manifest.from_data(invalid_fmt.format('0.6.98'))
+
+@pytest.mark.parametrize('ver', ['0.6.99'])
 def test_version_check_success(ver):
     # Test that version checking succeeds when it should.
-    #
-    # Parsing a well-formed manifest for a version of west no greater
-    # than this one, including RC and dev versions used for
-    # pre-releases, should not raise this error.
 
     fmt = '''\
     manifest:


### PR DESCRIPTION
A new attempt. GitHub won't let me reopen the previous pull request https://github.com/zephyrproject-rtos/west/pull/321, sorry.

Fixes: #126 

There are 3 different error paths on incompatible versions:

- help path: warn that extension command help will be missing and most commands won't run is printed
- error path: commands which are known to require the manifest (update, list, ...) print a fatal error with similar info for the help path
- watch-out path: commands which don't need the manifest (config, topdir) print a warning that they ought to work, but an upgrade is needed

Examples:

```
$ west [help,--help,-h]
WARNING: west v0.7 or later is required by the manifest
  West version: v0.6.99
  Manifest file: /home/mbolivar/zp/zephyr/west.yml
  Cannot get extension command help, and most commands won't run.
  To silence this warning, upgrade west.
usage: west [-h] [-z ZEPHYR_BASE] [-v] [-V] <command> ...
[... rest of help output ...]

$ west {update,list,manifest,diff,status,forall,build,flash,debug}
FATAL ERROR: west v0.7 or later is required by the manifest
  West version: v0.6.99
  Manifest file: /home/mbolivar/zp/zephyr/west.yml
  Please upgrade west and retry.

$ west config manifest.path
WARNING: west v0.7 or later is required by the manifest
  West version: v0.6.99
  Manifest file: /home/mbolivar/zp/zephyr/west.yml
  This should work, but most commands won't.
  To silence this warning, upgrade west.
zephyr

$ west topdir
WARNING: west v0.7 or later is required by the manifest
  West version: v0.6.99
  Manifest file: /home/mbolivar/zp/zephyr/west.yml
  This should work, but most commands won't.
  To silence this warning, upgrade west.
/home/mbolivar/zp
```
