### PR TITLE
West v0.10.1a1

### DIFF
--- a/src/west/version.py
+++ b/src/west/version.py
@@ -5,7 +5,7 @@
 # This is the Python 3 version of option 3 in:
 # https://packaging.python.org/guides/single-sourcing-package-version/#single-sourcing-the-version
 
-__version__ = '0.10.0'
+__version__ = '0.10.1a1'
 # MAINTAINERS:
 #
 # Make sure to update west.manifest.SCHEMA_VERSION if there have been

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -3,7 +3,6 @@
 import collections
 import os
 import re
-import shlex
 import shutil
 import subprocess
 import textwrap
@@ -965,7 +964,7 @@ def test_init_again(west_init_tmpdir):
 
     manifest = west_init_tmpdir / '..' / 'repos' / 'zephyr'
     popen = subprocess.Popen(
-        shlex.split(f'west -vvv init -m {manifest} workspace'),
+        ['west', '-vvv', 'init', '-m', str(manifest), 'workspace'],
         stdout=subprocess.DEVNULL,
         stderr=subprocess.PIPE,
         cwd=west_init_tmpdir.dirname)


### PR DESCRIPTION
Backport the 'west init --manifest-rev' change from master which
queries the remote for its HEAD branch if that option is not given.

Required for Zephyr to move its 'master' branch to 'main' without
breaking a plain 'west init'.