### PR TITLE
main: basic BrokenPipeError handling

### DIFF
--- a/src/west/main.py
+++ b/src/west/main.py
@@ -645,6 +645,8 @@ def main(argv=None):
             cmd.run(args, unknown, topdir, manifest=manifest)
     except KeyboardInterrupt:
         sys.exit(0)
+    except BrokenPipeError:
+        sys.exit(0)
     except CalledProcessError as cpe:
         log.err('command exited with status {}: {}'.
                 format(cpe.returncode, quote_sh_list(cpe.cmd)))


### PR DESCRIPTION
This prevents us from dumping stack on a broken pipe.

Depending on when the exception occurs, we may still see something
like this:

Exception ignored in: <colorama.ansitowin32.StreamWrapper object at 0x7fc755d5c990>
BrokenPipeError: [Errno 32] Broken pipe

We can try to avoid even this in Python 3.8, which added a
sys.unraisablehook() that can be called instead. Let's defer that for
now, though; 3.8 hasn't hit my Arch installation yet and I want to
wait for that to start playing with it.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>