### PR TITLE
West 0.11.1

### DIFF
--- a/src/west/version.py
+++ b/src/west/version.py
@@ -5,7 +5,7 @@
 # This is the Python 3 version of option 3 in:
 # https://packaging.python.org/guides/single-sourcing-package-version/#single-sourcing-the-version
 
-__version__ = '0.11.1a1'
+__version__ = '0.11.1'
 #
 # MAINTAINERS:
 #


### PR DESCRIPTION
New features:

- west status now only prints output for projects which have a nonempty
  status.

Bug fixes:

- The manifest file parser was incorrectly allowing project names which contain
  the path separator characters / and \. These invalid characters are
  now rejected.

  Note: if you need to place a project within a subdirectory of the workspace
  topdir, use the 'path:' key. If you need to customize a project's fetch URL
  relative to its remote 'url-base:', use 'repo-path:'.

- The changes made in west v0.10.1 to the 'west init --manifest-rev' option
  which selected the default branch name were leaving the manifest repository
  in a detached HEAD state. This has been fixed by using 'git clone' internally
  instead of 'git init' and 'git fetch'. See issue #522 for details.

- The WEST_CONFIG_LOCAL environment variable now correctly
  overrides the default location, <workspace topdir>/.west/config.

- west update --fetch=smart (smart is the default) now correclty skips
  fetches for project revisions which are lightweight tags (it already
  worked correctly for annotated tags; only lightweight tags were unnecessarily
  fetched).

Other changes:

- The fix for issue #522 mentioned above introduces a new restriction. The
  west init --manifest-rev option value, if given, must now be either a
  branch or a tag. In particular, "pseudo-branches" like GitHub's
  pull/1234/head references which could previously be used to fetch a pull
  request can no longer be passed to --manifest-rev. Users must now fetch
  and check out such revisions manually after running west init.

API changes:

- west.manifest.Manifest.get_projects() avoids incorrect results in
  some edge cases described in issue #523.

- west.manifest.Project.sha() now works correctly for tag revisions.
  (This applies to both lightweight and annotated tags.)

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>