### PR TITLE
Housekeeping: miscellaneous things

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -15,4 +15,4 @@ build:
     - export PATH=$PATH:$HOME/.local/bin
     - pip3 install tox
     - mkdir -p shippable/{testresults,codecoverage}
-    - tox -- --junitxml=$PWD/shippable/testresults/nosetests.xml --cov=west --cov-report=xml:$PWD/shippable/codecoverage/coverage.xml tests
+    - tox -- --junitxml=$PWD/shippable/testresults/nosetests.xml --cov-report=xml:$PWD/shippable/codecoverage/coverage.xml tests

--- a/.shippable.yml
+++ b/.shippable.yml
@@ -14,8 +14,5 @@ build:
     - python3 --version
     - export PATH=$PATH:$HOME/.local/bin
     - pip3 install tox
-    # This setuptools upgrade is only needed for find_namespace_packages().
-    # We can eliminate it if we make west a non-namespace package again.
-    - pip3 install --upgrade setuptools
     - mkdir -p shippable/{testresults,codecoverage}
     - tox -- --junitxml=$PWD/shippable/testresults/nosetests.xml --cov=west --cov-report=xml:$PWD/shippable/codecoverage/coverage.xml tests

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 # Copyright 2018 Open Source Foundries Limited.
+# Copyright (c) 2020, Nordic Semiconductor ASA
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -26,7 +27,7 @@ setuptools.setup(
     # http://docutils.sourceforge.net/FAQ.html#what-s-the-official-mime-type-for-restructuredtext-data
     long_description_content_type="text/x-rst",
     url='https://github.com/zephyrproject-rtos/west',
-    packages=setuptools.find_namespace_packages(where='src'),
+    packages=setuptools.find_packages(where='src'),
     package_dir={'': 'src'},
     include_package_data=True,
     classifiers=[
@@ -41,7 +42,7 @@ setuptools.setup(
         'PyYAML>=5.1',
         'pykwalify',
         'configobj',
-        'setuptools>=v40.1.0',  # for find_namespace_packages
+        'setuptools',
         'packaging',
     ],
     python_requires='>=3.6',

--- a/src/west/__init__.py
+++ b/src/west/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2020, Nordic Semiconductor ASA
+
+# nothing here

--- a/src/west/version.py
+++ b/src/west/version.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2019, Nordic Semiconductor ASA
+#
 # Don't put anything else in here!
 #
 # This is the Python 3 version of option 3 in:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019, Nordic Semiconductor ASA
+# Copyright (c) 2019, 2020 Nordic Semiconductor ASA
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2020, Nordic Semiconductor ASA
+
 import itertools
 
 import os

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1,4 +1,5 @@
 # Copyright 2018 Foundries.io Ltd
+# Copyright (c) 2020, Nordic Semiconductor ASA
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2020, Nordic Semiconductor ASA
+
 import collections
 import os
 import re

--- a/tox.ini
+++ b/tox.ini
@@ -23,5 +23,5 @@ whitelist_externals =
 setenv =
     TOXTEMPDIR={envtmpdir}
 commands =
-  py.test {posargs:tests}
+  py.test --cov=west {posargs:tests}
   flake8 --config={toxinidir}/tox.ini {toxinidir}


### PR DESCRIPTION
DNM, depends on these two:

- https://github.com/zephyrproject-rtos/west/pull/351
- https://github.com/zephyrproject-rtos/west/pull/352

A few miscellaneous commits to tidy up:

- `packaging: west is no longer a namespace package`
- `tree-wide: add python file copyright headers`
- `tests: enable coverage testing for plain 'tox'`

