### PR TITLE
manifest: fix ImportFlag docstring for sphinx, bump schema version

### DIFF
--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -428,24 +428,15 @@ class _ManifestImportDepth(ManifestImportFailed):
 class ImportFlag(enum.IntFlag):
     '''Bit flags for handling imports when resolving a manifest.
 
-    The DEFAULT (0) value allows reading the file system to resolve
-    "self: import:", and running git to resolve a "projects:" import.
-    Other flags:
-
-    - IGNORE: ignore projects added via "import:" in "self:" and "projects:"
-    - FORCE_PROJECTS: always invoke importer callback for "projects:" imports
-    - IGNORE_PROJECTS: ignore projects added via "import:" in "projects:" only;
-      including any projects added via "import:" in "self:"
-
     Note that any "path-prefix:" values set in an "import:" still take
     effect for the project itself even when IGNORE or IGNORE_PROJECTS are
-    given. For example, in this manifest:
+    given. For example, in this manifest::
 
-    manifest:
-      projects:
-      - name: foo
-        import:
-          path-prefix: bar
+       manifest:
+         projects:
+         - name: foo
+           import:
+             path-prefix: bar
 
     Project 'foo' has path 'bar/foo' regardless of whether IGNORE or
     IGNORE_PROJECTS is given. This ensures the Project has the same path
@@ -453,9 +444,18 @@ class ImportFlag(enum.IntFlag):
     ignored.
     '''
 
+    #: The default value, 0, reads the file system to resolve
+    #: "self: import:", and runs git to resolve a "projects:" import.
     DEFAULT = 0
+
+    #: Ignore projects added via "import:" in "self:" and "projects:"
     IGNORE = 1
+
+    #: Always invoke importer callback for "projects:" imports
     FORCE_PROJECTS = 2
+
+    #: Ignore projects added via "import:" : in "projects:" only;
+    #: including any projects added via "import:" : in "self:"
     IGNORE_PROJECTS = 4
 
 def _flags_ok(flags: ImportFlag) -> bool:

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -48,7 +48,7 @@ QUAL_REFS_WEST = 'refs/west/'
 #:
 #: This value changes when a new version of west includes new manifest
 #: file features not supported by earlier versions of west.
-SCHEMA_VERSION = '0.7'
+SCHEMA_VERSION = '0.8'
 # MAINTAINERS:
 #
 # If you want to update the schema version, you need to make sure that


### PR DESCRIPTION
- ImportFlag: Sphinx output isn't really what I want it to be for this class. Fix it up.
- SCHEMA_VERSION: there are incompatible changes since last release
