### PR TITLE
commands: import importlib.util explicitly

### DIFF
--- a/src/west/commands.py
+++ b/src/west/commands.py
@@ -5,7 +5,7 @@
 
 from abc import ABC, abstractmethod
 from collections import OrderedDict
-import importlib
+import importlib.util
 import itertools
 import os
 from pathlib import Path


### PR DESCRIPTION
Python environments usually do not import importlib.util
unless asked to do so specifically:

>\>\>\> import importlib
>\>\>\> importlib.util
>Traceback (most recent call last):
>  File "<stdin>", line 1, in <module>
>AttributeError: module 'importlib' has no attribute 'util'

Therefore it would be better to import importlib.util explicitly.
Some commands (e.g. west zephyr-export) do not work on my setup
without that change.

Signed-off-by: Ilya Tagunov <tagunil@gmail.com>