### PR TITLE
[wip] Fix manifest path vs self path

### DIFF
--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -1158,18 +1158,23 @@ class Manifest:
 
         This factory does not read any configuration files.
 
-        Letting the return value be ``m``. Results then depend on
-        keyword arguments in *kwargs*:
+        Let the return value be ``m``.
 
-            - Unless *topdir* is given, all absolute paths in ``m``,
-              like ``m.projects[1].abspath``, are ``None``.
+        Relative project paths in ``m`` (like ``m.projects[1].path``)
+        are taken from *source_data*.
 
-            - Relative paths, like ``m.projects[1].path``, are taken
-              from *source_data*.
+        You can pass this factory any of the *kwargs* documented for
+        `west.Manifest.__init__`. Some results in ``m`` depend on *kwargs*:
 
-            - If ``source_data['manifest']['self']['path']`` is not
-              set, then ``m.projects[MANIFEST_PROJECT_INDEX].abspath``
-              will be set to *manifest_path* if given.
+            - If *topdir* is unset in *kwargs*, then all absolute paths
+              in ``m`` (like ``m.projects[1].abspath``) are ``None``.
+
+            - Otherwise, absolute paths in ``m`` are rooted at *topdir*.
+
+            - If ``source_data['manifest']['self']['path']`` is unset,
+              ``m.projects[MANIFEST_PROJECT_INDEX].path``
+              will fall back to the *manifest_path* value in *kwargs*.
+              If both of these are unset, this value is ``None``.
 
         Returns the same exceptions as the Manifest constructor.
 

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -112,8 +112,10 @@ def test_project_init():
     assert p.abspath == os.path.join(TOPDIR, 'p')
     assert p.posixpath == TOPDIR_POSIX + '/p'
 
-def test_manifest_from_data():
+def test_manifest_from_data_without_topdir():
     # We can load manifest data as a dict or a string.
+    # If no *topdir* argument is given, as is done here,
+    # absolute path attributes should be None.
 
     manifest = Manifest.from_data('''\
     manifest:
@@ -122,12 +124,14 @@ def test_manifest_from_data():
           url: https://foo.com
     ''')
     assert manifest.projects[-1].name == 'foo'
+    assert manifest.projects[-1].abspath is None
 
     manifest = Manifest.from_data({'manifest':
                                    {'projects':
                                     [{'name': 'foo',
                                       'url': 'https:foo.com'}]}})
     assert manifest.projects[-1].name == 'foo'
+    assert manifest.projects[-1].abspath is None
 
 def test_validate():
     # Get some coverage for west.manifest.validate.


### PR DESCRIPTION
This fixes the issue reported by @permac. If .west/config says `manifest.path` is `foo` and we read `foo/west.yml`, but that file says `self: path: bar`, then we should ignore it when deciding where the ManifestProject.path location is.

WIP because although this fixes one bug, it causes regressions elsewhere. Just posting to show current status.