### PR TITLE
manifest: rework workspace escape checks

### DIFF
--- a/tests/manifests/invalid_absolute_project_path.yml
+++ b/tests/manifests/invalid_absolute_project_path.yml
@@ -1,0 +1,7 @@
+# Project paths must be relative.
+
+manifest:
+  projects:
+    - name: nope
+      url: ignore-me
+      path: /this/is/wrong

--- a/tests/manifests/invalid_project_path_escapes.yml
+++ b/tests/manifests/invalid_project_path_escapes.yml
@@ -1,0 +1,8 @@
+# Project paths must not escape the workspace topdir after
+# normalization.
+
+manifest:
+  projects:
+    - name: nope
+      url: ignore-me
+      path: this/is/../../../not-ok

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -2243,7 +2243,7 @@ def test_import_path_prefix_no_escape(manifest_repo):
                reconfigure=False)
     with pytest.raises(MalformedManifest) as excinfo:
         MF(topdir=topdir, import_flags=ImportFlag.IGNORE)
-    assert 'is not a subdirectory' in str(excinfo.value)
+    assert 'escapes the workspace topdir' in str(excinfo.value)
 
 @pytest.mark.skipif(WEST_SKIP_SLOW_TESTS,
                     reason='use WEST_SKIP_SLOW_TESTS=0 to enable')


### PR DESCRIPTION
Let's use a lexical check instead of escapes_directory(). This
continues to let some users who are symlinking outside the workspace
to keep doing that, even though we don't officially support it in
west.

Also throw in a check for an absolute project path, which should never
happen and is similarly a sign of an attempt to escape the workspace.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>