### PR TITLE
manifest: fix Manifest.from_file() with fall_back

### DIFF
--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -1143,12 +1143,15 @@ class Manifest:
         '''
         if source_file is None:
             start = Path.cwd()
+            fall_back = True
         else:
             source_file = Path(source_file).resolve()
             start = source_file.parent
+            fall_back = False
 
         # Find the workspace topdir.
-        topdir = Path(util.west_topdir(start=start, fall_back=False)).resolve()
+        topdir = Path(util.west_topdir(start=start,
+                                       fall_back=fall_back)).resolve()
 
         # Load a Configuration.
         if source_file is None:

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -133,6 +133,21 @@ def test_manifest_from_data_without_topdir():
     assert manifest.projects[-1].name == 'foo'
     assert manifest.projects[-1].abspath is None
 
+def test_manifest_from_file_with_fall_back(manifest_repo):
+    with open(manifest_repo / 'west.yml', 'w') as f:
+        f.write('''
+        manifest:
+          projects: []
+        ''')
+    repo_abspath = Path(str(manifest_repo))
+    os.chdir(repo_abspath.parent.parent)  # this is the tmp_workspace dir
+    try:
+        os.environ['ZEPHYR_BASE'] = os.fspath(manifest_repo)
+        manifest = MF()
+        assert Path(manifest.repo_abspath) == repo_abspath
+    finally:
+        del os.environ['ZEPHYR_BASE']
+
 def test_validate():
     # Get some coverage for west.manifest.validate.
 


### PR DESCRIPTION
Without a file argument, we should still use fall_back=True to search
for the workspace in the environment. This behavior was removed in the
recent rework of path handling, introducing a regression where the
manifest repository cannot be found when outside the workspace. Fix
it.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>