### PR TITLE
Allow userdata to be defined under self in manifest repository

### DIFF
--- a/src/west/manifest-schema.yml
+++ b/src/west/manifest-schema.yml
@@ -156,3 +156,7 @@ mapping:
       import:
         required: false
         type: any
+      # Arbitrary user data for manifest repository
+      userdata:
+        required: false
+        type: any

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -1361,7 +1361,7 @@ class Manifest:
         self._posixpath: Optional[str] = None
         self._repo_posixpath: Optional[str] = None
         # This backs the userdata property
-        self._userdata: Optional[Any] = None
+        self.userdata: Any = None
         # Load context needed for import resolution. Do top-level
         # argument validation and storage if self._top_level is True,
         # but otherwise just get self._ctx from the caller.
@@ -1803,7 +1803,7 @@ class Manifest:
             mp = ManifestProject(
                 path=self._config_path if self.topdir else self.yaml_path,
                 west_commands=self._ctx.manifest_west_commands,
-                topdir=self.topdir, userdata=self._userdata)
+                topdir=self.topdir, userdata=self.userdata)
 
             # Save the resulting projects and initialize lookup tables
             # that rely on the ManifestProject existing.
@@ -1906,7 +1906,7 @@ class Manifest:
             _logger.debug('resolved self import')
 
         userdata = slf.get('userdata')
-        self._userdata = userdata
+        self.userdata = userdata
 
         # The current manifest data's west-comands comes first because
         # we treat imports from self as if they are defined "before"

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -48,7 +48,7 @@ QUAL_REFS_WEST = 'refs/west/'
 #:
 #: This value changes when a new version of west includes new manifest
 #: file features not supported by earlier versions of west.
-SCHEMA_VERSION = '0.12'
+SCHEMA_VERSION = '0.13'
 # MAINTAINERS:
 #
 # - Make sure to update _VALID_SCHEMA_VERS if you change this.
@@ -115,7 +115,7 @@ _SCHEMA_VER = parse_version(SCHEMA_VERSION)
 _EARLIEST_VER_STR = '0.6.99'  # we introduced the version feature after 0.6
 _VALID_SCHEMA_VERS = [
     _EARLIEST_VER_STR,
-    '0.7', '0.8', '0.9', '0.10',
+    '0.7', '0.8', '0.9', '0.10', '0.12',
     SCHEMA_VERSION
 ]
 

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -589,9 +589,31 @@ def test_self_userdata(tmpdir):
     ''')
     foo, bar = m.get_projects(['manifest', 'bar'])
 
+    assert m.userdata == {'key': 'value'}
     assert foo.userdata == {'key': 'value'}
     assert bar.userdata is None
     assert 'userdata' in foo.as_dict()
+    assert 'userdata' not in bar.as_dict()
+
+
+def test_self_missing_userdata(tmpdir):
+    m = M('''
+    defaults:
+      remote: r
+    remotes:
+      - name: r
+        url-base: base
+    projects:
+    - name: bar
+    self:
+      path: foo
+    ''')
+    foo, bar = m.get_projects(['manifest', 'bar'])
+
+    assert m.userdata is None
+    assert foo.userdata is None
+    assert bar.userdata is None
+    assert 'userdata' not in foo.as_dict()
     assert 'userdata' not in bar.as_dict()
 
 

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -572,6 +572,29 @@ def test_project_userdata(tmpdir):
     assert 'userdata' not in foo.as_dict()
     assert 'a-string' == bar.as_dict()['userdata']
 
+
+def test_self_userdata(tmpdir):
+    m = M('''
+    defaults:
+      remote: r
+    remotes:
+      - name: r
+        url-base: base
+    projects:
+    - name: bar
+    self:
+      path: foo
+      userdata:
+        key: value
+    ''')
+    foo, bar = m.get_projects(['manifest', 'bar'])
+
+    assert foo.userdata == {'key': 'value'}
+    assert bar.userdata is None
+    assert 'userdata' in foo.as_dict()
+    assert 'userdata' not in bar.as_dict()
+
+
 def test_no_projects():
     # An empty projects list is allowed.
 


### PR DESCRIPTION
The purpose of this PR is to allow for specifying userdata in the manifest repository. One of the primary reasons I am making the switch from the Google repo tool to the Zephyr west tool is to allow for specifying the firmware version information using the userdata capability in the manifest file. I also wanted to be able to combine my manifest repository with my project repository. I soon discovered that userdata is allowed for projects but excluded for no seemingly good reason for the manifest repository.