### PR TITLE
main: handle PermissionError

### DIFF
--- a/src/west/app/main.py
+++ b/src/west/app/main.py
@@ -119,7 +119,7 @@ class WestApp:
             self.manifest = Manifest.from_topdir(topdir=self.topdir,
                                                  config=self.config)
         except (ManifestVersionError, MalformedManifest, MalformedConfig,
-                FileNotFoundError, ManifestImportFailed) as e:
+                ManifestImportFailed, FileNotFoundError) as e:
             # Defer exception handling to WestCommand.run(), which uses
             # handle_builtin_manifest_load_err() to decide what to do.
             #
@@ -182,10 +182,6 @@ class WestApp:
             if isinst(MalformedManifest, MalformedConfig):
                 log.die('\n  '.join(["can't load west manifest"] +
                                     list(self.mle.args)))
-            elif isinst(FileNotFoundError):
-                # This should ordinarily only happen when the top
-                # level manifest is not found.
-                log.die(f"file not found: {self.mle.filename}")
             elif isinst(_ManifestImportDepth):
                 log.die('failed, likely due to manifest import loop')
             elif isinst(ManifestImportFailed):
@@ -210,6 +206,10 @@ class WestApp:
 
                 log.die(f'failed manifest import in {p.name_and_path}\n' +
                         ctxt)
+            elif isinst(FileNotFoundError):
+                # This should ordinarily only happen when the top
+                # level manifest is not found.
+                log.die(f"file not found: {self.mle.filename}")
             else:
                 log.die('internal error:',
                         f'unhandled manifest load exception: {self.mle}')

--- a/src/west/app/main.py
+++ b/src/west/app/main.py
@@ -119,7 +119,7 @@ class WestApp:
             self.manifest = Manifest.from_topdir(topdir=self.topdir,
                                                  config=self.config)
         except (ManifestVersionError, MalformedManifest, MalformedConfig,
-                ManifestImportFailed, FileNotFoundError) as e:
+                ManifestImportFailed, FileNotFoundError, PermissionError) as e:
             # Defer exception handling to WestCommand.run(), which uses
             # handle_builtin_manifest_load_err() to decide what to do.
             #
@@ -210,6 +210,8 @@ class WestApp:
                 # This should ordinarily only happen when the top
                 # level manifest is not found.
                 log.die(f"file not found: {self.mle.filename}")
+            elif isinst(PermissionError):
+                log.die(f"permission denied: {self.mle.filename}")
             else:
                 log.die('internal error:',
                         f'unhandled manifest load exception: {self.mle}')


### PR DESCRIPTION
Be clearer about what happened when we lack permissions to load the
manifest, but we need to do so in order to proceed. This can happen,
for instance, if it is owned by another user and read access is
denied.

Fixes: #579