### PR TITLE
housekeeping: workspace, not installation

### DIFF
--- a/src/west/commands/config.py
+++ b/src/west/commands/config.py
@@ -18,7 +18,7 @@ West configuration file handling.
 West follows Git-like conventions for configuration file locations.
 There are three types of configuration file: system-wide files apply
 to all users on the current machine, global files apply to the current
-user, and local files apply to the current west installation.
+user, and local files apply to the current west workspace.
 
 System files:
 
@@ -36,7 +36,7 @@ Global files:
 
 Local files:
 
-- Linux, macOS, Windows: <installation-root-directory>/.west/config
+- Linux, macOS, Windows: <workspace-root-directory>/.west/config
 
 You can override these files' locations with the WEST_CONFIG_SYSTEM,
 WEST_CONFIG_GLOBAL, and WEST_CONFIG_LOCAL environment variables.
@@ -98,7 +98,7 @@ class Config(WestCommand):
             'config',
             'get or set configuration settings in west config files',
             CONFIG_DESCRIPTION,
-            requires_installation=False)
+            requires_workspace=False)
 
     def do_add_parser(self, parser_adder):
         parser = parser_adder.add_parser(
@@ -122,7 +122,7 @@ class Config(WestCommand):
         group.add_argument('--global', dest='configfile', nargs=0, action=Once,
                            help='global (user-wide) file')
         group.add_argument('--local', dest='configfile', nargs=0, action=Once,
-                           help="this installation's file")
+                           help="this workspace's file")
 
         parser.add_argument('name', nargs='?',
                             help='''config option in section.key format;

--- a/src/west/commands/project.py
+++ b/src/west/commands/project.py
@@ -105,16 +105,16 @@ class Init(_ProjectCommand):
     def __init__(self):
         super().__init__(
             'init',
-            'create a west installation',
+            'create a west workspace',
             textwrap.dedent(f'''\
-            Creates a west installation as follows:
+            Creates a west workspace as follows:
 
               1. Creates a .west directory and clones a manifest repository
                  from a git URL to a temporary subdirectory of .west,
                  .west/<tmpdir>.
               2. Parses the manifest file, .west/<tmpdir>/west.yml.
                  This file's contents can specify manifest.path, the location
-                 of the manifest repository in the installation, like so:
+                 of the manifest repository in the workspace, like so:
 
                  manifest:
                     self:
@@ -138,7 +138,7 @@ class Init(_ProjectCommand):
 
             The default revision in this repository to check out is
             "{MANIFEST_REV_DEFAULT}"; override with --mr.'''),
-            requires_installation=False)
+            requires_workspace=False)
 
     def do_add_parser(self, parser_adder):
         parser = self._parser(parser_adder)
@@ -156,7 +156,7 @@ class Init(_ProjectCommand):
 
         parser.add_argument(
             'directory', nargs='?', default=None,
-            help='''Directory to create the installation in (default: current
+            help='''Directory to create the workspace in (default: current
                  directory). Missing intermediate directories will be created.
                  If -l is given, this is the path to the manifest repository to
                  use instead.''')
@@ -172,7 +172,7 @@ class Init(_ProjectCommand):
                     In your environment, ZEPHYR_BASE is set to:
                     {zb}
 
-                    This forces west to search for an installation there.
+                    This forces west to search for a workspace there.
                     Try unsetting ZEPHYR_BASE and re-running this command.''')
             else:
                 msg = ''
@@ -558,7 +558,7 @@ class Update(_ProjectCommand):
               3. Check out the new manifest-rev commit as a detached HEAD
                  (but see "checked out branches")
 
-            You must have already created a west installation with "west init".
+            You must have already created a west workspace with "west init".
 
             This command does not alter the manifest repository's contents.''')
         )
@@ -817,9 +817,9 @@ class Topdir(_ProjectCommand):
     def __init__(self):
         super().__init__(
             'topdir',
-            'print the top level directory of the installation',
+            'print the top level directory of the workspace',
             textwrap.dedent('''\
-            Prints the absolute path of the current west installation's
+            Prints the absolute path of the current west workspace's
             top directory.
 
             This is the directory containing .west. All project
@@ -1019,7 +1019,7 @@ def _post_checkout_help(project, branch, sha, is_ancestor):
         # the new HEAD (e.g. if this is a topic branch the
         # user is working on and the remote hasn't changed),
         # print a message that makes it easy to get back,
-        # no matter where in the installation os.getcwd() is.
+        # no matter where in the workspace os.getcwd() is.
         log.wrn(f'left behind {project.name} branch "{branch}"; '
                 f'to switch back to it (fast forward), use: '
                 f'git -C {rel} checkout {branch}')
@@ -1035,7 +1035,7 @@ def _post_checkout_help(project, branch, sha, is_ancestor):
                 'use "west update --rebase".)')
 
 #
-# Special files and directories in the west installation.
+# Special files and directories in the west workspace.
 #
 # These are given variable names for clarity, but they can't be
 # changed without propagating the changes into west itself.

--- a/src/west/configuration.py
+++ b/src/west/configuration.py
@@ -7,7 +7,7 @@
 West follows Git-like conventions for configuration file locations.
 There are three types of configuration file: system-wide files apply
 to all users on the current machine, global files apply to the current
-user, and local files apply to the current west installation.
+user, and local files apply to the current west workspace.
 
 System files:
 
@@ -25,7 +25,7 @@ Global files:
 
 Local files:
 
-- Linux, macOS, Windows: ``<installation-root-directory>/.west/config``
+- Linux, macOS, Windows: ``<workspace-topdir>/.west/config``
 
 You can override these files' locations with the ``WEST_CONFIG_SYSTEM``,
 ``WEST_CONFIG_GLOBAL``, and ``WEST_CONFIG_LOCAL`` environment variables.
@@ -63,7 +63,7 @@ class ConfigFile(Enum):
 
     - SYSTEM: system level configuration shared by all users
     - GLOBAL: global or user-wide configuration
-    - LOCAL: per-installation configuration
+    - LOCAL: per-workspace configuration
     - ALL: all three of the above, where applicable
     '''
     ALL = 1
@@ -95,7 +95,7 @@ def read_config(configfile=None, config=config, topdir=None,
 
     :param configfile: a `west.configuration.ConfigFile`
     :param config: configuration object to read into
-    :param topdir: west installation root to read local options from
+    :param topdir: west workspace root to read local options from
     :param config_file: deprecated alternative for *configfile*
     '''
     if configfile is not None and config_file is not None:
@@ -114,7 +114,7 @@ def update_config(section, key, value, configfile=ConfigFile.LOCAL,
     :param key: key to set in the given section
     :param value: value to set the key to
     :param configfile: `west.configuration.ConfigFile`, must not be ALL
-    :param topdir: west installation root to write local config options to
+    :param topdir: west workspace root to write local config options to
 
     The destination file to write is given by *configfile*. The
     default value (``ConfigFile.LOCAL``) writes to the local
@@ -122,7 +122,7 @@ def update_config(section, key, value, configfile=ConfigFile.LOCAL,
 
     - topdir/.west/config, if topdir is given, or
     - the value of 'WEST_CONFIG_LOCAL' in the environment, if set, or
-    - the local configuration file in the west installation
+    - the local configuration file in the west workspace
       found by searching the file system (raising WestNotFound if
       one is not found).
     '''
@@ -150,7 +150,7 @@ def delete_config(section, key, configfile=None, topdir=None):
                        If a list of ConfigFile enumerators, delete
                        from those files.
                        Otherwise, delete from the given ConfigFile.
-    :param topdir: west installation root to delete local options from
+    :param topdir: west workspace root to delete local options from
 
     Deleting the only key in a section deletes the entire section.
 
@@ -161,7 +161,7 @@ def delete_config(section, key, configfile=None, topdir=None):
 
     - topdir/.west/config, if topdir is given, or
     - the value of 'WEST_CONFIG_LOCAL' in the environment, if set, or
-    - the local configuration file in the west installation
+    - the local configuration file in the west workspace
       found by searching the file system (raising WestNotFound if
       one is not found).
     '''

--- a/src/west/main.py
+++ b/src/west/main.py
@@ -80,9 +80,9 @@ class WestApp:
     def run(self, argv):
         # Run the command-line application with argument list 'argv'.
 
-        # See if we're in an installation. It's fine if we're not.
+        # See if we're in a workspace. It's fine if we're not.
         # Note that this falls back on searching from ZEPHYR_BASE
-        # if the current directory isn't inside a west installation.
+        # if the current directory isn't inside a west workspace.
         try:
             self.topdir = west_topdir()
         except WestNotFound:
@@ -155,7 +155,7 @@ class WestApp:
                 return
             elif args.command == 'init':
                 # init is fine to run -- it will print its own error,
-                # with context about where the installation was found,
+                # with context about where the workspace was found,
                 # and what the user's choices are.
                 return
             else:
@@ -398,7 +398,7 @@ class Help(WestCommand):
                          textwrap.dedent('''\
                          With an argument, prints help for that command.
                          Without one, prints top-level help for west.'''),
-                         requires_installation=False)
+                         requires_workspace=False)
 
     def do_add_parser(self, parser_adder):
         parser = parser_adder.add_parser(
@@ -710,7 +710,7 @@ def set_zephyr_base(args, manifest, topdir):
                 #
                 # Therefore, issue a warning as the user might have
                 # run zephyr-env.sh/cmd in some other zephyr
-                # installation and forgotten about it.
+                # workspace and forgotten about it.
                 log.wrn(f'ZEPHYR_BASE={zb_env} '
                         f'in the calling environment will be used,\n'
                         f'but the zephyr.base config option in {topdir} '
@@ -731,7 +731,7 @@ def set_zephyr_base(args, manifest, topdir):
                     '  - west config contains no zephyr.base setting\n'
                     '  - no manifest project has name or path "zephyr"\n'
                     '\n'
-                    "  If this isn't a Zephyr installation, you can "
+                    "  If this isn't a Zephyr workspace, you can "
                     "  silence this warning with something like this:\n"
                     '    west config zephyr.base not-using-zephyr')
 

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -26,7 +26,7 @@ from west import util, log
 import west.configuration as cfg
 
 #: Index in a Manifest.projects attribute where the `ManifestProject`
-#: instance for the installation is stored.
+#: instance for the workspace is stored.
 MANIFEST_PROJECT_INDEX = 0
 
 #: A git revision which points to the most recent `Project` update.
@@ -47,12 +47,12 @@ SCHEMA_VERSION = '0.6.99'
 # there were changes since 0.6 and we're in a development tree.
 
 def manifest_path():
-    '''Absolute path of the manifest file in the current installation.
+    '''Absolute path of the manifest file in the current workspace.
 
     Exceptions raised:
 
         - `west.util.WestNotFound` if called from outside of a west
-          installation
+          workspace
 
         - `MalformedConfig` if the configuration file has no
           ``manifest.path`` key
@@ -137,7 +137,7 @@ class Manifest:
     def from_file(source_file=None, **kwargs):
         '''Manifest object factory given a source YAML file.
 
-        The default behavior is to find the current west installation's
+        The default behavior is to find the current west workspace's
         manifest file and resolve it.
 
         Results depend on the keyword arguments given in *kwargs*:
@@ -150,7 +150,7 @@ class Manifest:
               at another location in the system.
 
             - If neither *source_file* nor *topdir* is given, the file
-              system is searched for *topdir*. That installation's
+              system is searched for *topdir*. That workspace's
               ``manifest.path`` configuration option is used to find
               *source_file*, ``topdir/<manifest.path>/west.yml``.
 
@@ -158,7 +158,7 @@ class Manifest:
               starting there. The directory containing *source_file*
               doesn't have to be ``manifest.path`` in this case.
 
-            - If only *topdir* is given, that installation's
+            - If only *topdir* is given, that workspace's
               ``manifest.path`` is used to find *source_file*.
 
         Exceptions raised:
@@ -175,7 +175,7 @@ class Manifest:
               can't be read
 
             - ``ValueError`` if *topdir* is given but is not a west
-              installation root
+              workspace root
 
         :param source_file: source file to load
         :param kwargs: Manifest.__init__ keyword arguments
@@ -185,7 +185,7 @@ class Manifest:
         if topdir is None:
             if source_file is None:
                 # neither source_file nor topdir: search the filesystem
-                # for the installation and use its manifest.path.
+                # for the workspace and use its manifest.path.
                 topdir = util.west_topdir()
                 kwargs.update({
                     'topdir': topdir,
@@ -203,8 +203,8 @@ class Manifest:
         elif source_file is None:
             # Just topdir.
 
-            # Verify topdir is a real west installation root.
-            msg = f'topdir {topdir} is not a west installation root'
+            # Verify topdir is a real west workspace root.
+            msg = f'topdir {topdir} is not a west workspace root'
             try:
                 real_topdir = util.west_topdir(start=topdir, fall_back=False)
             except util.WestNotFound:
@@ -265,7 +265,7 @@ class Manifest:
 
             - ``projects``: sequence of `Project`
 
-            - ``topdir``: west installation top level directory, or
+            - ``topdir``: west workspace top level directory, or
               None
 
             - ``path``: path to the manifest file itself, or None
@@ -324,7 +324,7 @@ class Manifest:
             string containing unparsed YAML data
         :param manifest_path: fallback `ManifestProject` ``path``
             attribute
-        :param topdir: used as the west installation top level
+        :param topdir: used as the west workspace top level
             directory
         :param importer: callback to resolve missing manifest import
             data
@@ -370,7 +370,7 @@ class Manifest:
         '''
 
         self.topdir = topdir
-        '''The west installation's top level directory, or None.'''
+        '''The west workspace's top level directory, or None.'''
 
         self.has_imports = False
 
@@ -972,7 +972,7 @@ class Project:
     - ``url``: project fetch URL
     - ``revision``: revision to fetch from ``url`` when the
       project is updated
-    - ``path``: relative path to the project within the installation
+    - ``path``: relative path to the project within the workspace
       (i.e. from ``topdir`` if that is set)
     - ``abspath``: absolute path to the project in the native path name
       format (or ``None`` if ``topdir`` is)
@@ -983,7 +983,7 @@ class Project:
       if this is used)
     - ``west_commands``: list of places to find extension commands in
       the project
-    - ``topdir``: the top level directory of the west installation
+    - ``topdir``: the top level directory of the west workspace
       the project is part of, or ``None``
     '''
 
@@ -1015,7 +1015,7 @@ class Project:
         :param west_commands: path to west commands directory in the
             project, relative to its own base directory, topdir / path,
             or list of these
-        :param topdir: the west installation's top level directory
+        :param topdir: the west workspace's top level directory
         '''
 
         self.name = name
@@ -1274,10 +1274,10 @@ class ManifestProject(Project):
     Meaningful attributes:
 
     - ``name``: the string ``"manifest"``
-    - ``topdir``: the top level directory of the west installation
+    - ``topdir``: the top level directory of the west workspace
       the manifest project controls, or ``None``
     - ``path``: relative path to the manifest repository within the
-      installation, or ``None`` (i.e. from ``topdir`` if that is set)
+      workspace, or ``None`` (i.e. from ``topdir`` if that is set)
     - ``abspath``: absolute path to the manifest repository in the
       native path name format (or ``None`` if ``topdir`` is)
     - ``posixpath``: like ``abspath``, but with slashes (``/``) as
@@ -1302,10 +1302,10 @@ class ManifestProject(Project):
     def __init__(self, path=None, west_commands=None, topdir=None):
         '''
         :param path: Relative path to the manifest repository in the
-            west installation, if known.
+            west workspace, if known.
         :param west_commands: path to the YAML file in the manifest
             repository configuring its extension commands, if any.
-        :param topdir: Root of the west installation the manifest
+        :param topdir: Root of the west workspace the manifest
             project is inside. If not given, all absolute path
             attributes (abspath and posixpath) will be None.
         '''
@@ -1407,7 +1407,7 @@ def _mpath(cp=None, topdir=None):
     # Return the value of the manifest.path configuration option
     # in *cp*, a ConfigParser. If not given, create a new one and
     # load configuration options with the given *topdir* as west
-    # installation root.
+    # workspace root.
     #
     # TODO: write a cfg.get(section, key)
     # wrapper, with friends for update and delete, to avoid

--- a/src/west/util.py
+++ b/src/west/util.py
@@ -51,10 +51,10 @@ def wrap(text, indent):
                          subsequent_indent=indent)
 
 class WestNotFound(RuntimeError):
-    '''Neither the current directory nor any parent has a West installation.'''
+    '''Neither the current directory nor any parent has a west workspace.'''
 
 def west_dir(start=None):
-    '''Returns the absolute path of the installation's .west directory.
+    '''Returns the absolute path of the workspace's .west directory.
 
     Starts the search from the start directory, and goes to its
     parents. If the start directory is not specified, the current
@@ -85,6 +85,6 @@ def west_topdir(start=None, fall_back=True):
                 return west_topdir(os.environ['ZEPHYR_BASE'],
                                    fall_back=False)
             else:
-                raise WestNotFound('Could not find a West installation '
+                raise WestNotFound('Could not find a West workspace '
                                    'in this or any parent directory')
         cur_dir = parent_dir

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -112,7 +112,7 @@ def _session_repos():
 def repos_tmpdir(tmpdir, _session_repos):
     '''Fixture for tmpdir with "remote" repositories.
 
-    These can then be used to bootstrap an installation and run
+    These can then be used to bootstrap a workspace and run
     project-related commands on it with predictable results.
 
     Switches directory to, and returns, the top level tmpdir -- NOT
@@ -177,15 +177,15 @@ def west_init_tmpdir(repos_tmpdir):
     '''Fixture for a tmpdir with 'remote' repositories and 'west init' run.
 
     Uses the remote repositories from the repos_tmpdir fixture to
-    create a west installation using the system bootstrapper's init
+    create a west workspace using the system bootstrapper's init
     command.
 
-    The contents of the west installation aren't checked at all.
+    The contents of the west workspace aren't checked at all.
     This is left up to the test cases.
 
     The directory that 'west init' created is returned as a
     py.path.local, with the current working directory set there.'''
-    west_tmpdir = repos_tmpdir / 'west_installation'
+    west_tmpdir = repos_tmpdir / 'workspace'
     manifest = repos_tmpdir / 'repos' / 'zephyr'
     cmd(f'init -m "{manifest}" "{west_tmpdir}"')
     west_tmpdir.chdir()

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -27,7 +27,7 @@ THIS_DIRECTORY = os.path.dirname(__file__)
 
 @pytest.fixture
 def fs_topdir(tmpdir):
-    # This fixture creates a skeletal west installation in a temporary
+    # This fixture creates a skeletal west workspace in a temporary
     # directory on the file system, and changes directory there.
     #
     # If you use this fixture, you can create
@@ -44,7 +44,7 @@ def fs_topdir(tmpdir):
     topdir.join('.west', 'config').write('[manifest]\n'
                                          'path = mp\n')
 
-    # Switch to the top-level West installation directory,
+    # Switch to the top-level west workspace directory,
     # and give it to the test case.
     topdir.chdir()
     return topdir
@@ -903,7 +903,7 @@ def make_importer(import_map):
     # This, makes it easier to set up tests cases where import
     # resolution can be done entirely with data in this file. That's
     # faster (both when writing tests and running them) than setting
-    # up a west installation on the file system.
+    # up a west workspace on the file system.
 
     def importer(project, file):
         return import_map[(project.name, file)]
@@ -1087,7 +1087,7 @@ def test_import_with_fork_and_proj():
 #
 # This tests "Downstream with directory of manifest files" in the
 # documentation. We do the testing in a tmpdir with just enough
-# files to fake out an installation.
+# files to fake out a workspace.
 _IMPORT_SELF_MANIFESTS = [
     # as a directory:
     '''\

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -54,7 +54,7 @@ def west_update_tmpdir(west_init_tmpdir):
 # Test cases
 #
 
-def test_installation(west_update_tmpdir):
+def test_workspace(west_update_tmpdir):
     # Basic test that west_update_tmpdir bootstrapped correctly. This
     # is a basic test of west init and west update.
 
@@ -333,14 +333,14 @@ def test_init_again(west_init_tmpdir):
 
 def test_init_local_manifest_project(repos_tmpdir):
     # Do a local clone of manifest repo
-    zephyr_install_dir = repos_tmpdir.join('west_installation', 'zephyr')
+    zephyr_install_dir = repos_tmpdir.join('workspace', 'zephyr')
     clone(str(repos_tmpdir.join('repos', 'zephyr')),
           str(zephyr_install_dir))
 
     cmd(f'init -l "{zephyr_install_dir}"')
 
     # Verify Zephyr has been installed during init -l, but not projects.
-    zid = repos_tmpdir.join('west_installation')
+    zid = repos_tmpdir.join('workspace')
     assert zid.check(dir=1)
     assert zid.join('subdir', 'Kconfiglib').check(dir=0)
     assert zid.join('net-tools').check(dir=0)
@@ -376,7 +376,7 @@ def test_init_local_missing_west_yml_failure(repos_tmpdir):
     # Test that 'west init -l' on repo without a 'west.yml' fails
 
     # Do a local clone of manifest repo
-    zephyr_install_dir = repos_tmpdir.join('west_installation', 'zephyr')
+    zephyr_install_dir = repos_tmpdir.join('workspace', 'zephyr')
     clone(str(repos_tmpdir.join('repos', 'zephyr')),
           str(zephyr_install_dir))
     os.remove(str(zephyr_install_dir.join('west.yml')))
@@ -452,7 +452,7 @@ def test_extension_command_multiproject(repos_tmpdir):
                               print('Testing kconfig test')
                       '''),
                       })
-    west_tmpdir = repos_tmpdir / 'west_installation'
+    west_tmpdir = repos_tmpdir / 'workspace'
     zephyr = repos_tmpdir / 'repos' / 'zephyr'
     cmd(f'init -m "{zephyr}" "{west_tmpdir}"')
     west_tmpdir.chdir()
@@ -532,7 +532,7 @@ def test_extension_command_duplicate(repos_tmpdir):
                               print('Testing kconfig test command')
                       '''),
                       })
-    west_tmpdir = repos_tmpdir / 'west_installation'
+    west_tmpdir = repos_tmpdir / 'workspace'
     zephyr = repos_tmpdir / 'repos' / 'zephyr'
     cmd(f'init -m "{zephyr}" "{west_tmpdir}"')
     west_tmpdir.chdir()
@@ -548,14 +548,14 @@ def test_extension_command_duplicate(repos_tmpdir):
     assert actual == expected
 
 def test_topdir_none(tmpdir):
-    # Running west topdir outside of any installation ought to fail.
+    # Running west topdir outside of any workspace ought to fail.
 
     tmpdir.chdir()
     with pytest.raises(subprocess.CalledProcessError):
         cmd('topdir')
 
-def test_topdir_in_installation(west_init_tmpdir):
-    # Running west topdir anywhere inside of an installation ought to
+def test_topdir_in_workspace(west_init_tmpdir):
+    # Running west topdir anywhere inside of a workspace ought to
     # work, and return the same thing.
 
     expected = str(west_init_tmpdir)
@@ -610,7 +610,7 @@ def default_updater(remotes):
 
 def update_helper(west_tmpdir, updater=default_updater):
     # Helper command for causing a change in two remote repositories,
-    # then running a project command on the west installation.
+    # then running a project command on the west workspace.
     #
     # Adds a commit to both of the kconfiglib and net-tools projects
     # remotes, then call updater(update_remotes),


### PR DESCRIPTION
DNM, depends on: https://github.com/zephyrproject-rtos/west/pull/351

This adds a commit `tree-wide: rename "installation" to "workspace" `, which reflects some discussions we've had around doing just that.

cc: @marc-hb 