### PR TITLE
manifest: make optional the 'name' attribute unused by Submodule

### DIFF
--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -90,8 +90,8 @@ _logger = logging.getLogger(__name__)
 class Submodule(NamedTuple):
     '''Represents a Git submodule within a project.'''
 
-    name: str
     path: str
+    name: Optional[str] = None
 
 # Submodules may be a list of values or a bool.
 SubmodulesType = Union[List[Submodule], bool]
@@ -353,7 +353,8 @@ def _is_submodule_dict_ok(subm: Any) -> bool:
 
     try:
         _assert(isinstance(subm, dict))
-        _assert(len(subm) == 2)
+        # Required key
+        _assert('path' in subm)
         # Allowed keys
         for k in subm:
             _assert(k in ['path', 'name'])

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -340,18 +340,29 @@ def _update_disabled_groups(disabled_groups: Set[str],
                  "along with as much information as you can, such as the "
                  "stack trace that preceded this message.")
 
-def _is_submodule_dict_ok(value: Any) -> bool:
-    # Check whether value is a dict that contains the expected
+def _is_submodule_dict_ok(subm: Any) -> bool:
+    # Check whether subm is a dict that contains the expected
     # submodule fields of proper types.
 
-    if not isinstance(value, dict):
+    class _failed(Exception):
+        pass
+
+    def _assert(cond):
+        if not cond:
+            raise _failed()
+
+    try:
+        _assert(isinstance(subm, dict))
+        _assert(len(subm) == 2)
+        # Allowed keys
+        for k in subm:
+            _assert(k in ['path', 'name'])
+            _assert(isinstance(subm[k], str))
+
+    except _failed:
         return False
 
-    if len(value) != 2:
-        return False  # Not enough keys, or too many.
-
-    return ('name' in value and isinstance(value['name'], str) and
-            'path' in value and isinstance(value['path'], str))
+    return True
 
 #
 # Public functions

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -510,8 +510,7 @@ def test_update_submodules_list(repos_tmpdir):
                         - name: zephyr
                           url: {zephyr}
                           submodules:
-                            - name: tagged_repo
-                              path: tagged_repo
+                            - path: tagged_repo
                         - name: net-tools
                           url: {net_tools}
                           submodules:
@@ -541,7 +540,7 @@ def test_update_submodules_list(repos_tmpdir):
 
     # Verify if tagged_repo submodule data are correct.
     assert zephyr_project.submodules
-    assert zephyr_project.submodules[0].name == 'tagged_repo'
+    assert zephyr_project.submodules[0].name is None
     assert zephyr_project.submodules[0].path == 'tagged_repo'
     # Verify if Kconfiglib submodule data are correct.
     assert net_tools_project.submodules


### PR DESCRIPTION
2 commits, see commit messages

Forcing users to define something unused is not just tedious, it's also confusing.