### PR TITLE
Manifest and west init bug fixes and test cases

### DIFF
--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -808,8 +808,8 @@ class Manifest:
 
         imptype = type(imp)
         if imptype == bool:
-            if imp is False:
-                return
+            # We should not have been called unless the import was truthy.
+            assert imp
             self._import_path_from_project(project, _WEST_YML, projects)
         elif imptype == str:
             self._import_path_from_project(project, imp, projects)
@@ -1392,12 +1392,6 @@ _EARLIEST_VER_STR = '0.6.99'  # we introduced the version feature after 0.6
 _EARLIEST_VER = parse_version(_EARLIEST_VER_STR)
 _DEFAULT_REV = 'master'
 
-def _quote_maybe(string):
-    if string:
-        return f'"{string}"'
-    else:
-        return None
-
 @lru_cache(maxsize=1)
 def _warn_once_if_no_git():
     # Using an LRU cache means this gets called once. Afterwards, the
@@ -1423,9 +1417,6 @@ def _mpath(cp=None, topdir=None):
         return cp.get('manifest', 'path')
     except (configparser.NoOptionError, configparser.NoSectionError) as e:
         raise MalformedConfig('no "manifest.path" config option is set') from e
-
-def _west_yml(topdir):
-    return os.path.join(topdir, _mpath(topdir=topdir), _WEST_YML)
 
 def _manifest_content_at(project, path, rev=QUAL_MANIFEST_REV_BRANCH):
     # Get a list of manifest data from project at path

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -1454,7 +1454,7 @@ def _manifest_content_at(project, path, rev=QUAL_MANIFEST_REV_BRANCH):
         # Importing a tree: return the content of the YAML files inside it.
         ret = []
         pathobj = PurePath(path)
-        for f in filter(_is_yml, project.listdir_at(path)):
+        for f in filter(_is_yml, project.listdir_at(path, rev=rev)):
             ret.append(project.read_at(str(pathobj / f),
                                        rev=rev).decode('utf-8'))
         return ret

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -1199,7 +1199,7 @@ class Project:
     def is_up_to_date(self, cwd=None):
         '''Check if the project HEAD is up to date with the manifest.
 
-        This is equivalent to ``is_up_to_date_with(self,revision,
+        This is equivalent to ``is_up_to_date_with(self.revision,
         cwd=cwd)``.
 
         :param cwd: directory to run command in (default:

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -79,7 +79,12 @@ def validate(data):
     :param data: YAML manifest data as a string or object
     '''
     if isinstance(data, str):
+        as_str = data
         data = yaml.safe_load(data)
+        if not isinstance(data, dict):
+            raise MalformedManifest(f'{as_str} is not a YAML dictionary')
+    elif not isinstance(data, dict):
+        raise TypeError(f'data type {type(data)} must be str or dict')
 
     if 'manifest' not in data:
         raise MalformedManifest('manifest data contains no "manifest" key')

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -840,6 +840,7 @@ class Manifest:
         for data in imported:
             if isinstance(data, str):
                 data = yaml.safe_load(data)
+                validate(data)
             try:
                 # Force a fallback onto manifest_path=project.path.
                 # The subpath to the manifest file itself will not be

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -80,7 +80,7 @@ def validate(data):
     '''
     if isinstance(data, str):
         as_str = data
-        data = yaml.safe_load(data)
+        data = _load(data)
         if not isinstance(data, dict):
             raise MalformedManifest(f'{as_str} is not a YAML dictionary')
     elif not isinstance(data, dict):
@@ -352,7 +352,7 @@ class Manifest:
             self._malformed('manifest contains no data')
 
         if isinstance(source_data, str):
-            source_data = yaml.safe_load(source_data)
+            source_data = _load(source_data)
 
         # Validate the manifest. Wrap a couple of the exceptions with
         # extra context about the problematic file in case of errors,
@@ -839,7 +839,7 @@ class Manifest:
 
         for data in imported:
             if isinstance(data, str):
-                data = yaml.safe_load(data)
+                data = _load(data)
                 validate(data)
             try:
                 # Force a fallback onto manifest_path=project.path.
@@ -1474,3 +1474,9 @@ def _is_yml(path):
 
 def _default_importer(project, file):
     raise ManifestImportFailed(project, file)
+
+def _load(data):
+    try:
+        return yaml.safe_load(data)
+    except yaml.scanner.ScannerError as e:
+        raise MalformedManifest(data) from e

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -1267,7 +1267,7 @@ class Project:
 
         # A tab character separates the SHA from the file name in each
         # NUL-separated entry.
-        return [f.decode(encoding).split('\t', 1)[1:]
+        return [f.decode(encoding).split('\t', 1)[1]
                 for f in out.split(b'\x00') if f]
 
 # FIXME: this whole class should just go away. See #327.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,8 +67,7 @@ def _session_repos():
                       'subsys/bluetooth/code.c': 'void foo(void) {}\n'})
 
     # Initialize the Kconfiglib repository.
-    subprocess.check_call([GIT, 'checkout', '-b', 'zephyr'],
-                          cwd=rp['Kconfiglib'])
+    create_branch(rp['Kconfiglib'], 'zephyr', checkout=True)
     add_commit(rp['Kconfiglib'], 'test kconfiglib commit',
                files={'kconfiglib.py': 'print("hello world kconfiglib")\n'})
 
@@ -258,6 +257,15 @@ def config_repo(path):
                            'west-test@example.com'],
                           cwd=path)
 
+def create_branch(path, branch, checkout=False):
+    subprocess.check_call([GIT, 'branch', branch], cwd=path)
+    if checkout:
+        checkout_branch(path, branch)
+
+def checkout_branch(path, branch, detach=False):
+    detach = ['--detach'] if detach else []
+    subprocess.check_call([GIT, 'checkout', branch] + detach,
+                          cwd=path)
 
 def add_commit(repo, msg, files=None, reconfigure=True):
     # Adds a commit with message 'msg' to the repo in 'repo'


### PR DESCRIPTION
~DNM, depends on these housekeeping pull requests:~

- https://github.com/zephyrproject-rtos/west/pull/351 (now merged)
- https://github.com/zephyrproject-rtos/west/pull/352 (now merged)
- https://github.com/zephyrproject-rtos/west/pull/353 (now merged)

The commit log for the final commit sums this up pretty well:

```
Add additional line coverage for manifest.py using output from pycov.

I'm pretty happy with the resulting level of statement coverage (94%)
and the number of bugs that got shaken out by writing these (5 real
ones along with a couple of other improvements).

The remaining 6% is mostly trivial or part of the unimplemented
functions needed to import maps. The trivial stuff can get addressed
some other day if we're interested in getting to 100%, but I think
it's time to move on to implementing map imports after this, now that
we've got better test coverage for the manifest API in general and its
basic import feature in particular.
```

There are also a few fixes for `west init` in here.