### PR TITLE
Backport recovery from bad import

### DIFF
--- a/src/west/app/project.py
+++ b/src/west/app/project.py
@@ -785,7 +785,7 @@ class Update(_ProjectCommand):
             # are not defined in the manifest repository.
             mr_unknown_set = set(mr_unknown)
             from_projects = [p for p in ids if p in mr_unknown_set]
-            log.die(f'refusing to update project: ' +
+            log.die('refusing to update project: ' +
                     " ".join(from_projects) + '\n' +
                     '  It or they were resolved via project imports.\n'
                     '  Only plain "west update" can currently update them.')

--- a/src/west/app/project.py
+++ b/src/west/app/project.py
@@ -261,7 +261,7 @@ class Init(_ProjectCommand):
         if not exists(temp_manifest):
             log.die(f'can\'t init: no "west.yml" found in {tempdir}\n'
                     f'  Hint: check --manifest-url={manifest_url} and '
-                    '--manifest-rev={manifest_rev}\n'
+                    f'--manifest-rev={manifest_rev}\n'
                     f'  You may need to remove {west_dir} before retrying.')
 
         # Parse the manifest to get the manifest path, if it declares one.

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -1630,7 +1630,7 @@ def _is_imap_ok(imap, project):
     # Return True if a project passes an import map's filters,
     # and False otherwise.
 
-    nwl, pwl, nbl, pbl = [_ensure_list(l) for l in
+    nwl, pwl, nbl, pbl = [_ensure_list(lst) for lst in
                           (imap.name_whitelist, imap.path_whitelist,
                            imap.name_blacklist, imap.path_blacklist)]
     name = project.name

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -239,6 +239,9 @@ def cmd(cmd, cwd=None, stderr=None, env=None):
         for k in os.environ:
             if k not in env:
                 print(f'\t{k}: deleted, was: {os.environ[k]}')
+    if cwd is not None:
+        cwd = os.fspath(cwd)
+        print(f'in {cwd}')
     try:
         return check_output(cmd, cwd=cwd, stderr=stderr, env=env)
     except subprocess.CalledProcessError:
@@ -264,8 +267,7 @@ def create_workspace(workspace_dir, and_git=False):
 
 def create_repo(path):
     # Initializes a Git repository in 'path', and adds an initial commit to it
-    if not isinstance(path, str):
-        path = str(path)
+    path = os.fspath(path)
 
     subprocess.check_call([GIT, 'init', path])
 
@@ -300,7 +302,7 @@ def add_commit(repo, msg, files=None, reconfigure=True):
     #
     # If 'reconfigure' is True, the user.name and user.email git
     # configuration variables will be set in 'repo' using config_repo().
-    repo = str(repo)
+    repo = os.fspath(repo)
 
     if reconfigure:
         config_repo(repo)


### PR DESCRIPTION
Backports https://github.com/zephyrproject-rtos/west/pull/415 to v0.7-branch. I will begin the MAINTAINERS.rst process for getting v0.7.3 with this fix out as soon as time permits (current focus is on other tasks).

Tack on a couple more commits: one to to get past CI, another because it's a trivial fix