### PR TITLE
Group filters

### DIFF
--- a/src/west/manifest-schema.yml
+++ b/src/west/manifest-schema.yml
@@ -123,9 +123,9 @@ mapping:
             required: false
             include: groups-schema
 
-  # If present, an allowlist/blocklist of project groups. Prefix a
-  # group name with "-" to block it. Give a group name as-is to
-  # allow it.
+  # If present, a list of project groups to enable and disable. Prefix
+  # a group name with "-" to disable it. Give a group name as-is to
+  # enable it.
   group-filter:
     required: false
     include: groups-schema

--- a/src/west/manifest-schema.yml
+++ b/src/west/manifest-schema.yml
@@ -19,7 +19,7 @@
 #
 # --------------------------------------------------------------
 
-schema;groups:
+schema;groups-schema:
   type: seq
   sequence:
     - type: str
@@ -121,14 +121,14 @@ mapping:
             type: any
           groups:
             required: false
-            include: groups
+            include: groups-schema
 
   # If present, an allowlist/blocklist of project groups. Prefix a
   # group name with "-" to block it. Give a group name as-is to
   # allow it.
-  groups:
+  group-filter:
     required: false
-    include: groups
+    include: groups-schema
 
   # The "self" key specifies values for the project containing the manifest
   # file (the "manifest repository").

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -2487,13 +2487,13 @@ def test_invalid_groups():
       groups: {}
     '''
 
-    fmt_scalar_groups = '''
+    fmt_scalar_group_filter = '''
     projects: []
-    groups: {}
+    group-filter: {}
     '''
 
     # These come from pykwalify itself.
-    for fmt in [fmt_scalar_project, fmt_scalar_groups]:
+    for fmt in [fmt_scalar_project, fmt_scalar_group_filter]:
         check(fmt, 'hello', 'is not a list')
         check(fmt, 3, 'is not a list')
         check(fmt, 3.14, 'is not a list')
@@ -2523,8 +2523,8 @@ def test_groups():
     assert is_group('hello+world')
     assert is_group(3.14)
 
-def test_invalid_manifest_groups():
-    # Test cases for invalid "manifest: groups:" lists.
+def test_invalid_manifest_group_filters():
+    # Test cases for invalid "manifest: group-filter:" lists.
 
     def check(fmt, arg, err_must_contain):
         with pytest.raises(MalformedManifest) as e:
@@ -2533,7 +2533,7 @@ def test_invalid_manifest_groups():
 
     fmt = '''
     projects: []
-    groups:
+    group-filter:
     - {}
     '''
 
@@ -2542,8 +2542,8 @@ def test_invalid_manifest_groups():
     check(fmt, 'no:colons', 'contains invalid item "no:colons"')
     # leading dashes are okay here!
 
-    def check2(groups, err_must_contain):
-        data = {'manifest': {'projects': [], 'groups': groups}}
+    def check2(group_filter, err_must_contain):
+        data = {'manifest': {'projects': [], 'group-filter': group_filter}}
         with pytest.raises(MalformedManifest) as e:
             Manifest.from_data(data)
         assert err_must_contain in "\n".join(e.value.args)
@@ -2554,10 +2554,10 @@ def test_invalid_manifest_groups():
     check2(3.14, 'not a list')
 
 def test_is_active():
-    # Checks for the results of the 'groups' fields on
+    # Checks for the results of the 'groups' and 'group-filter' fields on
     # Manifest.is_active(project).
 
-    def manifest(groups):
+    def manifest(group_filter):
         data = f"""
         defaults:
           remote: r
@@ -2573,40 +2573,40 @@ def test_is_active():
               - ga
               - gb
           - name: p3
-        {groups}
+        {group_filter}
         """
 
         return M(data)
 
-    def check(expected, groups, extra_groups=None):
+    def check(expected, group_filter, extra_filter=None):
         # Checks that the 'expected' tuple matches the is_active() value
         # for the p1, p2, and p3 projects in the above manifest.
         #
-        # 'groups' is passed to the above manifest() helper.
+        # 'group_filter' is passed to the above manifest() helper.
         #
-        # 'extra_groups' is an optional additional groups list, for
+        # 'extra_filter' is an optional additional group filter, for
         # testing command line additions or for faking out config file
         # changes.
 
-        m = manifest(groups)
-        assert tuple(m.is_active(p, extra_groups=extra_groups)
+        m = manifest(group_filter)
+        assert tuple(m.is_active(p, extra_filter=extra_filter)
                      for p in m.get_projects(['p1', 'p2', 'p3'])) == expected
 
     check((True, True, True), '')
-    check((True, True, True), 'groups: [+ga]')
-    check((False, True, True), 'groups: [-ga]')
-    check((True, True, True), 'groups: [-gb]',
-          extra_groups=['+ga'])
-    check((True, True, True), 'groups: [-gb]',
-          extra_groups=['+gb'])
-    check((True, True, True), 'groups: [-ga]',
-          extra_groups=['+ga'])
-    check((False, True, True), 'groups: [-ga]',
-          extra_groups=['+ga', '-ga'])
-    check((True, True, True), 'groups: [-ga]',
-          extra_groups=['+ga', '-gb'])
-    check((False, False, True), 'groups: [-ga]',
-          extra_groups=['-gb'])
+    check((True, True, True), 'group-filter: [+ga]')
+    check((False, True, True), 'group-filter: [-ga]')
+    check((True, True, True), 'group-filter: [-gb]',
+          extra_filter=['+ga'])
+    check((True, True, True), 'group-filter: [-gb]',
+          extra_filter=['+gb'])
+    check((True, True, True), 'group-filter: [-ga]',
+          extra_filter=['+ga'])
+    check((False, True, True), 'group-filter: [-ga]',
+          extra_filter=['+ga', '-ga'])
+    check((True, True, True), 'group-filter: [-ga]',
+          extra_filter=['+ga', '-gb'])
+    check((False, False, True), 'group-filter: [-ga]',
+          extra_filter=['-gb'])
 
 #########################################
 # Various invalid manifests

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1083,8 +1083,8 @@ def test_update_with_groups_enabled(west_init_tmpdir):
     remotes = west_init_tmpdir / '..' / 'repos'
 
     with open(west_init_tmpdir / 'zephyr' / 'west.yml', 'w') as f:
-        # The purpose of the 'blocked' group is to ensure that a
-        # project's groups' "allowed" bits are ORed together, not
+        # The purpose of the 'disabled' group is to ensure that a
+        # project's groups' "enabled" bits are ORed together, not
         # ANDed together, when deciding if the project is active.
         f.write(f'''
         manifest:
@@ -1098,18 +1098,18 @@ def test_update_with_groups_enabled(west_init_tmpdir):
               revision: zephyr
               path: subdir/Kconfiglib
               groups:
-              - allowed
-              - blocked
+              - enabled
+              - disabled
             - name: tagged_repo
               revision: v1.0
               groups:
-              - allow-on-cmd-line
-              - blocked
+              - enable-on-cmd-line
+              - disabled
             - name: net-tools
               groups:
-              - allow-in-config-file
-              - blocked
-          group-filter: [-allow-on-cmd-line,-allow-in-config-file,-disabled]
+              - enable-in-config-file
+              - disabled
+          group-filter: [-enable-on-cmd-line,-enable-in-config-file,-disabled]
           self:
             path: zephyr
         ''')
@@ -1119,17 +1119,17 @@ def test_update_with_groups_enabled(west_init_tmpdir):
     assert (west_init_tmpdir / 'tagged_repo').check(dir=0)
     assert (west_init_tmpdir / 'net-tools').check(dir=0)
 
-    cmd('update --group-filter +allow-on-cmd-line')
+    cmd('update --group-filter +enable-on-cmd-line')
     assert (west_init_tmpdir / 'tagged_repo').check(dir=1)
     assert (west_init_tmpdir / 'net-tools').check(dir=0)
 
-    cmd('config manifest.group-filter +allow-in-config-file')
+    cmd('config manifest.group-filter +enable-in-config-file')
     cmd('update')
     assert (west_init_tmpdir / 'net-tools').check(dir=1)
 
 
 def test_update_with_groups_disabled(west_init_tmpdir):
-    # Test "west update" with decreasing numbers of groups blocked.
+    # Test "west update" with decreasing numbers of groups disabled.
 
     remotes = west_init_tmpdir / '..' / 'repos'
 
@@ -1146,27 +1146,27 @@ def test_update_with_groups_disabled(west_init_tmpdir):
               revision: zephyr
               path: subdir/Kconfiglib
               groups:
-              - block-me
+              - disabled
             - name: tagged_repo
               revision: v1.0
               groups:
-              - block-me-on-cmd-line
+              - disabled-on-cmd-line
             - name: net-tools
               groups:
-              - block-me-in-config-file
-          group-filter: [-block-me]
+              - disabled-in-config-file
+          group-filter: [-disabled]
           self:
             path: zephyr
         ''')
 
-    cmd('config manifest.group-filter -- -block-me-in-config-file')
-    cmd('update --group-filter=-block-me-on-cmd-line')
+    cmd('config manifest.group-filter -- -disabled-in-config-file')
+    cmd('update --group-filter=-disabled-on-cmd-line')
     assert (west_init_tmpdir / 'subdir' / 'Kconfiglib').check(dir=0)
     assert (west_init_tmpdir / 'tagged_repo').check(dir=0)
     assert (west_init_tmpdir / 'net-tools').check(dir=0)
 
     cmd('config -d manifest.group-filter')
-    cmd('update --group-filter=-block-me-on-cmd-line')
+    cmd('update --group-filter=-disabled-on-cmd-line')
     assert (west_init_tmpdir / 'subdir' / 'Kconfiglib').check(dir=0)
     assert (west_init_tmpdir / 'tagged_repo').check(dir=0)
     assert (west_init_tmpdir / 'net-tools').check(dir=1)
@@ -1175,8 +1175,8 @@ def test_update_with_groups_disabled(west_init_tmpdir):
     assert (west_init_tmpdir / 'subdir' / 'Kconfiglib').check(dir=0)
     assert (west_init_tmpdir / 'tagged_repo').check(dir=1)
 
-    # allowlists override blocklists.
-    cmd('update --group-filter +block-me')
+    # Enabling overrides disabling.
+    cmd('update --group-filter +disabled')
     assert (west_init_tmpdir / 'subdir' / 'Kconfiglib').check(dir=1)
 
 def test_update_with_groups_explicit(west_init_tmpdir):
@@ -1198,8 +1198,8 @@ def test_update_with_groups_explicit(west_init_tmpdir):
               revision: zephyr
               path: subdir/Kconfiglib
               groups:
-              - block-me
-          group-filter: [-block-me]
+              - disabled
+          group-filter: [-disabled]
           self:
             path: zephyr
         ''')

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -164,7 +164,7 @@ def test_list_groups(west_init_tmpdir):
           - name: baz
             groups:
             - baz-group
-          groups: [-foo-group-1,-foo-group-2,-baz-group]
+          group-filter: [-foo-group-1,-foo-group-2,-baz-group]
         """)
 
     def check(command_string, expected):
@@ -192,7 +192,7 @@ def test_list_groups(west_init_tmpdir):
            'bar .. path-for-bar',
            'baz .baz-group. baz'])
 
-    cmd('config manifest.groups +foo-group-1')
+    cmd('config manifest.group-filter +foo-group-1')
     check('list -f "{name} .{groups}. {path}"',
           ['manifest .. zephyr',
            'foo .foo-group-1,foo-group-2. foo',
@@ -1109,7 +1109,7 @@ def test_update_with_groups_enabled(west_init_tmpdir):
               groups:
               - allow-in-config-file
               - blocked
-          groups: [-allow-on-cmd-line,-allow-in-config-file,-blocked]
+          group-filter: [-allow-on-cmd-line,-allow-in-config-file,-disabled]
           self:
             path: zephyr
         ''')
@@ -1119,11 +1119,11 @@ def test_update_with_groups_enabled(west_init_tmpdir):
     assert (west_init_tmpdir / 'tagged_repo').check(dir=0)
     assert (west_init_tmpdir / 'net-tools').check(dir=0)
 
-    cmd('update --groups +allow-on-cmd-line')
+    cmd('update --group-filter +allow-on-cmd-line')
     assert (west_init_tmpdir / 'tagged_repo').check(dir=1)
     assert (west_init_tmpdir / 'net-tools').check(dir=0)
 
-    cmd('config manifest.groups +allow-in-config-file')
+    cmd('config manifest.group-filter +allow-in-config-file')
     cmd('update')
     assert (west_init_tmpdir / 'net-tools').check(dir=1)
 
@@ -1154,19 +1154,19 @@ def test_update_with_groups_disabled(west_init_tmpdir):
             - name: net-tools
               groups:
               - block-me-in-config-file
-          groups: [-block-me]
+          group-filter: [-block-me]
           self:
             path: zephyr
         ''')
 
-    cmd('config manifest.groups -- -block-me-in-config-file')
-    cmd('update --groups=-block-me-on-cmd-line')
+    cmd('config manifest.group-filter -- -block-me-in-config-file')
+    cmd('update --group-filter=-block-me-on-cmd-line')
     assert (west_init_tmpdir / 'subdir' / 'Kconfiglib').check(dir=0)
     assert (west_init_tmpdir / 'tagged_repo').check(dir=0)
     assert (west_init_tmpdir / 'net-tools').check(dir=0)
 
-    cmd('config -d manifest.groups')
-    cmd('update --groups=-block-me-on-cmd-line')
+    cmd('config -d manifest.group-filter')
+    cmd('update --group-filter=-block-me-on-cmd-line')
     assert (west_init_tmpdir / 'subdir' / 'Kconfiglib').check(dir=0)
     assert (west_init_tmpdir / 'tagged_repo').check(dir=0)
     assert (west_init_tmpdir / 'net-tools').check(dir=1)
@@ -1176,7 +1176,7 @@ def test_update_with_groups_disabled(west_init_tmpdir):
     assert (west_init_tmpdir / 'tagged_repo').check(dir=1)
 
     # allowlists override blocklists.
-    cmd('update --groups +block-me')
+    cmd('update --group-filter +block-me')
     assert (west_init_tmpdir / 'subdir' / 'Kconfiglib').check(dir=1)
 
 def test_update_with_groups_explicit(west_init_tmpdir):
@@ -1199,7 +1199,7 @@ def test_update_with_groups_explicit(west_init_tmpdir):
               path: subdir/Kconfiglib
               groups:
               - block-me
-          groups: [-block-me]
+          group-filter: [-block-me]
           self:
             path: zephyr
         ''')


### PR DESCRIPTION
As a result of review of the project groups feature documentation, change some of the names to be more clear, and be a bit more forgiving in the error handling.

A project's 'groups' list remains the same. No changes there.

However, we make the following changes:

- 'manifest: groups:' is now 'manifest: group-filter:'
- we add a west.manifest.Manifest.group_filter value, exposing 'manifest: group-filter:' after validation and string conversion
- the config option 'manifest.groups' is now 'manifest.group-filter'
- invalid values in manifest.group-filter are downgraded to warnings
- the west update '--groups' option becomes '--group-filter', with a slightly shorter name '--gf' if you can't handle that

I tacked on another fixup to the tests I noticed.