### PR TITLE
Fix configuration error

### DIFF
--- a/src/west/configuration.py
+++ b/src/west/configuration.py
@@ -45,6 +45,10 @@ import warnings
 
 from west.util import west_dir, WestNotFound, PathType
 
+class MalformedConfig(Exception):
+    '''The west configuration was malformed.
+    '''
+
 def _configparser():            # for internal use
     return configparser.ConfigParser(allow_no_value=True)
 

--- a/src/west/configuration.py
+++ b/src/west/configuration.py
@@ -230,7 +230,7 @@ class Configuration:
             return [self._global]
         elif configfile == ConfigFile.LOCAL:
             if self._local is None:
-                raise RuntimeError('local configuration file not found')
+                raise MalformedConfig('local configuration file not found')
             return [self._local]
         else:
             raise ValueError(configfile)

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -25,7 +25,7 @@ import yaml
 
 from west import util
 from west.util import PathType
-from west.configuration import Configuration, ConfigFile
+from west.configuration import Configuration, ConfigFile, MalformedConfig
 
 #
 # Public constants
@@ -541,11 +541,6 @@ def is_group(raw_group: RawGroupType) -> bool:
 
 class MalformedManifest(Exception):
     '''Manifest parsing failed due to invalid data.
-    '''
-
-class MalformedConfig(Exception):
-    '''The west configuration was malformed in a way that made a
-    manifest operation fail.
     '''
 
 class ManifestImportFailed(Exception):

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -25,6 +25,7 @@ from west.manifest import Manifest, Project, ManifestProject, \
     MalformedManifest, ManifestVersionError, ManifestImportFailed, \
     manifest_path, ImportFlag, validate, MANIFEST_PROJECT_INDEX, \
     _ManifestImportDepth, is_group, SCHEMA_VERSION
+from west.configuration import MalformedConfig
 
 # White box checks for the schema version.
 from west.manifest import _VALID_SCHEMA_VERS
@@ -1017,7 +1018,7 @@ def test_from_bad_topdir(tmpdir):
     # If we give a bad temporary directory that isn't a workspace
     # root, that should also fail.
 
-    with pytest.raises(RuntimeError) as e:
+    with pytest.raises(MalformedConfig) as e:
         Manifest.from_topdir(topdir=tmpdir)
     assert 'local configuration file not found' in str(e.value)
 


### PR DESCRIPTION
Commit c757d6650f7df5e3950b704dd756241a9c84a352
("configuration: add Configuration class") was part of a general
re-work of how configuration file handling went.

As part of this change, an internal _whence() method was added, which
returns a list of configuration file paths on the file system for a
given ConfigFile enumerator. _whence() is currently erroring out with
a RuntimeError() when a local configuration file is requested, but not
found.

This breaks error handling in some cases.

For example, consider a flow like this:

```
  # This command fails for some reason, leaving a .west
  # directory but no .west/config
  $ west init

  # This command bombs out with RuntimeError: a topdir is
  # found, so main.py tries to create a Manifest, which asks
  # for the 'manifest.path' configuration option from the
  # local file, which ... boom
  $ west list
```

It would be better to raise MalformedConfig from here instead. This
lets higher layers handle this error better. In the above case,
we now get this instead:

```
  $ west list
  FATAL ERROR: can't load west manifest
    local configuration file not found
```

This is clearly better. There are probably still some other error
handling edge cases that aren't being handled properly as a result of
this change, but I'd be curious to know how many of them this fixes.
