### PR TITLE
Fix update verbosity

### DIFF
--- a/src/west/app/project.py
+++ b/src/west/app/project.py
@@ -1314,8 +1314,6 @@ def die_if_no_git():
 # Top-level west directory, containing west itself and the manifest.
 WEST_DIR = '.west'
 
-# Manifest repository directory under WEST_DIR.
-MANIFEST = 'manifest'
 # Default manifest repository URL.
 MANIFEST_URL_DEFAULT = 'https://github.com/zephyrproject-rtos/zephyr'
 # Default revision to check out of the manifest repository.

--- a/src/west/app/project.py
+++ b/src/west/app/project.py
@@ -848,11 +848,16 @@ class Update(_ProjectCommand):
         if self.args.keep_descendants and is_ancestor:
             # A descendant is currently checked out and keep_descendants was
             # given, so there's nothing more to do.
-            log.small_banner(f'{project.name}: left descendant branch '
-                             f'"{current_branch}" checked out')
+            log.inf(f'west update: left descendant branch '
+                    f'"{current_branch}" checked out; current status:')
+            if take_stats:
+                start = perf_counter()
+            project.git('status')
+            if take_stats:
+                stats['get current status'] = perf_counter - start
         elif try_rebase:
             # Attempt a rebase.
-            log.small_banner(f'{project.name}: rebasing to {MANIFEST_REV}')
+            log.inf(f'west update: rebasing to {MANIFEST_REV} {sha}')
             if take_stats:
                 start = perf_counter()
             project.git('rebase ' + QUAL_MANIFEST_REV)
@@ -863,11 +868,9 @@ class Update(_ProjectCommand):
             # out the new detached HEAD, then print some helpful context.
             if take_stats:
                 start = perf_counter()
-            project.git('checkout --detach --quiet ' + sha)
+            project.git('checkout --detach ' + sha)
             if take_stats:
                 stats['checkout new manifest-rev'] = perf_counter() - start
-            log.small_banner(
-                f'{project.name}: checked out {sha} as detached HEAD')
             _post_checkout_help(project, current_branch, sha, is_ancestor)
 
         # Print performance statistics.


### PR DESCRIPTION
Fixes: #380 

I've tested the following matrix of west updates:

{descendant branch checked out + dirty tree,
 detached head + dirty tree,
 branch checked out + clean tree,
 detached descendant HEAD + clean tree}

x

{default behavior,
 --keep-descendants,
 --rebase}

And the output always warns when something surprising happens. The win is mostly due to removing the --quiet from the 'git checkout --detach' and letting git do the work for us.

I want to backport these changes to 0.7.2, so I'm intentionally preserving the existing --keep-descendants behavior. We can defer changes to that to 0.8.0 pending resolution of https://github.com/zephyrproject-rtos/west/issues/381.