### PR TITLE
RFC: main: add global --color=when cli argument

### DIFF
--- a/src/west/app/main.py
+++ b/src/west/app/main.py
@@ -296,6 +296,10 @@ class WestApp:
                             version=f'West version: v{__version__}',
                             help='print the program version and exit')
 
+        parser.add_argument('--color', default='auto',
+                            choices=['always', 'auto', 'never'],
+                            help='select when colored output should be used')
+
         subparser_gen = parser.add_subparsers(metavar='<command>',
                                               dest='command')
 
@@ -307,6 +311,16 @@ class WestApp:
         # spec and re-parse arguments before running.
 
         args, unknown = self.west_parser.parse_known_args(args=argv)
+
+        # Makes ANSI color escapes work on Windows, and strips them when
+        # stdout/stderr isn't a terminal
+        if args.color == 'always':
+            strip = False
+        elif args.color == 'auto':
+            strip = None
+        else: # args.color == 'never'
+            strip = True
+        colorama.init(strip=strip)
 
         # Set up logging verbosity before running the command, so e.g.
         # verbose messages related to argument handling errors work
@@ -758,10 +772,6 @@ def main(argv=None):
     # logging.ERROR level. We want to handle those ourselves as
     # needed.
     logging.getLogger('pykwalify').setLevel(logging.CRITICAL)
-
-    # Makes ANSI color escapes work on Windows, and strips them when
-    # stdout/stderr isn't a terminal
-    colorama.init()
 
     # Create the WestApp instance and let it run.
     app = WestApp()


### PR DESCRIPTION
Implement commandline option similar to git, which allows to select when
colors should be printed. Based on that pass strip= keyword argument to
colorama.init().

This is just a scratch of the implementation and I would like to fallback into `color.ui`. Also I think that  things like `if not _use_colors():` could be removed then.

I have found following comment in 1967d3d47a983334bcd6932f4ba0f637ddf3c978:
> I was thinking of toggling colors at a higher level with colorama
at first, but colorama.init() makes it a bit tricky to get right for
both Linux and Windows. Probably not too bad to make it explicit like
this.

So the question is: what were the issues with `colorama.init()` approach? Unfortunately I don't have windows to test. On Linux at least I didn't notice issues with current `--color=when` implementation.