### PR TITLE
app: make the WestApp class and the run method public API

### DIFF
--- a/src/west/app/main.py
+++ b/src/west/app/main.py
@@ -8,7 +8,7 @@
 
 '''Zephyr RTOS meta-tool (west) main module
 
-Nothing in here is public API.
+Only the main() method in here is public API.
 '''
 
 import argparse
@@ -754,6 +754,14 @@ def dump_traceback():
     return name
 
 def main(argv=None):
+    '''Run the application with argument list ``argv``.
+
+    The argument list is identical to the command-line west application
+    arguments, see ``west help``
+
+    :param argv: argument list, the list of valid arguments can be seen by
+        invoking ``west help``
+    '''
     # Silence validation errors from pykwalify, which are logged at
     # logging.ERROR level. We want to handle those ourselves as
     # needed.


### PR DESCRIPTION
Changing the comment, as we now officially support direct use of
WestApp().

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>

---- 
This PR is needed by: https://github.com/zephyrproject-rtos/zephyr/pull/26060
in order to correctly render the `WestApp` api. 