### PR TITLE
zephyr base: Fixes issue with failing to discover Zephyr base

### DIFF
--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -459,7 +459,10 @@ class Manifest:
             else:
                 project = self._projects_by_name.get(pid)
             if project is None and allow_paths:
-                project = self._projects_by_cpath.get(util.canon_path(pid))
+                if pid == self.projects[MANIFEST_PROJECT_INDEX].path:
+                    project = self.projects[MANIFEST_PROJECT_INDEX]
+                else:
+                    project = self._projects_by_cpath.get(util.canon_path(pid))
 
             if project is None:
                 unknown.append(pid)


### PR DESCRIPTION
Fixes: #378

When Zephyr is also the manifest repository then west fails to identify
ZEPHYR_BASE correctly as the project name is manifest, with path zephyr.

Therefore, before checking projects with path `zephyr` we first check if
the manifest repository has path == zephyr.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>