### PR TITLE
Update optimizations

### DIFF
--- a/src/west/app/project.py
+++ b/src/west/app/project.py
@@ -1231,10 +1231,19 @@ class Update(_ProjectCommand):
         project.git(['fetch', '-f'] + tags + clone_depth +
                     self.args.fetch_opt +
                     ['--', project.url, refspec])
-        _update_manifest_rev(project, next_manifest_rev)
 
         if take_stats:
-            stats['fetch and set manifest-rev'] = perf_counter() - start
+            stats['fetch'] = perf_counter() - start
+
+        # Update manifest-rev, leaving an entry in the reflog.
+        if take_stats:
+            start = perf_counter()
+
+        new_ref = project.sha(next_manifest_rev)
+        _update_manifest_rev(project, new_ref)
+
+        if take_stats:
+            stats['set manifest-rev'] = perf_counter() - start
 
     @staticmethod
     def clean_refs_west(project, stats, take_stats):

--- a/src/west/app/project.py
+++ b/src/west/app/project.py
@@ -804,6 +804,11 @@ class Update(_ProjectCommand):
 
         self.group_filter: List[str] = []
 
+        if args.narrow:
+            self.narrow = True
+        else:
+            self.narrow = config.getboolean('update', 'narrow', fallback=False)
+
         def handle(group_filter_item):
             item = group_filter_item.strip()
             if not item.startswith(('-', '+')):
@@ -1201,7 +1206,7 @@ class Update(_ProjectCommand):
         # non-commit object" error when the revision is an annotated
         # tag. ^{commit} type peeling isn't supported for the <src> in a
         # <src>:<dst> refspec, so we have to do it separately.
-        if _maybe_sha(rev) and not self.args.narrow:
+        if _maybe_sha(rev) and not self.narrow:
             # We can't in general fetch a SHA from a remote, as some hosts
             # forbid it for security reasons. Let's hope it's reachable
             # from some branch.
@@ -1222,7 +1227,7 @@ class Update(_ProjectCommand):
         log.small_banner(f'{project.name}: fetching, need revision {rev}')
         # --tags is required to get tags if we're not run as 'west
         # update --narrow', since the remote is specified as a URL.
-        tags = (['--tags'] if not self.args.narrow else [])
+        tags = (['--tags'] if not self.narrow else [])
         clone_depth = (['--depth', str(project.clone_depth)] if
                        project.clone_depth else [])
         # -f is needed to avoid errors in case multiple remotes are

--- a/src/west/app/project.py
+++ b/src/west/app/project.py
@@ -1202,9 +1202,9 @@ class Update(_ProjectCommand):
         else:
             depth = []
         if _maybe_sha(rev):
-            # We can't in general fetch a SHA from a remote, as many hosts
-            # (GitHub included) forbid it for security reasons. Let's hope
-            # it's reachable from some branch.
+            # We can't in general fetch a SHA from a remote, as some hosts
+            # forbid it for security reasons. Let's hope it's reachable
+            # from some branch.
             refspec = f'refs/heads/*:{QUAL_REFS}*'
             next_manifest_rev = project.revision
         else:

--- a/src/west/app/project.py
+++ b/src/west/app/project.py
@@ -817,6 +817,10 @@ class Update(_ProjectCommand):
 
         self.narrow = args.narrow or config.getboolean('update', 'narrow',
                                                        fallback=False)
+        self.path_cache = args.path_cache or config.get('update', 'path-cache',
+                                                        fallback=None)
+        self.name_cache = args.name_cache or config.get('update', 'name-cache',
+                                                        fallback=None)
 
         self.group_filter: List[str] = []
 
@@ -1151,26 +1155,29 @@ class Update(_ProjectCommand):
     def project_cache(self, project):
         # Find the absolute path to a pre-existing local clone of a project
         # and return it. If the search fails, return None.
-        name_cache, path_cache = self.args.name_cache, self.args.path_cache
 
-        if name_cache is not None:
-            maybe = Path(name_cache) / project.name
+        if self.name_cache is not None:
+            maybe = Path(self.name_cache) / project.name
             if maybe.is_dir():
-                log.dbg(f'found {project.name} in --name-cache {name_cache}',
-                        level=log.VERBOSE_VERY)
+                log.dbg(
+                    f'found {project.name} in --name-cache {self.name_cache}',
+                    level=log.VERBOSE_VERY)
                 return os.fspath(maybe)
             else:
-                log.dbg(f'{project.name} not in --name-cache {name_cache}',
-                        level=log.VERBOSE_VERY)
-        elif self.args.path_cache is not None:
-            maybe = Path(self.args.path_cache) / project.path
+                log.dbg(
+                    f'{project.name} not in --name-cache {self.name_cache}',
+                    level=log.VERBOSE_VERY)
+        elif self.path_cache is not None:
+            maybe = Path(self.path_cache) / project.path
             if maybe.is_dir():
-                log.dbg(f'found {project.path} in --path-cache {path_cache}',
-                        level=log.VERBOSE_VERY)
+                log.dbg(
+                    f'found {project.path} in --path-cache {self.path_cache}',
+                    level=log.VERBOSE_VERY)
                 return os.fspath(maybe)
             else:
-                log.dbg(f'{project.path} not in --path-cache {path_cache}',
-                        level=log.VERBOSE_VERY)
+                log.dbg(
+                    f'{project.path} not in --path-cache {self.path_cache}',
+                    level=log.VERBOSE_VERY)
 
         return None
 

--- a/src/west/app/project.py
+++ b/src/west/app/project.py
@@ -170,7 +170,7 @@ With neither, -m {MANIFEST_URL_DEFAULT} is assumed.
 
         return parser
 
-    def do_run(self, args, ignored):
+    def do_run(self, args, _):
         if self.topdir:
             zb = os.environ.get('ZEPHYR_BASE')
             if zb:
@@ -786,7 +786,7 @@ class Update(_ProjectCommand):
 
         return parser
 
-    def do_run(self, args, user_args):
+    def do_run(self, args, _):
         self.die_if_no_git()
         self._setup_logging(args)
 
@@ -942,7 +942,7 @@ class Update(_ProjectCommand):
             log.die('one or more projects are unknown or defined via '
                     'imports; please run plain "west update".')
 
-        projects, unknown = projects_unknown(self.manifest, ids)
+        _, unknown = projects_unknown(self.manifest, ids)
         if unknown:
             die_unknown(unknown)
         else:

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -969,23 +969,34 @@ def test_update_name_cache(tmpdir):
     # network if it doesn't have to.
 
     name_cache_dir = tmpdir / 'name_cache'
-
     create_repo(name_cache_dir / 'foo')
     create_repo(name_cache_dir / 'bar')
-
     foo_head = rev_parse(name_cache_dir / 'foo', 'HEAD')
     bar_head = rev_parse(name_cache_dir / 'bar', 'HEAD')
 
     workspace = tmpdir / 'workspace'
     setup_cache_workspace(workspace, foo_head, bar_head)
+    workspace.chdir()
+    foo = workspace / 'subdir' / 'foo'
+    bar = workspace / 'bar'
 
-    cmd(f'update --name-cache {name_cache_dir}', cwd=workspace)
+    # Test the command line option.
+    cmd(f'update --name-cache {name_cache_dir}')
+    assert foo.check(dir=1)
+    assert bar.check(dir=1)
+    assert rev_parse(foo, 'HEAD') == foo_head
+    assert rev_parse(bar, 'HEAD') == bar_head
 
-    assert (workspace / 'subdir' / 'foo').check(dir=1)
-    assert (workspace / 'bar').check(dir=1)
-
-    assert rev_parse(workspace / 'subdir' / 'foo', 'HEAD') == foo_head
-    assert rev_parse(workspace / 'bar', 'HEAD') == bar_head
+    # Move the repositories out of the way and test the configuration option.
+    # (We can't use shutil.rmtree here because Windows.)
+    shutil.move(os.fspath(foo), os.fspath(tmpdir))
+    shutil.move(os.fspath(bar), os.fspath(tmpdir))
+    cmd(f'config update.name-cache {name_cache_dir}')
+    cmd('update')
+    assert foo.check(dir=1)
+    assert bar.check(dir=1)
+    assert rev_parse(foo, 'HEAD') == foo_head
+    assert rev_parse(bar, 'HEAD') == bar_head
 
 
 def test_update_path_cache(tmpdir):
@@ -993,23 +1004,34 @@ def test_update_path_cache(tmpdir):
     # network if it doesn't have to.
 
     path_cache_dir = tmpdir / 'path_cache_dir'
-
     create_repo(path_cache_dir / 'subdir' / 'foo')
     create_repo(path_cache_dir / 'bar')
-
     foo_head = rev_parse(path_cache_dir / 'subdir' / 'foo', 'HEAD')
     bar_head = rev_parse(path_cache_dir / 'bar', 'HEAD')
 
     workspace = tmpdir / 'workspace'
     setup_cache_workspace(workspace, foo_head, bar_head)
+    workspace.chdir()
+    foo = workspace / 'subdir' / 'foo'
+    bar = workspace / 'bar'
 
-    cmd(f'update --path-cache {path_cache_dir}', cwd=workspace)
+    # Test the command line option.
+    cmd(f'update --path-cache {path_cache_dir}')
+    assert foo.check(dir=1)
+    assert bar.check(dir=1)
+    assert rev_parse(foo, 'HEAD') == foo_head
+    assert rev_parse(bar, 'HEAD') == bar_head
 
-    assert (workspace / 'subdir' / 'foo').check(dir=1)
-    assert (workspace / 'bar').check(dir=1)
-
-    assert rev_parse(workspace / 'subdir' / 'foo', 'HEAD') == foo_head
-    assert rev_parse(workspace / 'bar', 'HEAD') == bar_head
+    # Move the repositories out of the way and test the configuration option.
+    # (We can't use shutil.rmtree here because Windows.)
+    shutil.move(os.fspath(foo), os.fspath(tmpdir))
+    shutil.move(os.fspath(bar), os.fspath(tmpdir))
+    cmd(f'config update.path-cache {path_cache_dir}')
+    cmd('update')
+    assert foo.check(dir=1)
+    assert bar.check(dir=1)
+    assert rev_parse(foo, 'HEAD') == foo_head
+    assert rev_parse(bar, 'HEAD') == bar_head
 
 
 def setup_narrow(tmpdir):


### PR DESCRIPTION
This implements new `west update` options that can be used to optimize performance:

- `--name-cache`, `--path-cache`: allows cloning project repositories from a known place on the file system before hitting the network to fetch the current revisions (improves performance by not fetching if possible)
- `--narrow`: fetches the project revision directly even if it is a SHA, and does not fetch tags (improves performance by fetching fewer objects than the default `west update`)
- `--fetch-opt`: allows specifying additional options to each `git fetch` used by `west update`, such as `--depth=1` (which may improve performance if many objects in history are not needed)

It also adds some new configuration options:

- `update.narrow`: boolean, default false. If true, `west update` uses `--narrow` always.
- `update.path-cache`: string, default no value. If nonempty, west update uses this as its `--path-cache` if not otherwise specified.
- `update.name-cache`: same as `update.path-cache`, but for the `--name-cache` option.
