### PR TITLE
Overhaul path handling

### DIFF
--- a/src/west/app/project.py
+++ b/src/west/app/project.py
@@ -261,7 +261,7 @@ class Init(_ProjectCommand):
         if not exists(temp_manifest):
             log.die(f'can\'t init: no "west.yml" found in {tempdir}\n'
                     f'  Hint: check --manifest-url={manifest_url} and '
-                    '--manifest-rev={manifest_rev}\n'
+                    f'--manifest-rev={manifest_rev}\n'
                     f'  You may need to remove {west_dir} before retrying.')
 
         # Parse the manifest to get the manifest path, if it declares one.

--- a/src/west/commands.py
+++ b/src/west/commands.py
@@ -114,7 +114,7 @@ class WestCommand(ABC):
         :param args: known arguments parsed via `WestCommand.add_parser`
         :param unknown: unknown arguments present on the command line;
             must be empty unless ``accepts_unknown_args`` is true
-        :param topdir: west workspace topdir, accessible as
+        :param topdir: west workspace topdir, accessible as a str via
             ``self.topdir`` from `WestCommand.do_run`
         :param manifest: `west.manifest.Manifest` or ``None``,
             accessible as ``self.manifest`` from `WestCommand.do_run`
@@ -123,7 +123,7 @@ class WestCommand(ABC):
             self.parser.error(f'unexpected arguments: {unknown}')
         if not topdir and self.requires_workspace:
             log.die(_no_topdir_msg(os.getcwd(), self.name))
-        self.topdir = topdir
+        self.topdir = os.fspath(topdir) if topdir else None
         self.manifest = manifest
         self.do_run(args, unknown)
 

--- a/src/west/configuration.py
+++ b/src/west/configuration.py
@@ -40,10 +40,11 @@ import os
 from pathlib import PureWindowsPath, Path
 import platform
 from enum import Enum
+from typing import Any, Optional, List
 
 import configobj
 
-from west.util import west_dir, WestNotFound
+from west.util import west_dir, WestNotFound, PathType
 
 def _configparser():            # for internal use
     return configparser.ConfigParser(allow_no_value=True)
@@ -71,7 +72,9 @@ class ConfigFile(Enum):
     GLOBAL = 3
     LOCAL = 4
 
-def read_config(configfile=None, config=config, topdir=None):
+def read_config(configfile: Optional[ConfigFile] = None,
+                config: configparser.ConfigParser = config,
+                topdir: Optional[PathType] = None) -> None:
     '''Read configuration files into *config*.
 
     Reads the files given by *configfile*, storing the values into the
@@ -100,8 +103,9 @@ def read_config(configfile=None, config=config, topdir=None):
         configfile = ConfigFile.ALL
     config.read(_gather_configs(configfile, topdir), encoding='utf-8')
 
-def update_config(section, key, value, configfile=ConfigFile.LOCAL,
-                  topdir=None):
+def update_config(section: str, key: str, value: Any,
+                  configfile: ConfigFile = ConfigFile.LOCAL,
+                  topdir: Optional[PathType] = None) -> None:
     '''Sets ``section.key`` to *value* in the given configuration file.
 
     :param section: config section; will be created if it does not exist
@@ -131,7 +135,9 @@ def update_config(section, key, value, configfile=ConfigFile.LOCAL,
     updater[section][key] = value
     updater.write()
 
-def delete_config(section, key, configfile=None, topdir=None):
+def delete_config(section: str, key: str,
+                  configfile: Optional[ConfigFile] = None,
+                  topdir: Optional[PathType] = None) -> None:
     '''Delete the option section.key from the given file or files.
 
     :param section: section whose key to delete
@@ -189,7 +195,7 @@ def delete_config(section, key, configfile=None, topdir=None):
     if not found:
         raise KeyError(f'{section}.{key}')
 
-def _location(cfg, topdir=None):
+def _location(cfg: ConfigFile, topdir: Optional[PathType] = None) -> str:
     # Making this a function that gets called each time you ask for a
     # configuration file makes it respect updated environment
     # variables (such as XDG_CONFIG_HOME, PROGRAMDATA) if they're set
@@ -250,7 +256,7 @@ def _location(cfg, topdir=None):
     else:
         raise ValueError(f'invalid configuration file {cfg}')
 
-def _gather_configs(cfg, topdir):
+def _gather_configs(cfg: ConfigFile, topdir: Optional[PathType]) -> List[str]:
     # Find the paths to the given configuration files, in increasing
     # precedence order.
     ret = []
@@ -267,7 +273,7 @@ def _gather_configs(cfg, topdir):
 
     return ret
 
-def _ensure_config(configfile, topdir):
+def _ensure_config(configfile: ConfigFile, topdir: Optional[PathType]) -> str:
     # Ensure the given configfile exists, returning its path. May
     # raise permissions errors, WestNotFound, etc.
     loc = _location(configfile, topdir=topdir)

--- a/src/west/configuration.py
+++ b/src/west/configuration.py
@@ -71,8 +71,7 @@ class ConfigFile(Enum):
     GLOBAL = 3
     LOCAL = 4
 
-def read_config(configfile=None, config=config, topdir=None,
-                config_file=None):
+def read_config(configfile=None, config=config, topdir=None):
     '''Read configuration files into *config*.
 
     Reads the files given by *configfile*, storing the values into the
@@ -96,14 +95,9 @@ def read_config(configfile=None, config=config, topdir=None,
     :param configfile: a `west.configuration.ConfigFile`
     :param config: configuration object to read into
     :param topdir: west workspace root to read local options from
-    :param config_file: deprecated alternative for *configfile*
     '''
-    if configfile is not None and config_file is not None:
-        raise ValueError('use "configfile" or "config_file"; not both')
     if configfile is None:
         configfile = ConfigFile.ALL
-    if config_file is not None:
-        configfile = config_file
     config.read(_gather_configs(configfile, topdir), encoding='utf-8')
 
 def update_config(section, key, value, configfile=ConfigFile.LOCAL,

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -25,6 +25,7 @@ import pykwalify.core
 import yaml
 
 from west import util
+from west.util import PathType
 import west.configuration as cfg
 
 #
@@ -60,13 +61,6 @@ SCHEMA_VERSION = '0.7'
 #
 
 # Type aliases
-
-# What we would eventually like to accept for paths. Using more
-# pathlib.Path internally would let us do comparisons with == and
-# support better hashing, which will make life easier on Windows.
-# However, right now, paths are 'str' in a variety of places, and we
-# are using west.util.canon_path(). See #273 on GitHub.
-PathType = Union[str, os.PathLike]
 
 # The value of a west-commands as passed around during manifest
 # resolution. It can become a list due to resolving imports, even

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -18,7 +18,7 @@ import shlex
 import subprocess
 import sys
 from typing import Any, Callable, Dict, Iterable, List, NoReturn, \
-    Optional, Union
+    Optional, TYPE_CHECKING, Union
 
 from packaging.version import parse as parse_version
 import pykwalify.core
@@ -1332,6 +1332,10 @@ class Manifest:
                     # When from_data() is called without a path hint, mp
                     # can have a topdir but no path, and thus no abspath.
                     continue
+                if TYPE_CHECKING:
+                    # The typing module can't tell that self.topdir
+                    # being truthy guarantees p.abspath is a str, not None.
+                    assert p.abspath
                 self._projects_by_cpath[util.canon_path(p.abspath)] = p
 
         _logger.debug(f'loaded {loading_what}')

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -834,8 +834,8 @@ class ManifestProject(Project):
     @property
     def abspath(self) -> Optional[str]:
         if self._abspath is None and self.topdir and self.path:
-            self._abspath = os.path.realpath(os.path.join(self.topdir,
-                                                          self.path))
+            self._abspath = os.path.abspath(os.path.join(self.topdir,
+                                                         self.path))
         return self._abspath
 
     def as_dict(self) -> Dict:

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -16,6 +16,7 @@ import os
 from pathlib import PurePath, PurePosixPath, Path
 import shlex
 import subprocess
+import sys
 from typing import Any, Callable, Dict, Iterable, List, NoReturn, \
     Optional, Union
 
@@ -609,6 +610,13 @@ class Project:
                 cwd = self.abspath
             else:
                 raise ValueError('no abspath; cwd must be given')
+        elif sys.version_info < (3, 6, 1) and not isinstance(cwd, str):
+            # Popen didn't accept a PathLike cwd on Windows until
+            # python v3.7; this was backported onto cpython v3.6.1,
+            # though. West currently supports "python 3.6", though, so
+            # in the unlikely event someone is running 3.6.0 on
+            # Windows, do the right thing.
+            cwd = os.fspath(cwd)
 
         args = ['git'] + cmd_list + extra_args
         cmd_str = util.quote_sh_list(args)

--- a/src/west/util.py
+++ b/src/west/util.py
@@ -11,10 +11,7 @@ import shlex
 import textwrap
 from typing import List, Optional, Union
 
-# What we would eventually like to accept for paths everywhere in
-# west's APIs. However, right now, paths are 'str' in a variety of
-# places, and we are using west.util.canon_path() to create strings we
-# can compare with ==. See #273 on GitHub.
+# What west's APIs accept for paths.
 #
 # Here, os.PathLike objects should return str from their __fspath__
 # methods, not bytes. We could try to do something like the approach
@@ -22,18 +19,6 @@ from typing import List, Optional, Union
 # as os.PathLike[str] if TYPE_CHECKING and plain os.PathLike
 # otherwise, but it doesn't seem worth it.
 PathType = Union[str, os.PathLike]
-
-def canon_path(path: str) -> str:
-    '''Returns a canonical version of the path.
-
-    This is currently ``os.path.normcase(os.path.abspath(path))``. The
-    path separator is converted to os.sep on platforms where that
-    matters (Windows).
-
-    :param path: path whose canonical name to return; need not
-                 refer to an existing file.
-    '''
-    return os.path.normcase(os.path.abspath(path))
 
 def escapes_directory(path: PathType, directory: PathType) -> bool:
     '''Returns True if `path` escapes parent directory `directory`.

--- a/src/west/util.py
+++ b/src/west/util.py
@@ -9,8 +9,21 @@ import os
 import pathlib
 import shlex
 import textwrap
+from typing import List, Optional, Union
 
-def canon_path(path):
+# What we would eventually like to accept for paths everywhere in
+# west's APIs. However, right now, paths are 'str' in a variety of
+# places, and we are using west.util.canon_path() to create strings we
+# can compare with ==. See #273 on GitHub.
+#
+# Here, os.PathLike objects should return str from their __fspath__
+# methods, not bytes. We could try to do something like the approach
+# taken in https://github.com/python/mypy/issues/5264 to annotate that
+# as os.PathLike[str] if TYPE_CHECKING and plain os.PathLike
+# otherwise, but it doesn't seem worth it.
+PathType = Union[str, os.PathLike]
+
+def canon_path(path: str) -> str:
     '''Returns a canonical version of the path.
 
     This is currently ``os.path.normcase(os.path.abspath(path))``. The
@@ -22,30 +35,28 @@ def canon_path(path):
     '''
     return os.path.normcase(os.path.abspath(path))
 
-def escapes_directory(path, directory):
+def escapes_directory(path: PathType, directory: PathType) -> bool:
     '''Returns True if `path` escapes parent directory `directory`.
 
     :param path: path to check is inside `directory`
     :param directory: parent directory to check
 
-    Verifies `path` is inside of `directory`, after computing
-    normalized real paths for both.'''
-    # It turns out not to be easy to implement this without using
-    # pathlib.
-    p = pathlib.Path(os.path.normcase(os.path.realpath(path)))
-    d = pathlib.Path(os.path.normcase(os.path.realpath(directory)))
+    Verifies `path` is inside of `directory`, after resolving
+    both.'''
+    path_resolved = pathlib.Path(path).resolve()
+    dir_resolved = pathlib.Path(directory).resolve()
     try:
-        p.relative_to(d)
+        path_resolved.relative_to(dir_resolved)
         ret = False
     except ValueError:
         ret = True
     return ret
 
-def quote_sh_list(cmd):
+def quote_sh_list(cmd: List[str]) -> str:
     '''Transform a command from list into shell string form.'''
     return ' '.join(shlex.quote(s) for s in cmd)
 
-def wrap(text, indent):
+def wrap(text: str, indent: str) -> List[str]:
     '''Convenience routine for wrapping text to a consistent indent.'''
     return textwrap.wrap(text, initial_indent=indent,
                          subsequent_indent=indent)
@@ -53,7 +64,7 @@ def wrap(text, indent):
 class WestNotFound(RuntimeError):
     '''Neither the current directory nor any parent has a west workspace.'''
 
-def west_dir(start=None):
+def west_dir(start: Optional[PathType] = None) -> str:
     '''Returns the absolute path of the workspace's .west directory.
 
     Starts the search from the start directory, and goes to its
@@ -64,21 +75,19 @@ def west_dir(start=None):
     '''
     return os.path.join(west_topdir(start), '.west')
 
-def west_topdir(start=None, fall_back=True):
+def west_topdir(start: Optional[PathType] = None,
+                fall_back: bool = True) -> str:
     '''
     Like west_dir(), but returns the path to the parent directory of the .west/
     directory instead, where project repositories are stored
     '''
-    # If you change this function, make sure to update the bootstrap
-    # script's find_west_topdir().
-
-    cur_dir = start or os.getcwd()
+    cur_dir = pathlib.Path(start or os.getcwd())
 
     while True:
-        if os.path.isdir(os.path.join(cur_dir, '.west')):
-            return cur_dir
+        if (cur_dir / '.west').is_dir():
+            return os.fspath(cur_dir)
 
-        parent_dir = os.path.dirname(cur_dir)
+        parent_dir = cur_dir.parent
         if cur_dir == parent_dir:
             # At the root. Should we fall back?
             if fall_back and os.environ.get('ZEPHYR_BASE'):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -66,7 +66,7 @@ def config_tmpdir(tmpdir):
 def cfg(f=ALL, topdir=None):
     # Load a fresh configuration object at the given level, and return it.
     cp = configparser.ConfigParser(allow_no_value=True)
-    config.read_config(config_file=f, config=cp, topdir=topdir)
+    config.read_config(configfile=f, config=cp, topdir=topdir)
     return cp
 
 def test_config_global():

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -504,6 +504,11 @@ def test_project_git_methods(tmpdir):
     assert p.listdir_at('', rev=a_sha) == ['a.txt']
     assert sorted(p.listdir_at('', rev=b_sha)) == ['a.txt', 'b.txt']
 
+    # p.git() should be able to take a cwd kwarg which is a PathLike
+    # or a str.
+    p.git('log -1', cwd=path)
+    p.git('log -1', cwd=str(path))
+
     # Basic checks for functions which operate on commits.
     assert a_content_at(a_sha) == 'a'
     assert p.is_ancestor_of(start_sha, a_sha)


### PR DESCRIPTION
Fixes: #273 

This makes west's internal representations for paths use pathlib objects whenever relevant or convenient. In particular, this is useful whenever path comparisons are necessary, since pathlib handles the canonicalization properly.

It also makes west accept os.PathLike in its public APIs in addition to str. This is consistent with the general direction of the python standard library and just generally reasonable practice for python in 2020.

I'm leaning pretty heavily on the type checker to catch my mistakes here. It definitely helped during development.

I tried to make this as symlink friendly as I could, but I can't say with 100% honesty that running west commands from `/some/symlink/to/a/workspace` doesn't ever leak the physical path behind the symlink.

Now that we are dealing with paths in a nicer way, we can move on to https://github.com/zephyrproject-rtos/west/issues/367 after this.

