### PR TITLE
update: fix --tags explanation in --narrow help string

### DIFF
--- a/src/west/app/project.py
+++ b/src/west/app/project.py
@@ -767,8 +767,9 @@ class Update(_ProjectCommand):
                            may be given more than once''')
         group.add_argument('-n', '--narrow', action='store_true',
                            help='''fetch just the project revision if fetching
-                           is necessary; skip fetching tags (may not work for
-                           SHA revisions depending on the Git host)''')
+                           is necessary; do not pass --tags to git fetch
+                           (may not work for SHA revisions depending on the Git
+                           host)''')
 
         group = parser.add_argument_group(
             title='checked out branch behavior',


### PR DESCRIPTION
For 'git fetch', neither --tags nor --no-tags is the default value. The
default value is a middle ground that fetches "any tag that points into
the histories being fetched is also fetched" - second paragraph in "git
help fetch". Rather than duplicating this relatively non-intuitive git
help in such a small space, be completely transparent about what the
west code does and lead the reader to the original git documentation.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>