### PR TITLE
west update: fix --fetch=smart for lightweight tags

### DIFF
--- a/src/west/app/project.py
+++ b/src/west/app/project.py
@@ -1512,7 +1512,7 @@ def _rev_type(project, rev=None):
     elif stdout != 'commit':    # just future-proofing
         return 'other'
 
-    # to tell branches apart from commits, we need rev-parse.
+    # to tell branches, lightweight tags, and commits apart, we need rev-parse.
     cp = project.git(['rev-parse', '--verify', '--symbolic-full-name', rev],
                      check=False, capture_stdout=True, capture_stderr=True)
     if cp.returncode:
@@ -1528,6 +1528,10 @@ def _rev_type(project, rev=None):
     stdout = cp.stdout.decode('utf-8').strip()
     if stdout.startswith('refs/heads'):
         return 'branch'
+    elif stdout.startswith('refs/tags'):
+        # Annotated tags are handled above. Lightweight tags are
+        # handled here.
+        return 'tag'
     elif not stdout:
         return 'commit'
     else:

--- a/tox.ini
+++ b/tox.ini
@@ -29,6 +29,7 @@ deps =
     setuptools-scm
     pytest
     pytest-cov
+    types-PyYAML
     flake8
     mypy
 setenv =


### PR DESCRIPTION
When a project revision in west.yml is a lightweight tag,
'git cat-file -t <revision>' prints 'commit' instead of 'tag'.

Hilarious as this may be, it confuses the _rev_type() helper used by
west update. The helper doesn't know what kind of revision it is,
since it's not a branch and doesn't look like a commit either. We then
fetch the tag unnecessarily since we don't know what we're dealing
with. That works, but we don't need to hit the network in this case.

Fix this by handling the lightweight tag case as well.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>