### PR TITLE
commands: add change

### DIFF
--- a/src/west/app/main.py
+++ b/src/west/app/main.py
@@ -30,7 +30,7 @@ import west.configuration
 from west.commands import WestCommand, extension_commands, \
     CommandError, ExtensionCommandError, Verbosity
 from west.app.project import List, ManifestCommand, Diff, Status, \
-    SelfUpdate, ForAll, Init, Update, Topdir
+    SelfUpdate, ForAll, Init, Update, Topdir, Change
 from west.app.config import Config
 from west.manifest import Manifest, MalformedConfig, MalformedManifest, \
     ManifestVersionError, ManifestImportFailed, _ManifestImportDepth, \
@@ -877,6 +877,7 @@ BUILTIN_COMMAND_GROUPS = {
         Diff,
         Status,
         ForAll,
+        Change,
     ],
 
     'other built-in commands': [

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -2090,3 +2090,33 @@ def test_import_project_rolling(repos_tmpdir):
 
     assert head_before != rev_parse(zephyr_ws, 'HEAD')
     assert (zephyr_ws / 'should-clone').check(file=1)
+
+def test_change(west_init_tmpdir):
+    # Chenge revision for 'zephyr' project.
+
+    new_revision = 'v1.0.2'
+
+    with open(west_init_tmpdir / 'zephyr/west.yml', 'w') as f:
+        f.write("""
+        manifest:
+          defaults:
+            remote: r
+          remotes:
+            - name: r
+              url-base: https://example.com
+          projects:
+          - name: Kconfiglib
+            revision: main
+            groups:
+            - foo-group-1
+          - name: bar
+            path: path-for-bar
+          - name: foo
+        """)
+
+    cmd(f'change Kconfiglib --revision {new_revision}')
+
+    manifest = Manifest.from_topdir(topdir=west_init_tmpdir)
+    projects = manifest.get_projects(['Kconfiglib'])
+
+    assert projects[0].revision == new_revision


### PR DESCRIPTION
Add command to change project details in the manifest.
Example of usage:

Change revision for openthread  project:
west change openthread --revision 36b2ac9fd02988319e9dcebc578d8f9a9f5ff892

Change path for openthread  project:
west change openthread --path modules/lib/openthread


Signed-off-by: Mariusz Poslinski <mariusz.poslinski@nordicsemi.no>