### PR TITLE
git: keep the refs space locally when fetching non-SHA revisions

### DIFF
--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -35,6 +35,11 @@ MANIFEST_REV_BRANCH = 'manifest-rev'
 #: A fully qualified reference to `MANIFEST_REV_BRANCH`.
 QUAL_MANIFEST_REV_BRANCH = 'refs/heads/' + MANIFEST_REV_BRANCH
 
+#: The west refs space used for current manifest revision.
+#: West ref space is temporary space for fetching of SHAs.
+#: The refspace also useable for future west operations, such as west rebase.
+WEST_REF_SPACE = 'refs/west/'
+
 #: The latest manifest schema version supported by this west program.
 #:
 #: This value changes when a new version of west includes new manifest


### PR DESCRIPTION
Example where fetch of non SHA revisions is kept locally.
Test not updated.

Inspired by: https://github.com/NordicPlayground/fw-nrfconnect-nrf/pull/1437

To allow later usage of the fetched refs space then git fetch will
always keep a local ref space even fetching non-SHA refs spaces, such
as branches and PRs.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>