### PR TITLE
Project groups

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,6 @@ setuptools.setup(
         'colorama',
         'PyYAML>=5.1',
         'pykwalify',
-        'configobj',
         'setuptools',
         'packaging',
     ],

--- a/src/west/app/config.py
+++ b/src/west/app/config.py
@@ -96,7 +96,7 @@ class Config(WestCommand):
     def __init__(self):
         super().__init__(
             'config',
-            'get or set configuration settings in west config files',
+            'get or set config file values',
             CONFIG_DESCRIPTION,
             requires_workspace=False)
 

--- a/src/west/app/project.py
+++ b/src/west/app/project.py
@@ -365,7 +365,7 @@ class List(_ProjectCommand):
     def __init__(self):
         super().__init__(
             'list',
-            'print information about projects in the west manifest',
+            'print information about projects',
             textwrap.dedent('''\
             Print information about projects in the west manifest,
             using format strings.'''))

--- a/src/west/app/project.py
+++ b/src/west/app/project.py
@@ -862,11 +862,6 @@ class Update(_ProjectCommand):
         else:
             return 'smart'
 
-    def fetch_missing_imports(self, args):
-        self.fs = 'always'      # just to be safe -- TODO needed?
-        self.manifest = Manifest.from_file(topdir=self.topdir,
-                                           importer=self.update_importer)
-
     def update(self, project):
         if self.args.stats:
             stats = dict()

--- a/src/west/manifest-schema.yml
+++ b/src/west/manifest-schema.yml
@@ -19,6 +19,14 @@
 #
 # --------------------------------------------------------------
 
+schema;groups:
+  type: seq
+  sequence:
+    - type: str
+    - type: int
+    - type: float
+  matching: any
+
 type: map
 mapping:
   # The "version" key is optional. It's the minimum version manifest
@@ -107,6 +115,16 @@ mapping:
           import:
             required: false
             type: any
+          groups:
+            required: false
+            include: groups
+
+  # If present, an allowlist/blocklist of project groups. Prefix a
+  # group name with "-" to block it. Give a group name as-is to
+  # allow it.
+  groups:
+    required: false
+    include: groups
 
   # The "self" key specifies values for the project containing the manifest
   # file (the "manifest repository").

--- a/src/west/version.py
+++ b/src/west/version.py
@@ -5,6 +5,7 @@
 # This is the Python 3 version of option 3 in:
 # https://packaging.python.org/guides/single-sourcing-package-version/#single-sourcing-the-version
 
+# DO NOT CUT 0.9 without bumping west.manifest.SCHEMA_VERSION too.
 __version__ = '0.8.99'
 # MAINTAINERS:
 #

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -181,8 +181,7 @@ def west_init_tmpdir(repos_tmpdir):
     '''Fixture for a tmpdir with 'remote' repositories and 'west init' run.
 
     Uses the remote repositories from the repos_tmpdir fixture to
-    create a west workspace using the system bootstrapper's init
-    command.
+    create a west workspace using west init.
 
     The contents of the west workspace aren't checked at all.
     This is left up to the test cases.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -497,3 +497,8 @@ def test_list():
     assert sorted_list('--global') == ['pytest.baz=where']
     assert sorted_list('--local') == ['pytest.bar=what',
                                       'pytest.foo=who']
+
+@pytest.mark.xfail()
+def test_round_trip():
+    cmd('config pytest.foo bar,baz')
+    assert cmd('config pytest.foo').strip() == 'bar,baz'

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -498,7 +498,6 @@ def test_list():
     assert sorted_list('--local') == ['pytest.bar=what',
                                       'pytest.foo=who']
 
-@pytest.mark.xfail()
 def test_round_trip():
     cmd('config pytest.foo bar,baz')
     assert cmd('config pytest.foo').strip() == 'bar,baz'


### PR DESCRIPTION
The purpose of this pull request is to allow projects to declare groups they belong to, like this:

```yaml
  manifest:
    # ...
    projects:
    - name: foo
      groups:
      - YouAreIt
    - name: bar
      groups:
      - YouAreIt
      - MeToo
    - name: baz
```

The above projects have these groups lists:

- foo: ['YouAreIt']
- bar: ['YouAreIt', 'MeToo']
- baz: []

Paired with this is a new top-level `update-groups` key in the manifest, which lets you specify allowlists and blocklists for groups:

```yaml
    manifest:
      # ...
      groups:
          - some-group
          - another-group
      no-groups:
          - not-this-one
```

By default, `west update` will no longer update any project whose group is blocked (if there is a `no-groups` blocklist), or not explicitly allowed (if there is a `groups` allowlist). Allowlists override blocklists: if a project is blocked and allowed, it will be updated. You can also configure allowlists and blocklists in the local configuration file, via new `manifest.groups` and `manifest.no-groups` configuration options.

In order to allow for one-time overrides, let the user specify additional groups to add to the allowlist via a new "--groups" argument to `west update`, and additional groups to add to the blocklist via "--no-groups".
