### PR TITLE
Initial support for manifest imports

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -1,15 +1,21 @@
 language: python
-# TODO: 3.7 is failing. It'd be good to figure this out eventually as
-# it's the latest version which is likely what Windows and macOS users
-# run on, but is left out for now.
+# TODO: 3.7 and 3.8 need testing here.
 python:
-  - 3.4                         # minimum supported version
-  - 3.5                         # ubuntu 16.04
-  - 3.6                         # ubuntu 18.04
+  - 3.6                         # minimum supported version
 
 build:
+  pre_ci_boot:
+    image_name: zephyrprojectrtos/ci
+    image_tag: v0.10.1
+    pull: true
+    options: "-e HOME=/home/buildslave --privileged=true --tty --net=bridge --user buildslave"
   ci:
-    - pip install --upgrade pip setuptools
-    - pip install tox
+    - type -p python3
+    - python3 --version
+    - export PATH=$PATH:$HOME/.local/bin
+    - pip3 install tox
+    # This setuptools upgrade is only needed for find_namespace_packages().
+    # We can eliminate it if we make west a non-namespace package again.
+    - pip3 install --upgrade setuptools
     - mkdir -p shippable/{testresults,codecoverage}
     - tox -- --junitxml=$PWD/shippable/testresults/nosetests.xml --cov=west --cov-report=xml:$PWD/shippable/codecoverage/coverage.xml tests

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,6 @@ setuptools.setup(
         'setuptools>=v40.1.0',  # for find_namespace_packages
         'packaging',
     ],
-    python_requires='>=3.4',
+    python_requires='>=3.6',
     entry_points={'console_scripts': ('west = west.main:main',)},
 )

--- a/src/west/commands/project.py
+++ b/src/west/commands/project.py
@@ -268,8 +268,7 @@ class Init(_ProjectCommand):
         log.dbg('moving', tempdir, 'to', manifest_abspath,
                 level=log.VERBOSE_EXTREME)
         shutil.move(tempdir, manifest_abspath)
-        log.dbg('setting manifest.path to', manifest_path,
-                level=log.VERBOSE_EXTREME)
+        log.small_banner('setting manifest.path to', manifest_path)
         update_config('manifest', 'path', manifest_path, topdir=topdir)
 
         return topdir

--- a/src/west/manifest-schema.yml
+++ b/src/west/manifest-schema.yml
@@ -103,6 +103,10 @@ mapping:
           west-commands:
             required: false
             type: str
+          # Additional manifest data to import from the project.
+          import:
+            required: false
+            type: any
 
   # The "self" key specifies values for the project containing the manifest
   # file (the "manifest repository").
@@ -118,3 +122,8 @@ mapping:
       west-commands:
         required: false
         type: str
+      # Additional manifest data to import from the manifest
+      # repository.
+      import:
+        required: false
+        type: any

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -574,14 +574,15 @@ class Project:
         return NotImplemented
 
     def __repr__(self):
-        return ('Project({}, {}, revision={}, path={}, clone_depth={}, '
-                'west_commands={}, topdir={}').format(
+        return ('Project("{}", "{}", revision="{}", path="{}", clone_depth={}, '
+                'west_commands={}, topdir={})').format(
                     self.name, self.url, self.revision, self.path,
-                    self.clone_depth, self.west_commands, self.topdir)
+                    self.clone_depth, _quote_maybe(self.west_commands),
+                    _quote_maybe(self.topdir))
 
     def __str__(self):
-        return '<Project {} at {}>'.format(
-            repr(self.name), repr(self.abspath or self.path))
+        return '<Project {} ({}) at {}>'.format(
+            self.name, repr(self.abspath or self.path), self.revision)
 
     def __init__(self, name, url, revision=None, path=None,
                  clone_depth=None, west_commands=None, topdir=None):
@@ -963,6 +964,12 @@ _SCHEMA_VER = parse_version(SCHEMA_VERSION)
 _EARLIEST_VER_STR = '0.6.99'  # we introduced the version feature after 0.6
 _EARLIEST_VER = parse_version(_EARLIEST_VER_STR)
 _DEFAULT_REV = 'master'
+
+def _quote_maybe(string):
+    if string:
+        return f'"{string}"'
+    else:
+        return None
 
 @lru_cache(maxsize=1)
 def _warn_once_if_no_git():


### PR DESCRIPTION
This is incomplete, because support for `import` keys with map values is not supported. However, you can use import keys which are:

- booleans
- files
- directories
- sequences of files and directories

Basic test cases at the west.manifest API level are supported, but I want to write much more detailed test cases before we release a version of west with these features.

However, I think this is ready for review and initial merge to get the feature into the hands of users and start collecting real feedback.