### PR TITLE
tox.ini: remove useless cruft

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
-envlist=py3-{posix,windows}
-skip_missing_interpreters=true
+envlist=py3
 
 [flake8]
 # We explicitly disable the following errors:
@@ -25,8 +24,6 @@ deps =
     pytest-cov
     flake8
     mypy
-platform = posix: (linux|darwin)
-           windows: win32
 setenv =
     TOXTEMPDIR={envtmpdir}
 passenv = WEST_SKIP_SLOW_TESTS


### PR DESCRIPTION
We no longer need to filter based on the platform like this. Our tests
know what to do at runtime and so should our CI.