### PR TITLE
west init: get default manifest-rev from remote

### DIFF
--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -3,7 +3,6 @@
 import collections
 import os
 import re
-import shlex
 import shutil
 import subprocess
 import textwrap
@@ -965,7 +964,7 @@ def test_init_again(west_init_tmpdir):
 
     manifest = west_init_tmpdir / '..' / 'repos' / 'zephyr'
     popen = subprocess.Popen(
-        shlex.split(f'west -vvv init -m {manifest} workspace'),
+        ['west', '-vvv', 'init', '-m', str(manifest), 'workspace'],
         stdout=subprocess.DEVNULL,
         stderr=subprocess.PIPE,
         cwd=west_init_tmpdir.dirname)


### PR DESCRIPTION
Thanks to @marc-hb for pointing me in the right direction on this `ls-remote` incantation.


Instead of hard-coding a default revision to fetch from the remote,
get it from the remote URL itself if it's not provided by the user.

If that fails, we ask for the --manifest-rev option to be provided
explicitly.

This makes the code more robust by making its behavior match git
clone, which checks out whatever the remote wants you to use by
default instead of making assumptions.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>