### PR TITLE
manifest: fix some Project.userdata issues

### DIFF
--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -658,7 +658,7 @@ class Project:
                 f'west_commands={self.west_commands}, '
                 f'topdir={repr(self.topdir)}, '
                 f'groups={repr(self.groups)}, '
-                f'userdata={self.userdata})')
+                f'userdata={repr(self.userdata)})')
 
     def __str__(self):
         path_repr = repr(self.abspath or self.path)
@@ -754,6 +754,8 @@ class Project:
                 _west_commands_maybe_delist(self.west_commands)
         if self.groups:
             ret['groups'] = self.groups
+        if self.userdata:
+            ret['userdata'] = self.userdata
 
         return ret
 

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -564,9 +564,13 @@ def test_project_userdata(tmpdir):
         key: value
     ''')
     foo, bar, baz = m.get_projects(['foo', 'bar', 'baz'])
+
     assert foo.userdata is None
     assert bar.userdata == 'a-string'
     assert baz.userdata == {'key': 'value'}
+
+    assert 'userdata' not in foo.as_dict()
+    assert 'a-string' == bar.as_dict()['userdata']
 
 def test_no_projects():
     # An empty projects list is allowed.


### PR DESCRIPTION
Make sure the userdata round-trips properly through 'west manifest
--freeze' by adding it to the project's dict representation.

Add a missing repr() inside the userdata related part of
Project.__repr__.

Fixes: #536

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>