### PR TITLE
treewide: don't call Project.git() with strings

### DIFF
--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -858,7 +858,7 @@ class Project:
         # Though we capture stderr, it will be available as the stderr
         # attribute in the CalledProcessError raised by git() in
         # Python 3.5 and above if this call fails.
-        cp = self.git(f'rev-parse {rev}^{{commit}}', capture_stdout=True,
+        cp = self.git(['rev-parse', rev + '^{commit}'], capture_stdout=True,
                       cwd=cwd, capture_stderr=True)
         # Assumption: SHAs are hex values and thus safe to decode in ASCII.
         # It'll be fun when we find out that was wrong and how...
@@ -879,7 +879,7 @@ class Project:
         :param cwd: directory to run command in (default:
             ``self.abspath``)
         '''
-        rc = self.git(f'merge-base --is-ancestor {rev1} {rev2}',
+        rc = self.git(['merge-base', '--is-ancestor', rev1, rev2],
                       check=False, cwd=cwd).returncode
 
         if rc == 0:
@@ -930,7 +930,7 @@ class Project:
         # instead, which prints an empty string (i.e., just a newline,
         # which we strip) for the top-level directory.
         _logger.debug(f'{self.name}: checking if cloned')
-        res = self.git('rev-parse --show-cdup', check=False, cwd=cwd,
+        res = self.git(['rev-parse', '--show-cdup'], check=False, cwd=cwd,
                        capture_stderr=True, capture_stdout=True)
 
         return not (res.returncode or res.stdout.strip())


### PR DESCRIPTION
Related discussion:

https://github.com/zephyrproject-rtos/zephyr/discussions/48837

I got another report about this on Discord today, so it looks like it
may really be a west bug.

Hypothesis: special characters when doing things like commit 'peeling'
in refs like "v3.0.0^{commit}" are being treated as metacharacters by
the windows cmd.exe on some people's machines:

   You must use quotation marks around the following special
   characters: & < > [ ] | { } ^ = ; ! ' + , ` ~ [white space].

   https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/cmd#syntax

If so, this should be a fix, since we'll no longer be using
shlex.split() in Project.git() for git() calls within west itself.
We definitely do include ^, {, and } in our command strings, and
shlex.split() is a POSIX-specific split, which may not be doing the
right thing on Windows, despite it passing CI.

Some Zephyr users are reporting problems that appear suspiciously like
this being the case:

https://github.com/zephyrproject-rtos/zephyr/discussions/48837

Unclear why this doesn't reproduce in our own testing.
