### PR TITLE
main: update ManifestImportFailed error handling

### DIFF
--- a/src/west/app/main.py
+++ b/src/west/app/main.py
@@ -192,8 +192,8 @@ class WestApp:
                 if args.command == 'update':
                     return      # that's fine
 
-                p, f = self.mle.project, self.mle.filename
-                ctxt = f'  Missing file: "{f}"'
+                p, imp = self.mle.project, self.mle.imp
+                ctxt = f'  Failed importing "{imp}"'
                 if not isinstance(p, ManifestProject):
                     # Try to be more helpful by explaining exactly
                     # what west.manifest needs to happen before we can
@@ -204,7 +204,7 @@ class WestApp:
                     ctxt += '  Hint: for this to work:\n'
                     ctxt += f'          - {p.name} must be cloned\n'
                     ctxt += (f'          - its {MANIFEST_REV_BRANCH} ref '
-                             'must point to a commit with the missing file\n')
+                             'must point to a commit with the import data\n')
                     ctxt += '        To fix, run:\n'
                     ctxt += '          west update'
 


### PR DESCRIPTION
Commit 2327610945323390cc330d23938d3c50a6f596c6
("manifest: ManifestImportFailed: relax argument specification")
changed the attributes in ManifestImportFailed instances, but the
corresponding error handling code in main.py was not updated.

This is incorrect and results in an ugly traceback instead of a
properly formatted error message.

Restore the preferred behavior by using the new attribute 'imp'.

Fixes: #588

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>