### PR TITLE
version: bump master branch to 0.8.99

### DIFF
--- a/src/west/version.py
+++ b/src/west/version.py
@@ -5,7 +5,7 @@
 # This is the Python 3 version of option 3 in:
 # https://packaging.python.org/guides/single-sourcing-package-version/#single-sourcing-the-version
 
-__version__ = '0.7.99'
+__version__ = '0.8.99'
 # MAINTAINERS:
 #
 # Make sure to update west.manifest.SCHEMA_VERSION if there have been


### PR DESCRIPTION
We've forked a v0.8-branch branch for releasing that version, push
master ahead.
