### PR TITLE
lint: flake8 fixes

### DIFF
--- a/src/west/app/project.py
+++ b/src/west/app/project.py
@@ -799,7 +799,7 @@ class Update(_ProjectCommand):
             # are not defined in the manifest repository.
             mr_unknown_set = set(mr_unknown)
             from_projects = [p for p in ids if p in mr_unknown_set]
-            log.die(f'refusing to update project: ' +
+            log.die('refusing to update project: ' +
                     " ".join(from_projects) + '\n' +
                     '  It or they were resolved via project imports.\n'
                     '  Only plain "west update" can currently update them.')

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -1630,7 +1630,7 @@ def _is_imap_ok(imap, project):
     # Return True if a project passes an import map's filters,
     # and False otherwise.
 
-    nwl, pwl, nbl, pbl = [_ensure_list(l) for l in
+    nwl, pwl, nbl, pbl = [_ensure_list(lst) for lst in
                           (imap.name_whitelist, imap.path_whitelist,
                            imap.name_blacklist, imap.path_blacklist)]
     name = project.name


### PR DESCRIPTION
Some new flake8 errors are enabled by default now; fix them up:

```
./src/west/manifest.py:1633:47: E741 ambiguous variable name 'l'
./src/west/app/project.py:802:21: F541 f-string is missing placeholders
```