### PR TITLE
Improve "unknown command" error message

### DIFF
--- a/src/west/app/main.py
+++ b/src/west/app/main.py
@@ -310,7 +310,18 @@ class WestApp:
         # If we're running an extension, instantiate it from its
         # spec and re-parse arguments before running.
 
-        args, unknown = self.west_parser.parse_known_args(args=argv)
+        try:
+            args, unknown = self.west_parser.parse_known_args(args=argv)
+        except SystemExit as se:
+            log.err('Please check the following:\n'
+                    '- Check you entered the command properly\n'
+                    '- If your command is not recognized, check you are in'
+                    ' a workspace, and that the workspace '
+                    'contains the extension command you want to use\n'
+                    '- If you are running `west` outside of a'
+                    ' workspace, you must set <something else> so that'
+                    ' `west` knows where the workspace is located\n')
+            raise se
 
         # Set up logging verbosity before running the command, so e.g.
         # verbose messages related to argument handling errors work


### PR DESCRIPTION
## Note

I'm not sure if you want to accept this PR at this time, as the error message I've added might be out of date soon [according to this comment](https://github.com/zephyrproject-rtos/zephyr/discussions/33521#discussioncomment-534744).

I'm not sure if there is a better way to work around argparse's behavior, while still only giving the error message if `parse_known_args()` specifically fails.

## PR Description

 - Currently, the error message printed by `west` when you type an invalid command is the generic error message from the `argparse` library
 - This commit improves the error message printed by telling the user a few common problems/solutions
 - This commit works around argparse terminating the application on error, by means of a wrapper function which records what error occured

Signed-off-by: Daniel Wong <drojfjord@gmail.com>