### PR TITLE
Additional changes for west 0.9

### DIFF
--- a/src/west/app/project.py
+++ b/src/west/app/project.py
@@ -745,8 +745,12 @@ class Update(_ProjectCommand):
 
         def handle(group):
             group = group.strip()
-            if not is_manifest_group(group, dash_ok=True):
-                log.die(f'invalid --groups item {group}')
+            if not group.startswith(('-', '+')):
+                log.die(f'invalid --groups item {group}: '
+                        'must start with - or +')
+            if not is_manifest_group(group[1:]):
+                log.die(f'invalid --groups item {group}: '
+                        '"{group[1:]}" is not a valid group name')
             self.extra_groups.append(group)
 
         for group in args.groups:

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -452,7 +452,7 @@ def is_group(group: GroupsEltType, dash_ok=False) -> bool:
         group = group[1:]
 
     return ((group >= 0) if isinstance(group, (float, int)) else
-            not _RESERVED_GROUP_RE.search(group))
+            bool(group and not _RESERVED_GROUP_RE.search(group)))
 
 #
 # Exception types

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -2466,11 +2466,13 @@ def test_invalid_groups():
       - {}
     '''
 
+    check(fmt, '', 'invalid group ""')
     check(fmt, 'white space', 'invalid group "white space"')
     check(fmt, 'no,commas', 'invalid group "no,commas"')
     check(fmt, 'no:colons', 'invalid group "no:colons"')
     check(fmt, '-noleadingdash', 'invalid group "-noleadingdash"')
 
+    assert not is_group('')
     assert not is_group('white space')
     assert not is_group('no,commas')
     assert not is_group('no:colons')

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -2466,17 +2466,19 @@ def test_invalid_groups():
       - {}
     '''
 
-    check(fmt, '', 'invalid group ""')
+    check(fmt, '""', 'invalid group ""')
     check(fmt, 'white space', 'invalid group "white space"')
     check(fmt, 'no,commas', 'invalid group "no,commas"')
     check(fmt, 'no:colons', 'invalid group "no:colons"')
     check(fmt, '-noleadingdash', 'invalid group "-noleadingdash"')
+    check(fmt, '+noleadingplus', 'invalid group "+noleadingplus"')
 
     assert not is_group('')
     assert not is_group('white space')
     assert not is_group('no,commas')
     assert not is_group('no:colons')
     assert not is_group('-noleadingdash')
+    assert not is_group('+noleadingplus')
 
     fmt_scalar_project = '''
     projects:
@@ -2518,8 +2520,8 @@ def test_groups():
 
     assert is_group(1)
     assert is_group('hello-world')
+    assert is_group('hello+world')
     assert is_group(3.14)
-    assert is_group('-leadingdash', dash_ok=True)
 
 def test_invalid_manifest_groups():
     # Test cases for invalid "manifest: groups:" lists.
@@ -2591,18 +2593,18 @@ def test_is_active():
                      for p in m.get_projects(['p1', 'p2', 'p3'])) == expected
 
     check((True, True, True), '')
-    check((True, True, True), 'groups: [ga]')
+    check((True, True, True), 'groups: [+ga]')
     check((False, True, True), 'groups: [-ga]')
     check((True, True, True), 'groups: [-gb]',
-          extra_groups=['ga'])
+          extra_groups=['+ga'])
     check((True, True, True), 'groups: [-gb]',
-          extra_groups=['gb'])
+          extra_groups=['+gb'])
     check((True, True, True), 'groups: [-ga]',
-          extra_groups=['ga'])
+          extra_groups=['+ga'])
     check((False, True, True), 'groups: [-ga]',
-          extra_groups=['ga', '-ga'])
+          extra_groups=['+ga', '-ga'])
     check((True, True, True), 'groups: [-ga]',
-          extra_groups=['ga', '-gb'])
+          extra_groups=['+ga', '-gb'])
     check((False, False, True), 'groups: [-ga]',
           extra_groups=['-gb'])
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -192,7 +192,7 @@ def test_list_groups(west_init_tmpdir):
            'bar .. path-for-bar',
            'baz .baz-group. baz'])
 
-    cmd('config manifest.groups foo-group-1')
+    cmd('config manifest.groups +foo-group-1')
     check('list -f "{name} .{groups}. {path}"',
           ['manifest .. zephyr',
            'foo .foo-group-1,foo-group-2. foo',
@@ -1077,8 +1077,8 @@ def test_init_local_with_empty_path(repos_tmpdir):
     assert (repos_tmpdir / 'workspace' / 'subdir' / 'Kconfiglib').check(dir=1)
 
 
-def test_update_with_groups_allow(west_init_tmpdir):
-    # Test "west update" with increasing numbers of groups allowed.
+def test_update_with_groups_enabled(west_init_tmpdir):
+    # Test "west update" with increasing numbers of groups enabled.
 
     remotes = west_init_tmpdir / '..' / 'repos'
 
@@ -1119,16 +1119,16 @@ def test_update_with_groups_allow(west_init_tmpdir):
     assert (west_init_tmpdir / 'tagged_repo').check(dir=0)
     assert (west_init_tmpdir / 'net-tools').check(dir=0)
 
-    cmd('update --groups allow-on-cmd-line')
+    cmd('update --groups +allow-on-cmd-line')
     assert (west_init_tmpdir / 'tagged_repo').check(dir=1)
     assert (west_init_tmpdir / 'net-tools').check(dir=0)
 
-    cmd('config manifest.groups allow-in-config-file')
+    cmd('config manifest.groups +allow-in-config-file')
     cmd('update')
     assert (west_init_tmpdir / 'net-tools').check(dir=1)
 
 
-def test_update_with_groups_block(west_init_tmpdir):
+def test_update_with_groups_disabled(west_init_tmpdir):
     # Test "west update" with decreasing numbers of groups blocked.
 
     remotes = west_init_tmpdir / '..' / 'repos'
@@ -1176,7 +1176,7 @@ def test_update_with_groups_block(west_init_tmpdir):
     assert (west_init_tmpdir / 'tagged_repo').check(dir=1)
 
     # allowlists override blocklists.
-    cmd('update --groups block-me')
+    cmd('update --groups +block-me')
     assert (west_init_tmpdir / 'subdir' / 'Kconfiglib').check(dir=1)
 
 def test_update_with_groups_explicit(west_init_tmpdir):


### PR DESCRIPTION
During review of the documentation for the 0.9 release, the following changes to manifest groups were requested:

- groups should be 'enabled' and 'disabled', not 'allowed' or 'blocked'
- enabling a group should be done by prefixing its name with '+'  in "manifest: groups:" or manifest.groups

Projects are still 'active' or 'inactive'.