### PR TITLE
Make sure west update can be used to recover from a bad import

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -239,6 +239,9 @@ def cmd(cmd, cwd=None, stderr=None, env=None):
         for k in os.environ:
             if k not in env:
                 print(f'\t{k}: deleted, was: {os.environ[k]}')
+    if cwd is not None:
+        cwd = os.fspath(cwd)
+        print(f'in {cwd}')
     try:
         return check_output(cmd, cwd=cwd, stderr=stderr, env=env)
     except subprocess.CalledProcessError:
@@ -264,8 +267,7 @@ def create_workspace(workspace_dir, and_git=False):
 
 def create_repo(path):
     # Initializes a Git repository in 'path', and adds an initial commit to it
-    if not isinstance(path, str):
-        path = str(path)
+    path = os.fspath(path)
 
     subprocess.check_call([GIT, 'init', path])
 
@@ -300,7 +302,7 @@ def add_commit(repo, msg, files=None, reconfigure=True):
     #
     # If 'reconfigure' is True, the user.name and user.email git
     # configuration variables will be set in 'repo' using config_repo().
-    repo = str(repo)
+    repo = os.fspath(repo)
 
     if reconfigure:
         config_repo(repo)


### PR DESCRIPTION
Consider the following situation:

1. `m` is the manifest repository, `p` is a project
2. `m/west.yml` imports `p` at revision `rbad`; `p/west.yml` at `rbad` contains an invalid manifest
3. user runs `west update`, setting `p`'s `manifest-rev` to `rbad` (and failing the update)
4. user updates `m/west.yml` to point at `p` revision `rgood`, which contains good manifest data
5. user runs `west update` again

The `west update` in the last step should fix `p`'s manifest-rev, pointing it at `rgood`, and should succeed.

It doesn't, because west refuses to run `update` and just allows the command to crash because there was no valid manifest data, leaving the workspace in an unusable state: even though the top-level manifest points at a valid configuration, you can't run west update, or list, or ....

Whoops. Turns out `west update` is perfectly smart enough to fix this situation, so just let it run.

This opens us up to running `west update` even with an invalid manifest and no imports. We handle this in main.py.

Reported by @plskeggs