### PR TITLE
Fix west.manifest.Project.sha() for tag revisions

### DIFF
--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -832,8 +832,8 @@ class Project:
         # Though we capture stderr, it will be available as the stderr
         # attribute in the CalledProcessError raised by git() in
         # Python 3.5 and above if this call fails.
-        cp = self.git(f'rev-parse {rev}', capture_stdout=True, cwd=cwd,
-                      capture_stderr=True)
+        cp = self.git(f'rev-parse {rev}^{{commit}}', capture_stdout=True,
+                      cwd=cwd, capture_stderr=True)
         # Assumption: SHAs are hex values and thus safe to decode in ASCII.
         # It'll be fun when we find out that was wrong and how...
         return cp.stdout.decode('ascii').strip()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -331,6 +331,8 @@ def add_commit(repo, msg, files=None, reconfigure=True):
          '--no-gpg-sign', '--no-post-rewrite'], cwd=repo)
 
 def add_tag(repo, tag, commit='HEAD', msg=None):
+    repo = os.fspath(repo)
+
     if msg is None:
         msg = 'tag ' + tag
 
@@ -340,6 +342,7 @@ def add_tag(repo, tag, commit='HEAD', msg=None):
                           cwd=repo)
 
 def rev_parse(repo, revision):
+    repo = os.fspath(repo)
     out = subprocess.check_output([GIT, 'rev-parse', revision], cwd=repo)
     return out.decode(sys.getdefaultencoding()).strip()
 

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -27,7 +27,7 @@ from west.manifest import Manifest, Project, ManifestProject, \
     _ManifestImportDepth, is_group
 
 from conftest import create_workspace, create_repo, checkout_branch, \
-    create_branch, add_commit, rev_parse, GIT, check_proj_consistency
+    create_branch, add_commit, add_tag, rev_parse, GIT, check_proj_consistency
 
 assert 'TOXTEMPDIR' in os.environ, "you must run these tests using tox"
 
@@ -535,6 +535,18 @@ def test_project_repr():
     ''')
     assert repr(m.projects[1]) == \
         'Project("zephyr", "https://foo.com", revision="r", path=\'zephyr\', clone_depth=None, west_commands=[\'some-path/west-commands.yml\'], topdir=None, groups=[])'  # noqa: E501
+
+def test_project_sha(tmpdir):
+    tmpdir = Path(os.fspath(tmpdir))
+    create_repo(tmpdir)
+    add_tag(tmpdir, 'test-tag')
+    expected_sha = rev_parse(tmpdir, 'HEAD^{commit}')
+    project = Project('name',
+                      'url-do-not-fetch',
+                      revision='test-tag',
+                      path=tmpdir.name,
+                      topdir=tmpdir.parent)
+    assert project.sha(project.revision) == expected_sha
 
 def test_no_projects():
     # An empty projects list is allowed.


### PR DESCRIPTION
We need to use commit peeling to ensure that a revision which is a tag
is converted to a SHA. The current way Project.sha() works only
handles branches.

