### PR TITLE
setup.py: support development mode from other directories

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,9 @@ import os
 
 import setuptools
 
+SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
+os.chdir(SCRIPT_DIR)
+
 with open('README.rst', 'r') as f:
     long_description = f.read()
 


### PR DESCRIPTION
this adds support for running python ~/path/to/west/setup.py develop
from other directories.

Signed-off-by: Jacob Siverskog <jacob@teenage.engineering>