### PR TITLE
Improve west init -l docs

### DIFF
--- a/src/west/app/project.py
+++ b/src/west/app/project.py
@@ -164,9 +164,11 @@ class Init(_ProjectCommand):
         parser.add_argument('--mf', '--manifest-file', dest='manifest_file',
                             help='manifest file name to use')
         parser.add_argument('-l', '--local', action='store_true',
-                            help='''use an existing local manifest repository
-                            instead of cloning one; cannot be combined with
-                            -m or --mr.''')
+                            help='''use "directory" as an existing local
+                            manifest repository instead of cloning one from
+                            MANIFEST_URL; .west is created next to "directory"
+                            in this case, and manifest.path points at
+                            "directory"''')
 
         parser.add_argument(
             'directory', nargs='?', default=None,


### PR DESCRIPTION
Let's make it clearer what happens in this case.

For the sake of not making the command line help too long, let's drop
the point that it can't be combined with -m or --mr and just make it
clear that -l doesn't use MANIFEST_URL. People will find out right
away if they try it that it doesn't work if they combine these
options.
