### PR TITLE
Bump versions for post-0.9 development

### DIFF
--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -50,7 +50,7 @@ QUAL_REFS_WEST = 'refs/west/'
 #:
 #: This value changes when a new version of west includes new manifest
 #: file features not supported by earlier versions of west.
-SCHEMA_VERSION = '0.8.99'
+SCHEMA_VERSION = '0.9'
 # MAINTAINERS:
 #
 # If you want to update the schema version, you need to make sure that

--- a/src/west/version.py
+++ b/src/west/version.py
@@ -5,8 +5,7 @@
 # This is the Python 3 version of option 3 in:
 # https://packaging.python.org/guides/single-sourcing-package-version/#single-sourcing-the-version
 
-# DO NOT CUT 0.9 without bumping west.manifest.SCHEMA_VERSION too.
-__version__ = '0.8.99'
+__version__ = '0.9.99'
 # MAINTAINERS:
 #
 # Make sure to update west.manifest.SCHEMA_VERSION if there have been


### PR DESCRIPTION
This branch is now moving independently of v0.9-branch.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>