### PR TITLE
Fix west command duplicate warnings

### DIFF
--- a/src/west/commands.py
+++ b/src/west/commands.py
@@ -216,6 +216,12 @@ class WestExtCommandSpec:
         It may do some additional steps (like importing the definition of
         the command) before constructing it, however.'''
 
+    def __repr__(self):
+        return (f'<WestExtCommandSpec name={repr(self.name)}'
+                f' project {self.project.name}'
+                f' help={repr(self.help)}'
+                f' factory={self.factory}>')
+
 def extension_commands(manifest=None):
     # Get descriptions of available extension commands.
     #

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -1018,8 +1018,13 @@ class Manifest:
         # Merge two west_commands attributes. Try to keep the result a
         # str if possible, but upgrade it to a list if both wc1 and
         # wc2 are truthy.
+        #
+        # Filter out duplicates to make sure that if the user imports
+        # a manifest and redundantly specifies its west-commands,
+        # we don't get the same entries twice.
         if wc1 and wc2:
-            return _ensure_list(wc1) + _ensure_list(wc2)
+            wc1 = _ensure_list(wc1)
+            return wc1 + [wc for wc in _ensure_list(wc2) if wc not in wc1]
         else:
             return wc1 or wc2
 


### PR DESCRIPTION
The import feature is printing spurious warnings for duplicated west extensions if the user imports a manifest *and* gives a west-commands that the imported manifest already declares. Fix it.

See commit log for the second patch for a detailed example.