### PR TITLE
main.py: Prevent shortened command line arguments

### DIFF
--- a/src/west/app/main.py
+++ b/src/west/app/main.py
@@ -328,7 +328,7 @@ class WestApp:
         parser = WestArgumentParser(
             prog='west', description='The Zephyr RTOS meta-tool.',
             epilog='''Run "west help <command>" for help on each <command>.''',
-            add_help=False, west_app=self)
+            add_help=False, west_app=self, allow_abbrev=False)
 
         # Remember to update zephyr's west-completion.bash if you add or
         # remove flags. This is currently the only place where shell


### PR DESCRIPTION
This prevents python's argparse library from allowing it to generate its own shortened command line options which can cause problems when commands are added in future with similar names to existing arguments.

Not tested with tox since it does not seem to want to run on my PC for some reason, not even in a new virtual environment.