### PR TITLE
Logging reorg

### DIFF
--- a/src/west/app/project.py
+++ b/src/west/app/project.py
@@ -485,7 +485,7 @@ class ManifestCommand(_ProjectCommand):
         #
         # The code in main.py is responsible for handling any errors
         # and printing useful messages.
-        manifest = Manifest.from_file()
+        manifest = Manifest.from_file(topdir=self.topdir)
         dump_kwargs = {'default_flow_style': False,
                        'sort_keys': False}
 

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -85,7 +85,8 @@ def validate(data):
         if not isinstance(data, dict):
             raise MalformedManifest(f'{as_str} is not a YAML dictionary')
     elif not isinstance(data, dict):
-        raise TypeError(f'data type {type(data)} must be str or dict')
+        raise TypeError(f'{data} has type {type(data)}, '
+                        'expected valid manifest data')
 
     if 'manifest' not in data:
         raise MalformedManifest('manifest data contains no "manifest" key')
@@ -363,6 +364,8 @@ class Manifest:
             raise ManifestVersionError(mv.version, file=source_file) from mv
         except MalformedManifest as mm:
             self._malformed(mm.args[0], parent=mm)
+        except TypeError as te:
+            self._malformed(te.args[0], parent=te)
 
         self.projects = None
         '''Sequence of `Project` objects representing manifest

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -118,7 +118,6 @@ def validate(data):
     except pykwalify.errors.SchemaError as se:
         raise MalformedManifest(se._msg) from se
 
-# TODO rewrite without enum.IntFlag if we can't move to python 3.6+
 class ImportFlag(enum.IntFlag):
     '''Bit flags for handling imports when resolving a manifest.
 

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -1235,9 +1235,7 @@ class Project:
         elif rc == 1:
             return False
         else:
-            log.wrn(f'{self.name_and_path}: git failed with exit code {rc}; '
-                    f'treating as if "{rev1}" is not an ancestor of "{rev2}"')
-            return False
+            raise RuntimeError(f'unexpected git merge-base result {rc}')
 
     def is_up_to_date_with(self, rev, cwd=None):
         '''Check if the project is up to date with *rev*, returning

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -541,9 +541,11 @@ class Manifest:
         # manifest data, which must be validated according to the schema.
 
         if self.path:
-            _logger.debug(f'loading file {self.path}')
+            loading_what = f'file {self.path}'
         else:
-            _logger.debug('loading data (no file was given)')
+            loading_what = 'data (no file)'
+
+        _logger.debug(f'loading {loading_what}')
 
         # We want to make an ordered map from project names to
         # corresponding Project instances. Insertion order into this
@@ -580,6 +582,8 @@ class Manifest:
                     # can have a topdir but no path, and thus no abspath.
                     continue
                 self._projects_by_cpath[util.canon_path(p.abspath)] = p
+
+        _logger.debug(f'loaded {loading_what}')
 
     def _load_self(self, manifest, path_hint, projects):
         # Handle the "self:" section in the manifest data.
@@ -646,29 +650,27 @@ class Manifest:
         if mp.abspath:
             # Fast path, when we're working inside a fully initialized
             # topdir.
-            log.dbg('manifest repository root:', mp.abspath,
-                    level=log.VERBOSE_EXTREME)
             repo_root = Path(mp.abspath)
         else:
             # Fallback path, which is needed by at least west init. If
             # this happens too often, something may be wrong with how
             # we've implemented this. We'd like to avoid too many git
             # commands, as subprocesses are slow on windows.
-            log.dbg('searching for the manifest repository root',
-                    level=log.VERBOSE_EXTREME)
+            start = Path(self.path).parent
+            _logger.debug(
+                f'searching for manifest repository root from {start}')
             repo_root = Path(mp.git('rev-parse --show-toplevel',
                                     capture_stdout=True,
-                                    cwd=str(Path(self.path).parent)).
+                                    cwd=start).
                              stdout[:-1].      # chop off newline
                              decode('utf-8'))  # hopefully this is safe
         p = repo_root / imp
 
         if p.is_file():
-            log.dbg(f'found submanifest: {p}', level=log.VERBOSE_EXTREME)
+            _logger.debug(f'found submanifest file: {p}')
             self._import_pathobj_from_self(mp, p, projects)
         elif p.is_dir():
-            log.dbg(f'found directory of submanifests: {p}',
-                    level=log.VERBOSE_EXTREME)
+            _logger.debug(f'found submanifest directory: {p}')
             for yml in filter(_is_yml, sorted(p.iterdir())):
                 self._import_pathobj_from_self(mp, p / yml, projects)
         else:
@@ -737,14 +739,13 @@ class Manifest:
             # Add the project to the map if it's new.
             added = self._add_project(project, projects)
             if added:
-                log.dbg(f'manifest file {self.path}: added {project}',
-                        level=log.VERBOSE_EXTREME)
+                _logger.debug(f'added {project} from file {self.path}')
                 # Track project imports unless we are ignoring those.
                 imp = pd.get('import')
                 if imp:
                     if self._import_flags & ImportFlag.IGNORE:
-                        log.dbg(f'project {project} import {imp} ignored',
-                                level=log.VERBOSE_EXTREME)
+                        _logger.debug(
+                            f'project {project}: ignored import ({imp})')
                     else:
                         have_imports.append((project, imp))
 
@@ -863,9 +864,7 @@ class Manifest:
                     self._add_project(subp, projects)
 
     def _import_content_from_project(self, project, path):
-        log.dbg(f'manifest file {self.path}: resolving import {path} '
-                f'for {project}',
-                level=log.VERBOSE_EXTREME)
+        _logger.debug(f'resolving import {path} for {project}')
         if not (self._import_flags & ImportFlag.FORCE_PROJECTS) and \
            project.is_cloned():
             try:
@@ -1174,7 +1173,7 @@ class Project:
         args = ['git'] + cmd_list + extra_args
         cmd_str = util.quote_sh_list(args)
 
-        log.dbg(f"running '{cmd_str}' in {cwd}", level=log.VERBOSE_VERY)
+        _logger.debug(f"running '{cmd_str}' in {cwd}")
         popen = subprocess.Popen(
             args, cwd=cwd,
             stdout=subprocess.PIPE if capture_stdout else None,
@@ -1182,13 +1181,12 @@ class Project:
 
         stdout, stderr = popen.communicate()
 
-        if log.VERBOSE >= log.VERBOSE_VERY:
-            dbg_msg = f"{cmd_str} exit code: {popen.returncode}"
-            if capture_stdout:
-                dbg_msg += f'\ncaptured stdout:\n{stdout}'
-            if capture_stderr:
-                dbg_msg += f'\ncaptured stderr:\n{stderr}'
-            log.dbg(dbg_msg, level=log.VERBOSE_VERY)
+        # We use logger style % formatting here to avoid the
+        # potentially expensive overhead of formatting long
+        # stdout/stderr strings if the current log level isn't DEBUG,
+        # which is the usual case.
+        _logger.debug('"%s" exit code: %d stdout: %r stderr: %r',
+                      cmd_str, popen.returncode, stdout, stderr)
 
         if check and popen.returncode:
             raise subprocess.CalledProcessError(popen.returncode, cmd_list,
@@ -1276,7 +1274,7 @@ class Project:
         # the top-level directory of a Git repository. Use --show-cdup
         # instead, which prints an empty string (i.e., just a newline,
         # which we strip) for the top-level directory.
-        log.dbg(f'{self.name}: checking if cloned', level=log.VERBOSE_EXTREME)
+        _logger.debug(f'{self.name}: checking if cloned')
         res = self.git('rev-parse --show-cdup', check=False,
                        capture_stderr=True, capture_stdout=True)
 
@@ -1483,8 +1481,7 @@ def _manifest_content_at(project, path, rev=QUAL_MANIFEST_REV_BRANCH):
     # Though this module and the "west update" implementation share
     # this code, it's an implementation detail, not API.
 
-    log.dbg(f'{project.name}: looking up path {path} type at {rev}',
-            level=log.VERBOSE_EXTREME)
+    _logger.debug(f'{project.name}: looking up path {path} type at {rev}')
 
     # Returns 'blob', 'tree', etc. for path at revision, if it exists.
     out = project.git(['ls-tree', rev, path], capture_stdout=True,

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -11,10 +11,8 @@ import collections
 import configparser
 import enum
 import errno
-from functools import lru_cache
 import os
 from pathlib import PurePath, Path
-import shutil
 import shlex
 import subprocess
 
@@ -1156,8 +1154,6 @@ class Project:
             raised if git finishes with a non-zero return code
         :param cwd: directory to run git in (default: ``self.abspath``)
         '''
-        _warn_once_if_no_git()
-
         if isinstance(cmd, str):
             cmd_list = shlex.split(cmd)
         else:
@@ -1451,14 +1447,6 @@ _SCHEMA_VER = parse_version(SCHEMA_VERSION)
 _EARLIEST_VER_STR = '0.6.99'  # we introduced the version feature after 0.6
 _EARLIEST_VER = parse_version(_EARLIEST_VER_STR)
 _DEFAULT_REV = 'master'
-
-@lru_cache(maxsize=1)
-def _warn_once_if_no_git():
-    # Using an LRU cache means this gets called once. Afterwards, the
-    # (nonexistent) memoized result is simply returned from the cache,
-    # so the warning is emitted only once per process invocation.
-    if shutil.which('git') is None:
-        log.wrn('Git is not installed or cannot be found')
 
 def _mpath(cp=None, topdir=None):
     # Return the value of the manifest.path configuration option

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -635,7 +635,7 @@ class Manifest:
             for subimp in imp:
                 self._import_from_self(mp, subimp, projects)
         elif imptype == dict:
-            self._import_map(mp, imp, self.import_path_from_self, projects)
+            self._import_map(mp, imp, self._import_path_from_self, projects)
         else:
             self._malformed(f'{mp.abspath}: "self: import: {imp}" '
                             f'has invalid type {imptype}')


### PR DESCRIPTION
This replaces direct use of west.log from west.manifest with the standard python logging module. There are a few miscellaneous fixes I found along the way.

While doing this, I figured out why our logging in `west -v manifest --resolve` is incorrectly printing messages about some projects being added (in particular, it prints them twice). I won't fix this in this PR, though, as we'll need to start passing an additional "don't log" keyword argument when doing some types of recursive manifest loads, and respecting it.

I will need a bit more time to look at the code paths and implement that.
