### PR TITLE
west: initial support for type hints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ __pycache__/
 shippable/
 .tox/
 .coverage*
+.mypy_cache/
 

--- a/src/west/commands.py
+++ b/src/west/commands.py
@@ -9,6 +9,8 @@ import importlib
 import itertools
 import os
 import sys
+from types import ModuleType
+from typing import Dict
 
 import pykwalify
 import yaml
@@ -25,6 +27,16 @@ west commands subclass.
 This package also provides support for extension commands.'''
 
 __all__ = ['CommandContextError', 'CommandError', 'WestCommand']
+
+_EXT_SCHEMA_PATH = os.path.join(os.path.dirname(__file__),
+                                'west-commands-schema.yml')
+
+# Cache which maps files implementing extension commands to their
+# imported modules.
+_EXT_MODULES_CACHE: Dict[str, ModuleType] = {}
+# Infinite iterator of "fresh" extension command module names.
+_EXT_MODULES_NAME_IT = (f'west.commands.ext.cmd_{i}'
+                        for i in itertools.count(1))
 
 class CommandError(RuntimeError):
     '''Indicates that a command failed.'''
@@ -345,16 +357,6 @@ def _commands_module_from_file(file):
     _EXT_MODULES_CACHE[file] = mod
 
     return mod
-
-_EXT_SCHEMA_PATH = os.path.join(os.path.dirname(__file__),
-                                'west-commands-schema.yml')
-
-# Cache which maps files implementing extension commands to their
-# imported modules.
-_EXT_MODULES_CACHE = {}
-# Infinite iterator of "fresh" extension command module names.
-_EXT_MODULES_NAME_IT = (f'west.commands.ext.cmd_{i}'
-                        for i in itertools.count(1))
 
 class _ExtFactory:
 

--- a/src/west/log.py
+++ b/src/west/log.py
@@ -14,6 +14,7 @@ from west import configuration as config
 
 import colorama
 import sys
+from typing import NoReturn
 
 VERBOSE_NONE = 0
 '''Default verbosity level, no dbg() messages printed.'''
@@ -134,7 +135,7 @@ def err(*args, fatal=False):
     if _use_colors():
         _reset_colors(sys.stderr)
 
-def die(*args, exit_code=1):
+def die(*args, exit_code=1) -> NoReturn:
     '''Print a fatal error, and abort the program.
 
     :param args: sequence of arguments to print.

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,10 @@ ignore = E126,E261,E302,E305,W504
 # Don't lint setup.py, the .tox virtualenv directory, or the build directory
 exclude = setup.py,.tox,build
 
+[mypy]
+mypy_path=src
+ignore_missing_imports=True
+
 [testenv]
 deps = -rtox_deps.txt
 platform = posix: (linux|darwin)
@@ -25,4 +29,5 @@ setenv =
 passenv = WEST_SKIP_SLOW_TESTS
 commands =
   flake8 --config={toxinidir}/tox.ini {toxinidir}
+  mypy --config-file={toxinidir}/tox.ini --package=west
   py.test --cov=west {posargs:tests}

--- a/tox_deps.txt
+++ b/tox_deps.txt
@@ -2,3 +2,4 @@ setuptools-scm
 pytest
 pytest-cov
 flake8
+mypy


### PR DESCRIPTION
These changes introduce initial support for type hints. Support for mypy
static analysis on GitHub workflows has also been enabled.

Signed-off-by: Gerard Marull-Paretas <gerard@teslabs.com>