### PR TITLE
Overhaul manifest path handling

### DIFF
--- a/src/west/app/main.py
+++ b/src/west/app/main.py
@@ -116,7 +116,8 @@ class WestApp:
             return
 
         try:
-            self.manifest = Manifest.from_file(topdir=self.topdir)
+            self.manifest = Manifest.from_topdir(topdir=self.topdir,
+                                                 config=self.config)
         except (ManifestVersionError, MalformedManifest, MalformedConfig,
                 FileNotFoundError, ManifestImportFailed) as e:
             # Defer exception handling to WestCommand.run(), which uses

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -547,18 +547,24 @@ class ManifestImportFailed(Exception):
 
     Attributes:
 
-    - ``project``: the Project instance with the missing manifest data
-    - ``filename``: the missing file, as a str
+    - ``project``: the Project instance with the missing manifest data;
+      None if it's from the manifest via "manifest: self: import:"
+    - ``imp``: the parsed YAML data whose import was requested
     '''
 
-    def __init__(self, project: 'Project', filename: PathType):
-        super().__init__(project, filename)
+    def __init__(self, project: Optional['Project'], imp: Any):
+        super().__init__()
         self.project = project
-        self.filename = os.fspath(filename)
+        self.imp = imp
 
     def __str__(self):
-        return (f'ManifestImportFailed: project {self.project} '
-                f'file {self.filename}')
+        if self.project is not None:
+            return (f'ManifestImportFailed: project {self.project} '
+                    f'value {self.imp}')
+        else:
+            return (f'ManifestImportFailed: manifest repository '
+                    f'value {self.imp}')
+
 
 class ManifestVersionError(Exception):
     '''The manifest required a version of west more recent than the

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -994,7 +994,7 @@ class ManifestProject(Project):
     '''
 
     def __repr__(self):
-        return (f'ManifestProject({self.name}, path={repr(self.path)}, '
+        return (f'ManifestProject(path={repr(self.path)}, '
                 f'west_commands={self.west_commands}, '
                 f'topdir={repr(self.topdir)})')
 

--- a/tests/manifests/invalid_duplicate_name.yml
+++ b/tests/manifests/invalid_duplicate_name.yml
@@ -1,1 +1,7 @@
+manifests:
+  projects:
+    - name: foo
+      url: x
+    - name: foo
+      url: y
 

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -149,10 +149,8 @@ def test_validate():
     with pytest.raises(MalformedManifest):
         validate({'not-manifest': 'foo'})
 
-    assert validate({'manifest':
-                     {'projects':
-                      [{'name': 'p',
-                        'url': 'u'}]}}) is None
+    manifest_data = {'manifest': {'projects': [{'name': 'p', 'url': 'u'}]}}
+    assert validate(manifest_data) == manifest_data
 
     with pytest.raises(MalformedManifest):
         # White box:
@@ -174,7 +172,11 @@ def test_validate():
       projects:
       - name: p
         url: u
-    ''') is None
+    ''') == {
+        'manifest': {
+            'projects': [{'name': 'p', 'url': 'u'}]
+        }
+    }
 
 def test_not_both_args():
     with pytest.raises(ValueError) as e:

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -56,7 +56,7 @@ def tmp_workspace(tmpdir):
 
     # Create the manifest repository directory and skeleton config.
     topdir = tmpdir / 'topdir'
-    create_workspace(topdir, and_git=False)
+    create_workspace(topdir)
 
     # Switch to the top-level west workspace directory,
     # and give it to the test case.

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -382,7 +382,7 @@ def test_update_tag_to_tag(west_init_tmpdir):
 
         # Update the manifest file to point the project's revision at
         # the new tag.
-        manifest = Manifest.from_file(topdir=west_init_tmpdir)
+        manifest = Manifest.from_topdir(topdir=west_init_tmpdir)
         for p in manifest.projects:
             if p.name == 'tagged_repo':
                 p.revision = 'v2.0'
@@ -472,8 +472,9 @@ def test_update_some_with_imports(repos_tmpdir):
 
     cmd('update net-tools', cwd=ws)
     with pytest.raises(ManifestImportFailed):
-        Manifest.from_file(topdir=ws)
-    manifest = Manifest.from_file(topdir=ws, import_flags=MIF.IGNORE_PROJECTS)
+        Manifest.from_topdir(topdir=ws)
+    manifest = Manifest.from_topdir(topdir=ws,
+                                    import_flags=MIF.IGNORE_PROJECTS)
     projects = manifest.get_projects(['net-tools', 'zephyr'])
     net_tools_project = projects[0]
     zephyr_project = projects[1]
@@ -484,7 +485,7 @@ def test_update_some_with_imports(repos_tmpdir):
     assert zephyr_project.is_cloned()
 
     cmd('update', cwd=ws)
-    manifest = Manifest.from_file(topdir=ws)
+    manifest = Manifest.from_topdir(topdir=ws)
     assert manifest.get_projects(['Kconfiglib'])[0].is_cloned()
 
 def test_update_submodules_list(repos_tmpdir):
@@ -543,7 +544,8 @@ def test_update_submodules_list(repos_tmpdir):
     add_commit(net_tools, 'net-tools submodule change commit')
 
     # Get parsed data from the manifest.
-    manifest = Manifest.from_file(topdir=ws, import_flags=MIF.IGNORE_PROJECTS)
+    manifest = Manifest.from_topdir(topdir=ws,
+                                    import_flags=MIF.IGNORE_PROJECTS)
     projects = manifest.get_projects(['zephyr', 'net-tools'])
     zephyr_project = projects[0]
     net_tools_project = projects[1]
@@ -642,7 +644,8 @@ def test_update_all_submodules(repos_tmpdir):
     add_commit(zephyr, 'zephyr submodule net-tools commit')
 
     # Get parsed data from the manifest.
-    manifest = Manifest.from_file(topdir=ws, import_flags=MIF.IGNORE_PROJECTS)
+    manifest = Manifest.from_topdir(topdir=ws,
+                                    import_flags=MIF.IGNORE_PROJECTS)
     projects = manifest.get_projects(['zephyr'])
     zephyr_project = projects[0]
 
@@ -720,7 +723,8 @@ def test_update_no_submodules(repos_tmpdir):
     add_commit(zephyr, 'zephyr submodule net-tools commit')
 
     # Get parsed data from the manifest.
-    manifest = Manifest.from_file(topdir=ws, import_flags=MIF.IGNORE_PROJECTS)
+    manifest = Manifest.from_topdir(topdir=ws,
+                                    import_flags=MIF.IGNORE_PROJECTS)
     projects = manifest.get_projects(['zephyr'])
     zephyr_project = projects[0]
 
@@ -802,7 +806,8 @@ def test_update_submodules_strategy(repos_tmpdir):
     add_commit(net_tools, 'net-tools submodule change commit')
 
     # Get parsed data from the manifest.
-    manifest = Manifest.from_file(topdir=ws, import_flags=MIF.IGNORE_PROJECTS)
+    manifest = Manifest.from_topdir(topdir=ws,
+                                    import_flags=MIF.IGNORE_PROJECTS)
     projects = manifest.get_projects(['zephyr', 'net-tools'])
     zephyr_project = projects[0]
     net_tools_project = projects[1]
@@ -1801,12 +1806,12 @@ def test_import_project_release(repos_tmpdir):
     cmd(f'init -m {manifest_remote} {ws}')
     with pytest.raises(ManifestImportFailed):
         # We can't load this yet, because we haven't cloned zephyr.
-        Manifest.from_file(topdir=ws)
+        Manifest.from_topdir(topdir=ws)
 
     # Run west update and make sure we can load the manifest now.
     cmd('update', cwd=ws)
 
-    actual = Manifest.from_file(topdir=ws).projects
+    actual = Manifest.from_topdir(topdir=ws).projects
     expected = [ManifestProject(path='mp', topdir=ws),
                 Project('zephyr', zephyr,
                         revision='test-tag', topdir=ws),
@@ -1832,7 +1837,7 @@ def test_import_project_release(repos_tmpdir):
     cmd('update', cwd=ws)
 
     assert head_before == rev_parse(zephyr_ws, 'HEAD')
-    actual = Manifest.from_file(topdir=ws).projects
+    actual = Manifest.from_topdir(topdir=ws).projects
     for a, e in zip(actual, expected):
         check_proj_consistency(a, e)
     assert (zephyr_ws / 'should-not-clone').check(file=0)
@@ -1871,11 +1876,11 @@ def test_import_project_release_fork(repos_tmpdir):
 
     cmd(f'init -l {manifest_repo}')
     with pytest.raises(ManifestImportFailed):
-        Manifest.from_file(topdir=ws)
+        Manifest.from_topdir(topdir=ws)
 
     cmd('update', cwd=ws)
 
-    actual = Manifest.from_file(topdir=ws).projects
+    actual = Manifest.from_topdir(topdir=ws).projects
     expected = [ManifestProject(path='mp', topdir=ws),
                 Project('zephyr', zephyr,
                         revision='zephyr-tag', topdir=ws),
@@ -1898,7 +1903,7 @@ def test_import_project_release_fork(repos_tmpdir):
     cmd('update', cwd=ws)
 
     assert head_before == rev_parse(zephyr_ws, 'HEAD')
-    actual = Manifest.from_file(topdir=ws).projects
+    actual = Manifest.from_topdir(topdir=ws).projects
     for a, e in zip(actual, expected):
         check_proj_consistency(a, e)
     assert (zephyr_ws / 'should-not-clone').check(file=0)
@@ -1948,10 +1953,10 @@ def test_import_project_release_dir(tmpdir):
 
     cmd(f'init -l {manifest_repo}')
     with pytest.raises(ManifestImportFailed):
-        Manifest.from_file(topdir=ws)
+        Manifest.from_topdir(topdir=ws)
 
     cmd('update', cwd=ws)
-    actual = Manifest.from_file(topdir=ws).projects
+    actual = Manifest.from_topdir(topdir=ws).projects
     expected = [ManifestProject(path='mp', topdir=ws),
                 Project('imported', imported,
                         revision='import-tag', topdir=ws),
@@ -1985,11 +1990,11 @@ def test_import_project_rolling(repos_tmpdir):
 
     cmd(f'init -l {manifest_repo}')
     with pytest.raises(ManifestImportFailed):
-        Manifest.from_file(topdir=ws)
+        Manifest.from_topdir(topdir=ws)
 
     cmd('update', cwd=ws)
 
-    actual = Manifest.from_file(topdir=ws).projects
+    actual = Manifest.from_topdir(topdir=ws).projects
     expected = [ManifestProject(path='mp', topdir=ws),
                 Project('zephyr', zephyr,
                         revision='master', topdir=ws),


### PR DESCRIPTION
Fixes: #572 

This is an API break. We are still allowed to do that until west 1.0.

The west.manifest.Manifest class's path handling has become
unmaintainable and we need to overhaul it. The from_data() and
from_file() constructors are too clever and try to allow too many use
cases, which results in the guts of the manifest construction code
often not being able to tell whether it's in a real workspace or not.

This makes it difficult to know when we can safely read configuration
files or not. That in turn makes it difficult to accurately
distinguish between the 'manifest.path' value in the local configuration
file and the 'self: path:' value in the manifest data, especially when
we can take keyword arguments that say "hey, pretend this is your
path".

Additionally, there are a few assumptions in the code that pretend
that the manifest file itself always lives in the top level directory
of the manifest repository. That was a valid assumption up to the
point the 'manifest.file' configuration variable was introduced, but
it's no longer valid anymore, since 'manifest.file' can point to a
subdirectory of the manifest repository. This leaves us with some
hacks to find the git repository we live in that shouldn't be
necessary and which we can now remove with this overhaul.

Rework the whole thing so that we can correctly handle the following
situations:

 - when running in a workspace, you should now use from_file() or
   a newly introduced from_topdir() to make your Manifest

 - when running outside of any workspace, use from_data()

From now on, we forbid creating a manifest from data "as if" it were
in a real workspace. If all you have is data, the abspath attributes
will all be None, reflecting reality.

Accordingly, rework the `Manifest.__init__()` method to either take a
topdir or a bit of data, but not both. Additionally, now that we have
both manifest.path and manifest.file configuration options, it's not
usually the right thing to ask for a Manifest from a *file*: what you
really usually want is a Manifest from a *workspace*, and for that you
just need a topdir. From the topdir, you can create a
west.configuration.Configuration, and from there you can read
manifest.path and manifest.file to get the complete path to the top
level manifest within its repository. For that reason, we remove the
source_file keyword argument from `__init__()` in favor of topdir and a
new 'config' argument.

For backwards compatibility, it's still allowed to use from_file() to
load another manifest file than the one pointed to by
topdir/manifest.path/manifest.file. However, this handling code is now
just a bit of special case trickery in from_file(), and it also
introduces a restriction that the other file is still in a git
repository in the workspace. This moves potential sources for error or
confusion out of `Manifest.__init__()` and the functions it calls. (This
has proven to be a useful feature in practice; I am aware of west
extensions that use it to compare the parsed contents of two different
manifest files within the same workspace.)

To migrate away from the now-outdated from_file(), introduce a new
from_topdir() factory method and use it throughout the tree. This is
clearer and more accurate code, which always avoids the hacks left
behind for compatibility in from_file().

Finally, add various new instance attributes to the Manifest class
that will let us tell the YAML path from the actual path, and the path
to the manifest file from the path to the manifest repository in the
workspace. These in turn let us remove some hacky code from the 'west
list' implementation, and allow us to rework our internals so that
ManifestProject is just a legacy remnant at this point, further
helping along with #327.

Keep tests up to date, removing obsolete code as needed and updating
cases to reflect API breakage.
