### PR TITLE
app: print error instead of assert

### DIFF
--- a/src/west/app/main.py
+++ b/src/west/app/main.py
@@ -168,7 +168,6 @@ class WestApp:
                 # and what the user's choices are.
                 return
             else:
-                assert args.command not in no_manifest_ok
                 log.die(mve_msg(self.mle))
 
         # Other errors generally just fall back on no_manifest_ok.


### PR DESCRIPTION
if running with invalid version (for instance newer than current
west), print (more) user-friendly error such as:

FATAL ERROR: west v1.0 or later is required by the manifest
  West version: v0.8.99
  Manifest file: west/west.yml
  Please upgrade west and retry.

instead of:

  File "west/src/west/app/main.py", line 172, in handle_builtin_manifest_load_err
    assert args.command not in no_manifest_ok
AssertionError

Signed-off-by: Jacob Siverskog <jacob@teenage.engineering>