### PR TITLE
Import group filters, too

### DIFF
--- a/src/west/__init__.py
+++ b/src/west/__init__.py
@@ -1,3 +1,6 @@
-# Copyright (c) 2020, Nordic Semiconductor ASA
+# Copyright (c) 2021 Nordic Semiconductor ASA
 
-# nothing here
+import logging
+
+# https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library
+logging.getLogger('west').addHandler(logging.NullHandler())

--- a/src/west/manifest-schema.yml
+++ b/src/west/manifest-schema.yml
@@ -68,8 +68,12 @@ mapping:
 
   # The "projects" key specifies a sequence of "projects", each of which has a
   # remote, and may specify additional configuration.
+  #
+  # A manifest without projects was forbidden up through west 0.9.x,
+  # but it can be convenient to create such manifests at times, so it
+  # is now allowed.
   projects:
-    required: true
+    required: false
     type: seq
     sequence:
       - type: map

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -704,6 +704,8 @@ class Project:
         if self.west_commands:
             ret['west-commands'] = \
                 _west_commands_maybe_delist(self.west_commands)
+        if self.groups:
+            ret['groups'] = self.groups
 
         return ret
 
@@ -1381,6 +1383,8 @@ class Manifest:
         # and Python 3.7+ guarantee.
         r: Dict[str, Any] = {}
         r['manifest'] = {}
+        if self.group_filter:
+            r['manifest']['group-filter'] = self.group_filter
         r['manifest']['projects'] = project_dicts
         r['manifest']['self'] = self.projects[MANIFEST_PROJECT_INDEX].as_dict()
 

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -49,7 +49,7 @@ QUAL_REFS_WEST = 'refs/west/'
 #:
 #: This value changes when a new version of west includes new manifest
 #: file features not supported by earlier versions of west.
-SCHEMA_VERSION = '0.9'
+SCHEMA_VERSION = '0.10'
 # MAINTAINERS:
 #
 # If you want to update the schema version, you need to make sure that
@@ -1835,6 +1835,9 @@ class Manifest:
         # Load projects and add them to the list, returning
         # information about which ones have imports that need to be
         # processed next.
+
+        if 'projects' not in manifest:
+            return
 
         have_imports = []
         names = set()

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -78,6 +78,12 @@ ImporterType = Callable[['Project', str], ImportedContentType]
 # which always returns True.
 ImapFilterFnType = Optional[Callable[['Project'], bool]]
 
+# A list of group names to enable and disable, like ['+foo', '-bar'].
+GroupFilterType = List[str]
+
+# A list of group names belonging to a project, like ['foo', 'bar']
+GroupsType = List[str]
+
 # The parsed contents of a manifest YAML file as returned by _load(),
 # after sanitychecking with validate().
 ManifestDataType = Union[str, Dict]
@@ -330,16 +336,6 @@ def _compose_imap_filters(imap_filter1: ImapFilterFnType,
     else:
         return imap_filter1 or imap_filter2
 
-# A 'raw' element in a project 'groups:' or manifest 'group-filter:' list,
-# as it is parsed from YAML, before conversion to string.
-RawGroupType = Union[str, int, float]
-
-#: A list of group names belonging to a project, like ['foo', 'bar']
-GroupsType = List[str]
-
-#: A list of group names to enable and disable, like ['+foo', '-bar'].
-GroupFilterType = List[str]
-
 _RESERVED_GROUP_RE = re.compile(r'(^[+-]|[\s,:])')
 
 def _update_disabled_groups(disabled_groups: Set[str],
@@ -463,6 +459,10 @@ def validate(data: Any) -> None:
                             schema_files=[_SCHEMA_PATH]).validate()
     except pykwalify.errors.SchemaError as se:
         raise MalformedManifest(se.msg) from se
+
+# A 'raw' element in a project 'groups:' or manifest 'group-filter:' list,
+# as it is parsed from YAML, before conversion to string.
+RawGroupType = Union[str, int, float]
 
 def is_group(raw_group: RawGroupType) -> bool:
     '''Is a 'raw' project group value 'raw_group' valid?

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -460,6 +460,7 @@ def validate(data: Any) -> None:
             min_version_str = str(data['version'])
             casted_to_str = True
         else:
+            min_version_str = data['version']
             casted_to_str = False
 
         min_version = parse_version(min_version_str)

--- a/src/west/version.py
+++ b/src/west/version.py
@@ -5,9 +5,7 @@
 # This is the Python 3 version of option 3 in:
 # https://packaging.python.org/guides/single-sourcing-package-version/#single-sourcing-the-version
 
-__version__ = '0.9.99'
-# !!! DO NOT CUT 0.10 without updating west.manifest.SCHEMA_VERSION !!!
-#
+__version__ = '0.10.0a1'
 # MAINTAINERS:
 #
 # Make sure to update west.manifest.SCHEMA_VERSION if there have been

--- a/src/west/version.py
+++ b/src/west/version.py
@@ -6,6 +6,8 @@
 # https://packaging.python.org/guides/single-sourcing-package-version/#single-sourcing-the-version
 
 __version__ = '0.9.99'
+# !!! DO NOT CUT 0.10 without updating west.manifest.SCHEMA_VERSION !!!
+#
 # MAINTAINERS:
 #
 # Make sure to update west.manifest.SCHEMA_VERSION if there have been

--- a/tests/manifests/invalid_no_projects.yml
+++ b/tests/manifests/invalid_no_projects.yml
@@ -1,4 +1,0 @@
-manifest:
-  remotes:
-    - name: testremote
-      url-base: https://example.com

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1141,6 +1141,25 @@ def test_as_dict_and_yaml(manifest_repo):
                 manifest.as_frozen_yaml()
             assert 'cannot be resolved to a SHA' in str(e.value)
 
+def test_as_dict_groups():
+    # Make sure groups and group-filter round-trip properly.
+
+    actual = Manifest.from_data('''\
+    manifest:
+      group-filter: [+foo,-bar]
+      projects:
+        - name: p1
+          url: u
+        - name: p2
+          url: u
+          groups:
+            - g
+    ''').as_dict()['manifest']
+
+    assert actual['group-filter'] == ['+foo', '-bar']
+    assert 'groups' not in actual['projects'][0]
+    assert actual['projects'][1]['groups'] == ['g']
+
 def test_version_check_failure():
     # Check that the manifest.version key causes manifest parsing to
     # fail when it should.

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -535,6 +535,18 @@ def test_project_repr():
     assert repr(m.projects[1]) == \
         'Project("zephyr", "https://foo.com", revision="r", path=\'zephyr\', clone_depth=None, west_commands=[\'some-path/west-commands.yml\'], topdir=None, groups=[])'  # noqa: E501
 
+def test_no_projects():
+    # An empty projects list is allowed.
+
+    m = Manifest.from_data('manifest: {}')
+    assert len(m.projects) == 1  # just ManifestProject
+
+    m = M('''
+    self:
+      path: foo
+    ''')
+    assert len(m.projects) == 1  # just ManifestProject
+
 #########################################
 # Tests for the manifest repository
 


### PR DESCRIPTION
The west 0.9 documentation for group-filter states:

    Only the top level manifest file’s manifest: group-filter:
    value has any effect. The manifest: group-filter: values in any
    imported manifests are ignored.

See [Project Groups and Active Projects](https://docs.zephyrproject.org/latest/guides/west/manifest.html#project-groups-and-active-projects) for details on this feature.

This turns out to have been a mistake, which we are reversing course on.

It's a mistake because all users who import a manifest which makes some projects inactive will have to also manually disable the same groups just to get the same default list of projects.

Example manifest fragments showing the issue:

```yaml
   # my/west.yml
   manifest:
     projects:
       - name: upstream
         import: true
```

and:

```yaml
   # upstream/west.yml
   manifest:
     group-filter: [-disabled-group]
     projects:
       - name: i-want-this
       - name: i-do-not-want-this
         groups:
         - disabled-group
```

As written, my/west.yml will include 'i-do-not-want-this' as an active project.

This kind of leaky faucet has proven to be an unintuitive and poor user experience. People expect to get the default projects without having to copy the group-filter for everything they import.

We can't reverse this behavior without pushing out a new schema version, however: manifest schema 0.9 is doomed to repeat this behavior.

What we can do is create a new schema version that does the right thing, and get the word out to users to upgrade as soon as we can.

This PR updates the behavior for the new schema version (0.10) after some prep work to keep things tidy.

Additional notes:

- supersedes #481 by implementing the new behavior, and including test cases for all relevant scenarios.
- the original use case which showed the mistake is described in nrfconnect/sdk-nrf#3884
- the corresponding documentation update is in https://github.com/zephyrproject-rtos/zephyr/pull/32381