### PR TITLE
add __main__.py

### DIFF
--- a/src/west/__main__.py
+++ b/src/west/__main__.py
@@ -1,0 +1,3 @@
+from west.app.main import main
+
+main()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,17 @@
+import subprocess
+import sys
+
+import west.version
+
+def test_main():
+    # A quick check that the package can be executed as a module which
+    # takes arguments, using e.g. "python3 -m west --version" to
+    # produce the same results as "west --version", and that both are
+    # sane (i.e. the actual version number is printed instead of
+    # simply an error message to stderr).
+
+    output_as_module = subprocess.check_output([sys.executable, '-m', 'west',
+                                                '--version']).decode()
+    output_directly = subprocess.check_output(['west', '--version']).decode()
+    assert west.version.__version__ in output_as_module
+    assert output_as_module == output_directly


### PR DESCRIPTION
This allows west to be executed as a module with "python3 -m west".

This can be useful if it's desired to execute west under a particular
Python interpreter, e.g. the same one that's used elsewhere in a
larger system.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>