### PR TITLE
Raise RuntimeError() if can't find rev for HEAD

### DIFF
--- a/src/west/app/project.py
+++ b/src/west/app/project.py
@@ -1349,6 +1349,11 @@ class Update(_ProjectCommand):
         if take_stats:
             stats['get current branch HEAD'] = perf_counter() - start
         current_branch = cp.stdout.decode('utf-8').strip()
+        if not current_branch:
+            log.die(
+                f"Unable to retrieve ref for 'HEAD' in project "
+                f"{project.name!r}. It is possible the project has a tag or "
+                f"branch with the name 'HEAD'. If so, please delete it.")
         if current_branch != 'HEAD':
             if take_stats:
                 start = perf_counter()


### PR DESCRIPTION
If a project has created a tag or branch with the name HEAD (which
they really shouldn't do) it will cause the command:
'git rev-parse --abbrev-ref HEAD' to fail to provide a ref.

Check if 'git rev-parse --abbrev-ref HEAD' fails to return a value and
if so do a `log.die()` rather than failing at the 'git merge-base'
stage with a less useful error.

Closes #561