### PR TITLE
Manifest import tweaks

### DIFF
--- a/src/west/app/project.py
+++ b/src/west/app/project.py
@@ -901,14 +901,10 @@ def _maybe_sha(rev):
 def _clone(project):
     log.small_banner(f'{project.name}: cloning and initializing')
     project.git(f'init {project.abspath}', cwd=util.west_topdir())
-    # The "origin" remote is added to follow the practice that 'origin'
-    # is the remote a Git repository was always cloned from.
-    #
-    # However, west doesn't fetch from this remote: it always forms
-    # a fetch URL from the manifest file and fetches that directly.
-    #
-    # The URL of this remote can thus be changed by the user at will.
-    project.git(f'remote add -- origin {project.url}')
+    # This remote is added as a convenience for the user.
+    # However, west always fetches project data by URL, not remote name.
+    # The user is therefore free to change the URL of this remote.
+    project.git(f'remote add -- {project.remote_name} {project.url}')
 
 def _rev_type(project, rev=None):
     # Returns a "refined" revision type of rev (default:

--- a/src/west/commands.py
+++ b/src/west/commands.py
@@ -167,6 +167,12 @@ class WestCommand(ABC):
     #
 
     @property
+    def has_manifest(self):
+        '''Property which is True if self.manifest is safe to access.
+        '''
+        return self._manifest is not None
+
+    @property
     def manifest(self):
         '''Property for the manifest which was passed to run().
 

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -820,7 +820,7 @@ class Manifest:
         return Project(name, url, pd.get('revision', defaults.revision),
                        pd.get('path', name), clone_depth=pd.get('clone-depth'),
                        west_commands=pd.get('west-commands'),
-                       topdir=self.topdir)
+                       topdir=self.topdir, remote_name=remote)
 
     def _import_from_project(self, project, imp, projects, filter_fn):
         # Recursively resolve a manifest import from 'project'.
@@ -1056,6 +1056,8 @@ class Project:
       the project
     - ``topdir``: the top level directory of the west workspace
       the project is part of, or ``None``
+    - ``remote_name``: the name of the remote which should be set up
+      when the project is being cloned (default: 'origin')
     '''
 
     def __eq__(self, other):
@@ -1072,7 +1074,8 @@ class Project:
         return f'<Project {self.name} ({path_repr}) at {self.revision}>'
 
     def __init__(self, name, url, revision=None, path=None,
-                 clone_depth=None, west_commands=None, topdir=None):
+                 clone_depth=None, west_commands=None, topdir=None,
+                 remote_name=None):
         '''Project constructor.
 
         If *topdir* is ``None``, then absolute path attributes
@@ -1087,6 +1090,8 @@ class Project:
             project, relative to its own base directory, topdir / path,
             or list of these
         :param topdir: the west workspace's top level directory
+        :param remote_name: the name of the remote which should be
+            set up if the project is being cloned (default: 'origin')
         '''
 
         self.name = name
@@ -1096,6 +1101,7 @@ class Project:
         self.clone_depth = clone_depth
         self.west_commands = west_commands
         self.topdir = topdir
+        self.remote_name = remote_name or 'origin'
 
     @property
     def path(self):


### PR DESCRIPTION
DNM, depends on https://github.com/zephyrproject-rtos/west/pull/363

This pull request covers some remaining work in manifest imports:

- git repository remote names match west manifest remote names on clone again 
- we allow west update on projects defined in the manifest repository, even if there are imports
- don't update projects twice when we've already done so via imports