### PR TITLE
manifest: Use the parent folder for checking escape path

### DIFF
--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -1652,7 +1652,7 @@ class Manifest:
             assert isinstance(ret.abspath, str)
             apath = Path(ret.abspath)
             topdir = Path(self.topdir)
-            if escapes_directory(apath, topdir) or apath == topdir:
+            if escapes_directory(apath.parent, topdir) or apath == topdir:
                 self._malformed(f'project {name} absolute path {apath} '
                                 'is not a subdirectory of topdir ' +
                                 self.topdir)


### PR DESCRIPTION
Fixes: #437

The project itself will always have a directory name, `<project>`.
It only needs to be ensure that the path leading up to `<project>` must
not escape the west workspace.

We only want to ensure that any paths specified in the manifest doesn't
escape the workspace.

Any user should have the freedom to decide if the project itself should
be a symlink to another location.

This commit provides freedom to the user, and at the sametime ensures
that path-prefix cannot escape the workspace.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>