### PR TITLE
ci: move west to a different node pool

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -1,3 +1,6 @@
+runtime:
+  nodePool: large_nodes
+
 language: python
 # TODO: 3.7 and 3.8 need testing here.
 python:


### PR DESCRIPTION
This new pool uses large nodes and suitable for anything that does not
run sanitycheck. The queue for this pool is not as a long as with the
2XL pool which will give west instant results instead of waiting for 2XL
node to finish sanitycheck.