### PR TITLE
update: add support for git submodules in west update.

### DIFF
--- a/src/west/manifest-schema.yml
+++ b/src/west/manifest-schema.yml
@@ -103,6 +103,10 @@ mapping:
           path:
             required: false
             type: str
+          # Submodules to checkout within the project
+          submodules:
+            required: false
+            type: any
           # Limits the clone depth of the project if given.
           clone-depth:
             required: false


### PR DESCRIPTION
The submodules were added to the manifest in order to enable updating projects submodules when performing update operation.

Description of the `west update` command behaviour regarding submodules:
* Submodules can be defined in the west manifest file for the specific project, by adding submodules: field.
* Submodules field is not required for every project and should be added only if it is desired.
* Submodules field may have boolean values (true/false) or be the list of specific submodules.
* Assigning false value to the submodules field means that submodules are not used for given project. Example presented below:
    - name: example_project
      submodules: false
* Assigning true value to the submodules field means that all submodules attached by git to the project repository will be updated. Example presented below:
    projects:
    - name: example_project
      submodules: true
* Assigning true value to the submodules field means that all submodules attached by git to the project repository will be updated. Example presented below:
    projects:
    - name: example_project
      submodules: true
* Assigning list of submodules to the submodules field means that only those submodules present on the list will be updated (no matter that there might be any other submodules attached in git). Every element of the submodules list should have the name and the path fields (which is an absolute path to the directory where submodule should be updated). Example presented below:
    - name: example_project
      submodules:
        - name: first_submodule
          path: first_submodule_dir/repo
        - name: second_submodule
          path: second_submodule_dir/repo
* Submodules for each project are defined independently, so in some cases they might have assigned true/false values, lists or not be defined at all.
* When calling `west update` command, submodules for each project are detected and updated with the `recursive` option.
* By default submodules are updated using `--checkout` strategy, however it is possible to update them using `--rebase` strategy, by calling `west update -r` command.

What `west update` command does not do with the submodules:
* Updating submodules does not support `west update -k` option. In case of using such command, `-k` option is ignored and submodules are updated using default `--checkout` strategy.
* Assigning true or false value to the submodules field does not apply to the all projects and their submodules, but only to the all submodules of a specific project for which submodules field was defined.

Fixes: #365

Signed-off-by: Kamil Kasperczyk <kamil.kasperczyk@nordicsemi.no>