### PR TITLE
west list: fix "{sha}" for manifest project

### DIFF
--- a/src/west/app/project.py
+++ b/src/west/app/project.py
@@ -389,10 +389,10 @@ The following arguments are available:
             if not project.is_cloned():
                 log.die(f'cannot get sha for uncloned project {project.name}; '
                         f'run "west update {project.name}" and retry')
-            elif project.revision:
-                return project.sha(MANIFEST_REV)
-            else:
+            elif isinstance(project, ManifestProject):
                 return f'{"N/A":40}'
+            else:
+                return project.sha(MANIFEST_REV)
 
         def cloned_thunk(project):
             self.die_if_no_git()

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -200,6 +200,14 @@ def test_list_groups(west_init_tmpdir):
            'foo .foo-group-1,foo-group-2. foo',
            'bar .. path-for-bar'])
 
+
+def test_list_sha(west_update_tmpdir):
+    # Regression test for listing with {sha}. This should print N/A
+    # for the first project, which is the ManifestProject.
+
+    assert cmd('list -f "{sha}"').startswith("N/A")
+
+
 def test_manifest_freeze(west_update_tmpdir):
     # We should be able to freeze manifests.
     actual = cmd('manifest --freeze').splitlines()


### PR DESCRIPTION
This isn't working properly because the ManifestProject's revision is
"HEAD", so it looks like an ordinary project and we try to get
manifest-rev from it. That is obviously incorrect. Fix it by detecting
the ManifestProject explicitly and doing the right thing there.

Fixes: #550

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>