### PR TITLE
[RFC] manifest: allow projects to say where their SHAs are

### DIFF
--- a/src/west/commands/project.py
+++ b/src/west/commands/project.py
@@ -863,7 +863,11 @@ def _fetch(project):
     update_cmd = 'update-ref ' + QUAL_MANIFEST_REV + ' '
     if _maybe_sha(project.revision):
         # Don't fetch a SHA directly, as server may restrict from doing so.
-        fetch_cmd += 'refs/heads/*:refs/west/*'
+        # Respect the project's revision-ref if there is one.
+        if project.revision_ref:
+            fetch_cmd += '{revision_ref}:refs/west/{revision_ref}'
+        else:
+            fetch_cmd += 'refs/heads/*:refs/west/*'
         update_cmd += '{revision}'
     else:
         # The revision is definitely not a SHA, so it's safe to fetch directly.

--- a/src/west/manifest-schema.yml
+++ b/src/west/manifest-schema.yml
@@ -37,8 +37,12 @@ mapping:
       remote:
         required: false
         type: str
-      # The default revision (master if not given).
+      # The default project revision (master if not given).
       revision:
+        required: false
+        type: str
+      # The default project revision-ref value (none if not given).
+      revision-ref:
         required: false
         type: str
 
@@ -90,6 +94,15 @@ mapping:
           revision:
             required: false
             type: text        # SHAs could be only numbers
+          # If revision is a SHA, then revision-ref is an optional git
+          # ref which will be fetched to get the SHA when 'west
+          # update'-ing the project.
+          #
+          # This lets west avoid fetching the entire remote ref space
+          # just to get a SHA.
+          revision-ref:
+            required: false
+            type: str
           # Path to check out, relative to the west installation root.
           # The default is the name.
           path:


### PR DESCRIPTION
Note: "revision-ref" is kind of a placeholder name. I would like to try to come up with something better.

Add a new "revision-ref" project attribute, and accept it in the
defaults section. If provided, it will be fetched during 'west update'
whenever the revision looks like a SHA, instead of syncing the entire
remote ref space.

The new attribute is ignored if the revision doesn't look like a SHA.

There's no need to update the manifest schema version since we haven't
released a version of west with manifest schema versioning yet. 0.6.99
is still correct.

Here is an example change to zephyr/west.yml making use of it for all
projects:

```
    diff --git a/west.yml b/west.yml
    index 67b8001ed2..2d117bd394 100644
    --- a/west.yml
    +++ b/west.yml
    @@ -17,6 +17,7 @@
     manifest:
       defaults:
         remote: upstream
    +    revision-ref: master

       remotes:
         - name: upstream
    @@ -36,6 +37,7 @@ manifest:
           path: modules/lib/civetweb
         - name: esp-idf
           revision: 6835bfc741bf15e98fb7971293913f770df6081f
    +      revision-ref: zephyr
           path: modules/hal/esp-idf
         - name: fatfs
           revision: df96914dd989907f3a5de4cb95b116c2f305820d
    @@ -69,6 +71,7 @@ manifest:
           path: modules/hal/libmetal
         - name: lvgl
           revision: d4708d0a432e95f51bdc712591ba5295b751140c
    +      revision-ref: zephyr
           path: modules/lib/gui/lvgl
         - name: mbedtls
           revision: 4f1e8f5a78dc08aa42a47cc1ad059cce558c26c3
    @@ -90,6 +93,7 @@ manifest:
           path: modules/lib/open-amp
         - name: openthread
           revision: 882e7074b5986027b85cb4f3ba1dc563a11ca013
    +      revision-ref: zephyr
           path: modules/lib/openthread
         - name: segger
           revision: 6fcf61606d6012d2c44129edc033f59331e268bc
    @@ -97,12 +101,15 @@ manifest:
         - name: tinycbor
           path: modules/lib/tinycbor
           revision: 0fc68fceacd1efc1ce809c5880c380f3d98b7b6e
    +      revision-ref: zephyr
         - name: littlefs
           path: modules/fs/littlefs
           revision: fe9572dd5a9fcf93a249daa4233012692bd2881d
    +      revision-ref: zephyr
         - name: mipi-sys-t
           path: modules/debug/mipi-sys-t
           revision: baf51863f19f009b92e762115ba5572a5b996b92
    +      revision-ref: zephyr

       self:
         path: zephyr
    --
    2.24.0
```

This saves network bandwidth and avoid clogging up refs/west/* with
stuff we don't care about.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>