### PR TITLE
git: clean west ref space after fetching

### DIFF
--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -36,6 +36,9 @@ MANIFEST_REV_BRANCH = 'manifest-rev'
 #: A fully qualified reference to `MANIFEST_REV_BRANCH`.
 QUAL_MANIFEST_REV_BRANCH = 'refs/heads/' + MANIFEST_REV_BRANCH
 
+#: Git ref space used by west for internal purposes.
+QUAL_REFS_WEST = 'refs/west/'
+
 #: The latest manifest schema version supported by this west program.
 #:
 #: This value changes when a new version of west includes new manifest


### PR DESCRIPTION
As discussed in PR #331 the cleanup of `refs/west` has been split into separate PR.


Note: Cleanup is done BEFORE updating the `manifest-rev` as this ensures the update is the newest entry in reflog, as example:
```
fec2a3c (HEAD, ncs/master, manifest-rev) manifest-rev@{0}: west update: moving to fec2a3c3b4d79b7eb6d1ebdf24e6813476116769
9da9943 (tag: v1.1.0, ncs/v1.1-branch) manifest-rev@{1}: west fetch: entry for refs/west/v1.1-branch
efcbc25 (tag: v1.0.0, ncs/v1.0-branch) manifest-rev@{2}: west fetch: entry for refs/west/v1.0-branch
....
```