### PR TITLE
project.py: --initial-branch=placeholder to silence verbose warning

### DIFF
--- a/src/west/app/project.py
+++ b/src/west/app/project.py
@@ -1117,7 +1117,17 @@ class Update(_ProjectCommand):
 
         if cache_dir is None:
             log.small_banner(f'{project.name}: initializing')
-            project.git(['init', project.abspath], cwd=self.topdir)
+
+            init_cmd = ['init', project.abspath]
+            # Silence the very verbose and repetitive init.defaultBranch
+            # warning (10 lines per new git clone). The branch
+            # 'placeholder' will never have any commit so it will never
+            # actually exist.
+            if self.git_version_info >= (2, 28, 0):
+                init_cmd.insert(1, '--initial-branch=init_placeholder')
+
+            project.git(init_cmd, cwd=self.topdir)
+
             # This remote is added as a convenience for the user.
             # However, west always fetches project data by URL, not name.
             # The user is therefore free to change the URL of this remote.


### PR DESCRIPTION
Silences the following, verbose and repetive warning when using
git >= 2.28

As this warning is 10 lines long and there are 40 projects in zephyr
right now, this cuts stderr for `west init` almost in half, from ~950
lines down to ~550 lines.

The non @static-ness of the git methods explained in PR #494 has to
"leak" to ensure_cloned(), at least for now. A single Update object
downloads all projects so this does not cause git --version to be
invoked many times.

```
hint: Using 'master' as the name for the initial branch. This default branch name
hint: is subject to change. To configure the initial branch name to use in all
hint: of your new repositories, which will suppress this warning, call:
hint:
hint:   git config --global init.defaultBranch <name>
hint:
hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
hint: 'development'. The just-created branch can be renamed via this command:
hint:
hint:   git branch -m <name>
```
Signed-off-by: Marc Herbert <marc.herbert@intel.com>