### PR TITLE
Fix checkout -b in conftest

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -307,7 +307,11 @@ def create_repo(path, initial_branch='master'):
                                path])
     else:
         subprocess.check_call([GIT, 'init', path])
-        subprocess.check_call([GIT, 'checkout', '-b', initial_branch],
+        # -B instead of -b because on some versions of git (at
+        # least 2.25.1 as shipped by Ubuntu 20.04), if 'git init path'
+        # created an 'initial_branch' already, we get errors that it
+        # already exists with plain '-b'.
+        subprocess.check_call([GIT, 'checkout', '-B', initial_branch],
                               cwd=path)
 
     config_repo(path)


### PR DESCRIPTION
Commit 6d42388
("tests: adjust create_repo() to keep working on newer git") got tox
working again in Arch on my laptop, and in CI for whatever GitHub
decides to use for ubuntu-latest, but it breaks tox on my Ubuntu 20.04
LTS testing environment that I use for release testing.

Fix it, again, and hopefully for the last time. See comments in the
source code for details on the fix.