### PR TITLE
init: fix 'west init -l .'

### DIFF
--- a/src/west/app/project.py
+++ b/src/west/app/project.py
@@ -213,7 +213,12 @@ class Init(_ProjectCommand):
         if args.manifest_rev is not None:
             log.die('--mr cannot be used with -l')
 
-        manifest_dir = Path(args.directory or os.getcwd())
+        # We need to resolve this to handle the case that args.directory
+        # is '.'. In that case, Path('.').parent is just Path('.') instead of
+        # Path('..').
+        #
+        # https://docs.python.org/3/library/pathlib.html#pathlib.PurePath.parent
+        manifest_dir = Path(args.directory or os.getcwd()).resolve()
         manifest_filename = args.manifest_file or 'west.yml'
         manifest_file = manifest_dir / manifest_filename
         topdir = manifest_dir.parent

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -627,6 +627,19 @@ def test_init_local_with_manifest_filename(repos_tmpdir):
     cmd('update')
 
 
+def test_init_local_with_empty_path(repos_tmpdir):
+    # Test "west init -l ." + "west update".
+    # Regression test for:
+    # https://github.com/zephyrproject-rtos/west/issues/435
+
+    local_manifest_dir = repos_tmpdir / 'workspace' / 'zephyr'
+    clone(str(repos_tmpdir / 'repos' / 'zephyr'), str(local_manifest_dir))
+    os.chdir(local_manifest_dir)
+    cmd('init -l .')
+    cmd('update')
+    assert (repos_tmpdir / 'workspace' / 'subdir' / 'Kconfiglib').check(dir=1)
+
+
 def test_init_with_manifest_filename(repos_tmpdir):
     # Test 'west init --mf' on a normal repo
 


### PR DESCRIPTION
This isn't working properly without resolving the manifest directory.

Fixes: #435
Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>