### PR TITLE
manifest-schema.yml: fix a comment

### DIFF
--- a/src/west/manifest-schema.yml
+++ b/src/west/manifest-schema.yml
@@ -124,8 +124,7 @@ mapping:
             include: groups-schema
 
   # If present, a list of project groups to enable and disable. Prefix
-  # a group name with "-" to disable it. Give a group name as-is to
-  # enable it.
+  # a group name with "-" to disable it; prefix with "+" to enable it.
   group-filter:
     required: false
     include: groups-schema


### PR DESCRIPTION
This is stale from before the move to group-filter and changing its
semantics to requiring a + and -.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>