### PR TITLE
An empty "self: path:" is an error

### DIFF
--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -1395,7 +1395,14 @@ class Manifest:
         # Handle the "self:" section in the manifest data.
 
         slf = manifest.get('self', {})
-        path = slf.get('path', path_hint)
+        if 'path' in slf:
+            path = slf['path']
+            if path is None:
+                self._malformed(f'self: path: is {path}; this value '
+                                'must be nonempty if present')
+        else:
+            path = path_hint
+
         mp = ManifestProject(path=path, topdir=self.topdir,
                              west_commands=slf.get('west-commands'))
 

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -586,7 +586,6 @@ def test_manifest_project():
     assert mp.revision == 'HEAD'
     assert mp.clone_depth is None
 
-@pytest.mark.xfail()
 def test_self_tag():
     # Manifests may contain a self section describing the manifest
     # repository. It should work with multiple projects and remotes as

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -586,6 +586,7 @@ def test_manifest_project():
     assert mp.revision == 'HEAD'
     assert mp.clone_depth is None
 
+@pytest.mark.xfail()
 def test_self_tag():
     # Manifests may contain a self section describing the manifest
     # repository. It should work with multiple projects and remotes as
@@ -633,6 +634,14 @@ def test_self_tag():
     - name: p
       url: u
     ''', manifest_path='mpath').projects[0].path == 'mpath'
+
+    # Empty paths are an error.
+    with pytest.raises(MalformedManifest) as e:
+        M('''\
+        projects: []
+        self:
+          path:''')
+    assert 'must be nonempty if present' in str(e.value)
 
 #########################################
 # File system tests


### PR DESCRIPTION
A manifest like this is not well-formed:

```yaml
manifest:
  projects: [...]
  self:
    path:
```

Currently the `Manifest` parser accepts this data and gives back a `None` value in `self.projects[MANIFEST_PROJECT_INDEX].path`, which is wrong. The entire manifest should just be rejected as ill-formed.