### PR TITLE
commands: fix git version detection on macOS

### DIFF
--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,0 +1,16 @@
+# Copyright (c) 2021, Nordic Semiconductor ASA
+
+import os
+
+from west.commands import WestCommand
+
+assert 'TOXTEMPDIR' in os.environ, "you must run these tests using tox"
+
+gv = WestCommand._parse_git_version
+
+def test_parse_git_version():
+    # White box test for git parsing behavior.
+    assert gv(b'git version 2.25.1\n') == (2, 25, 1)
+    assert gv(b'git version 2.28.0.windows.1\n') == (2, 28, 0)
+    assert gv(b'git version 2.24.3 (Apple Git-128)\n') == (2, 24, 3)
+    assert gv(b'git version 2.29.GIT\n') == (2, 29)


### PR DESCRIPTION
I ran into this testing 0.11.0a1. Our current code matches against the
last word in the 'git --version' output. Unfortunately, for 'git
version 2.24.3 (Apple Git-128)', that's incorrectly matching against
'Git-128)', which doesn't work.

Generalize the version detection a bit to handle this.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>