### PR TITLE
Detached HEAD in manifest repository and master fixes

### DIFF
--- a/MAINTAINERS.rst
+++ b/MAINTAINERS.rst
@@ -4,7 +4,7 @@ Pre-release test plan
 ---------------------
 
 0. If no release branch exists, fork the version numbers in the release branch
-   (vX.Y-branch) and the master branch. See "Cutting a release branch", below,
+   (vX.Y-branch) and the main branch. See "Cutting a release branch", below,
    for details.
 
    The rest of these steps should be done in the release branch::
@@ -102,16 +102,16 @@ maintainers that it's time and push it manually to GitHub.
 The release branch for minor version vX.Y.0 should be named "vX.Y-branch".
 
 Subsequent fixes for patch versions vX.Y.Z should go to vX.Y-branch after
-being backported from master (or the other way around in case of an urgent
+being backported from main (or the other way around in case of an urgent
 hotfix).
 
 In vX.Y-branch, in src/west/version.py, set __version__ to X.Y.0a1.
-Don't include this commit in the master branch.
+Don't include this commit in the main branch.
 
 Summary of the outcome:
 
-- precondition: vX.Y-branch does not exist, master is at version X.(Y-1).99
-- postcondition: v.X.Y-branch exists and is at version vX.Y.0a1, master is at
+- precondition: vX.Y-branch does not exist, main is at version X.(Y-1).99
+- postcondition: v.X.Y-branch exists and is at version vX.Y.0a1, main is at
   version vX.Y.99
 
 Check if west.manifest.SCHEMA_VERSION also needs an update. The rule is that
@@ -129,9 +129,9 @@ Send this as a pull request to the newly created release branch. (This
 requires a PR and review because getting the release number wrong would
 upload potentially buggy software to anyone who runs 'pip install west'.)
 
-In master (but not the release branch), set __version__ to X.Y.99. Send this
-commit as a PR to master. Make sure any SCHEMA_VERSION updates are reflected in
-master too.
+In main (but not the release branch), set __version__ to X.Y.99. Send this
+commit as a PR to main. Make sure any SCHEMA_VERSION updates are reflected in
+main too.
 
-From this point forward, the master branch is moving independently from the
+From this point forward, the main branch is moving independently from the
 release branch.

--- a/MAINTAINERS.rst
+++ b/MAINTAINERS.rst
@@ -41,6 +41,9 @@ Pre-release test plan
      cd zephyrproject
      west update
 
+   Make sure zephyrproject/zephyr has a branch checked out that matches the
+   default branch used by zephyr itself.
+
 6. Do the following Zephyr specific testing in the Zephyr workspace on all of
    the platforms from 1. Skip QEMU tests on non-Linux platforms, and make sure
    ZEPHYR_BASE is unset in the calling environment. ::

--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ You use ``west init`` to set up this directory, then ``west update`` to fetch
 and/or update the repositories named in the manifest.
 
 By default, west uses `upstream Zephyr's manifest file
-<https://github.com/zephyrproject-rtos/zephyr/blob/master/west.yml>`_, but west
+<https://github.com/zephyrproject-rtos/zephyr/blob/main/west.yml>`_, but west
 doesn't care if the manifest repository is a Zephyr tree or not.
 
 For more details, see `Multiple Repository Management
@@ -45,8 +45,8 @@ What just happened:
   creating working trees in the installation directory ``zephyrproject``.
 
 Use ``west init -m`` to specify another manifest repository. Use ``--mr`` to
-use a revision other than ``master``. Use ``--mf`` to use a manifest file other
-than ``west.yml``.
+use a revision to inialize from; if not given, the remote's default branch is used.
+Use ``--mf`` to use a manifest file other than ``west.yml``.
 
 Additional Commands
 -------------------

--- a/src/west/app/project.py
+++ b/src/west/app/project.py
@@ -375,7 +375,7 @@ With neither, -m {MANIFEST_URL_DEFAULT} is assumed.
         else:
             # Fetch the ref-space similar to git clone plus the ref
             # given by user.  Redundancy is ok, for example if the user
-            # specifies 'heads/master'. This allows users to specify:
+            # specifies 'heads/my-branch'. This allows users to specify:
             # pull/<no>/head for pull requests
             self.check_call(('git', 'fetch', 'origin', '--tags', '--',
                              rev, 'refs/heads/*:refs/remotes/origin/*'),
@@ -1486,15 +1486,13 @@ class Update(_ProjectCommand):
             # we called Update.init_project() above), check out
             # 'manifest-rev' in a detached HEAD state.
             #
-            # Otherwise, the initial state would have nothing checked
-            # out, and HEAD would point to a non-existent
-            # refs/heads/master branch (that would get created if the
-            # user makes an initial commit). Among other things, this
-            # ensures the rev-parse --abbrev-ref HEAD which happens
-            # later in the update() will always succeed.
+            # Otherwise, it's possible for the initial state to have
+            # nothing checked out and HEAD pointing to a non-existent
+            # branch. This causes the 'git rev-parse --abbrev-ref HEAD'
+            # which happens later in the update to fail.
             #
             # The --detach flag is strictly redundant here, because
-            # the refs/heads/<branch> form already detaches HEAD, but
+            # the qualified manifest-rev form detaches HEAD, but
             # it avoids a spammy detached HEAD warning from Git.
             if take_stats:
                 start = perf_counter()

--- a/src/west/manifest-schema.yml
+++ b/src/west/manifest-schema.yml
@@ -5,7 +5,7 @@
 ##
 ## This schema has similar semantics to the repo XML format:
 ##
-## https://gerrit.googlesource.com/git-repo/+/master/docs/manifest-format.txt
+## https://gerrit.googlesource.com/git-repo/+/master/docs/manifest-format.md
 ##
 ## However, the features don't map 1:1.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -295,11 +295,20 @@ def create_workspace(workspace_dir, and_git=True):
     if and_git:
         create_repo(mp)
 
-def create_repo(path):
-    # Initializes a Git repository in 'path', and adds an initial commit to it
+def create_repo(path, initial_branch='master'):
+    # Initializes a Git repository in 'path', and adds an initial
+    # commit to it in a new branch 'initial_branch'. We're currently
+    # keeping the old default initial branch to keep assumptions made
+    # elsewhere in the test code working with newer versions of git.
     path = os.fspath(path)
 
-    subprocess.check_call([GIT, 'init', path])
+    if GIT_INIT_HAS_BRANCH:
+        subprocess.check_call([GIT, 'init', '--initial-branch', initial_branch,
+                               path])
+    else:
+        subprocess.check_call([GIT, 'init', path])
+        subprocess.check_call([GIT, 'checkout', '-b', initial_branch],
+                              cwd=path)
 
     config_repo(path)
     add_commit(path, 'initial')


### PR DESCRIPTION
The main point of this PR is to fix an issue where initializing from a URL leaves the manifest repository in a detached HEAD state. 

To get here, though, I needed to include other fixes so I could test it on my Arch machine, which is no longer passing tox, due to changes in the way git works.

While I'm here, I decided to grep for 'master' throughout the tree and remove it where possible or no longer applicable, to keep up as much as practical with where git is going in the time I have to work on this. I'm leaving some work for the future; see commit logs for details.