### PR TITLE
Revert "app: make main() in west.app.main module public API"

### DIFF
--- a/src/west/app/main.py
+++ b/src/west/app/main.py
@@ -8,7 +8,7 @@
 
 '''Zephyr RTOS meta-tool (west) main module
 
-Only the main() method in here is public API.
+Nothing in here is public API.
 '''
 
 import argparse
@@ -754,14 +754,6 @@ def dump_traceback():
     return name
 
 def main(argv=None):
-    '''Run the application with argument list ``argv``.
-
-    The argument list is identical to the command-line west application
-    arguments, see ``west help``
-
-    :param argv: argument list, the list of valid arguments can be seen by
-        invoking ``west help``
-    '''
     # Silence validation errors from pykwalify, which are logged at
     # logging.ERROR level. We want to handle those ourselves as
     # needed.


### PR DESCRIPTION
This reverts commit 5843eef713fe28ab58885f5537f38a5604368212. We
figured out another way to accomplish the goal that this was done for,
so there's no reason to expose these details to the user now.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>