### PR TITLE
topdir: west topdir prints posix style path.

### DIFF
--- a/src/west/app/project.py
+++ b/src/west/app/project.py
@@ -1062,7 +1062,7 @@ class Topdir(_ProjectCommand):
         return self._parser(parser_adder)
 
     def do_run(self, args, user_args):
-        log.inf(self.topdir)
+        log.inf(PurePath(self.topdir).as_posix())
 
 class SelfUpdate(_ProjectCommand):
     def __init__(self):

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -6,6 +6,7 @@ import re
 import shlex
 import subprocess
 import textwrap
+from pathlib import PurePath
 
 import pytest
 
@@ -653,7 +654,7 @@ def test_topdir_in_workspace(west_init_tmpdir):
     # Running west topdir anywhere inside of a workspace ought to
     # work, and return the same thing.
 
-    expected = str(west_init_tmpdir)
+    expected = PurePath(str(west_init_tmpdir)).as_posix()
 
     # This should be available immediately after west init.
     assert cmd('topdir').strip() == expected


### PR DESCRIPTION
Fixes: #374

This commit ensures that west topdir always prints in posix style and
thus fixes an issue in windows where CMake fails to parse the path when
'\' is used as separator.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>