### PR TITLE
Fix submodule file protocol error

### DIFF
--- a/src/west/app/project.py
+++ b/src/west/app/project.py
@@ -795,6 +795,11 @@ class Update(_ProjectCommand):
                            help='''proceed as if FILTER was appended to
                            manifest.group-filter; may be given multiple
                            times''')
+        group.add_argument('--submodule-init-config',
+                           action='append', default=[],
+                           help='''git configuration option to set when running
+                           'git submodule init' in '<option>=<value>' format;
+                           may be given more than once''')
 
         group = parser.add_argument_group('deprecated options')
         group.add_argument('-x', '--exclude-west', action='store_true',
@@ -1011,20 +1016,26 @@ class Update(_ProjectCommand):
         submodules = project.submodules
         submodules_update_strategy = ('--rebase' if self.args.rebase
                                       else '--checkout')
+        config_opts = []
+        for config_opt in self.args.submodule_init_config:
+            config_opts.extend(['-c', config_opt])
+
         # For the list type, update given list of submodules.
         if isinstance(submodules, list):
             for submodule in submodules:
                 if self.sync_submodules:
                     project.git(['submodule', 'sync', '--recursive',
                                  '--', submodule.path])
-                project.git(['submodule', 'update',
+                project.git(config_opts +
+                            ['submodule', 'update',
                              '--init', submodules_update_strategy,
                              '--recursive', submodule.path])
         # For the bool type, update all project submodules
         elif isinstance(submodules, bool):
             if self.sync_submodules:
                 project.git(['submodule', 'sync', '--recursive'])
-            project.git(['submodule', 'update', '--init',
+            project.git(config_opts +
+                        ['submodule', 'update', '--init',
                          submodules_update_strategy, '--recursive'])
 
     def update(self, project):

--- a/src/west/commands.py
+++ b/src/west/commands.py
@@ -574,7 +574,8 @@ class WestExtCommandSpec:
     # the command) before constructing it, however.
     factory: _ExtFactory
 
-def extension_commands(config: Configuration, manifest: Manifest = None):
+def extension_commands(config: Configuration,
+                       manifest: Optional[Manifest] = None):
     # Get descriptions of available extension commands.
     #
     # The return value is an ordered map from project paths to lists of

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -60,6 +60,9 @@ SUBMODULE_ADD = [GIT,
                  'submodule',
                  'add']
 
+# Helper string for the same purpose when running west update.
+PROTOCOL_FILE_ALLOW = '--submodule-init-config protocol.file.allow=always'
+
 #
 # Test fixtures
 #
@@ -645,7 +648,7 @@ def test_update_submodules_list(repos_tmpdir):
     assert not net_tools_project.is_cloned()
 
     # Update only zephyr project.
-    cmd('update zephyr', cwd=ws)
+    cmd(f'update {PROTOCOL_FILE_ALLOW} zephyr', cwd=ws)
 
     # Verify if only zephyr project was cloned.
     assert zephyr_project.is_cloned()
@@ -658,7 +661,7 @@ def test_update_submodules_list(repos_tmpdir):
     assert not (res.returncode or res.stdout.strip())
 
     # Update all projects
-    cmd('update', cwd=ws)
+    cmd(f'update {PROTOCOL_FILE_ALLOW}', cwd=ws)
 
     # Verify if both projects were cloned
     assert zephyr_project.is_cloned()
@@ -739,7 +742,7 @@ def test_update_all_submodules(repos_tmpdir):
     assert not zephyr_project.is_cloned()
 
     # Update zephyr project.
-    cmd('update zephyr', cwd=ws)
+    cmd(f'update {PROTOCOL_FILE_ALLOW} zephyr', cwd=ws)
 
     # Verify if zephyr project was cloned.
     assert zephyr_project.is_cloned()
@@ -903,7 +906,7 @@ def test_update_submodules_strategy(repos_tmpdir):
     assert not net_tools_project.is_cloned()
 
     # Update only zephyr project using checkout strategy (selected by default).
-    cmd('update zephyr', cwd=ws)
+    cmd(f'update {PROTOCOL_FILE_ALLOW} zephyr', cwd=ws)
 
     # Verify if only zephyr project was cloned.
     assert zephyr_project.is_cloned()
@@ -916,7 +919,7 @@ def test_update_submodules_strategy(repos_tmpdir):
     assert not (res.returncode or res.stdout.strip())
 
     # Update only net-tools project using rebase strategy
-    cmd('update net-tools -r', cwd=ws)
+    cmd(f'update {PROTOCOL_FILE_ALLOW} net-tools -r', cwd=ws)
 
     # Verify if both projects were cloned
     assert zephyr_project.is_cloned()

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -49,6 +49,17 @@ UpdateResults = collections.namedtuple('UpdateResults',
                                        'kl_head_0 kl_head_1 '
                                        'tr_head_0 tr_head_1')
 
+# Helper list for forming commands that add submodules from
+# remotes which may be on the local file system. Such cases
+# must be explicitly authorized since git 2.28.1. For details,
+# see:
+#
+# https://github.blog/2022-10-18-git-security-vulnerabilities-announced/#cve-2022-39253
+SUBMODULE_ADD = [GIT,
+                 '-c', 'protocol.file.allow=always',
+                 'submodule',
+                 'add']
+
 #
 # Test fixtures
 #
@@ -600,15 +611,16 @@ def test_update_submodules_list(repos_tmpdir):
     cmd(f'init -l {manifest_repo}')
 
     # Make tagged_repo to be zephyr project submodule.
-    subprocess.check_call(
-        [GIT, 'submodule', 'add', str(tagged_repo), 'tagged_repo'], cwd=zephyr)
+    subprocess.check_call(SUBMODULE_ADD +
+                          [str(tagged_repo), 'tagged_repo'],
+                          cwd=zephyr)
     # Commit changes to the zephyr repo.
     add_commit(zephyr, 'zephyr submodule change commit')
 
     # Make Kconfiglib to be net-tools project submodule.
-    subprocess.check_call(
-        [GIT, 'submodule', 'add', str(kconfiglib), kconfiglib_submodule],
-        cwd=net_tools)
+    subprocess.check_call(SUBMODULE_ADD +
+                          [str(kconfiglib), kconfiglib_submodule],
+                          cwd=net_tools)
     # Commit changes to the net-tools repo.
     add_commit(net_tools, 'net-tools submodule change commit')
 
@@ -694,21 +706,23 @@ def test_update_all_submodules(repos_tmpdir):
     cmd(f'init -l {manifest_repo}')
 
     # Make tagged_repo to be zephyr project submodule.
-    subprocess.check_call(
-        [GIT, 'submodule', 'add', str(tagged_repo), 'tagged_repo'], cwd=zephyr)
+    subprocess.check_call(SUBMODULE_ADD +
+                          [str(tagged_repo), 'tagged_repo'],
+                          cwd=zephyr)
     # Commit changes to the zephyr repo.
     add_commit(zephyr, 'zephyr submodule tagged_repo commit')
 
     # Make Kconfiglib to be net_tools submodule.
-    subprocess.check_call(
-        [GIT, 'submodule', 'add', str(kconfiglib), 'Kconfiglib'],
-        cwd=net_tools)
+    subprocess.check_call(SUBMODULE_ADD +
+                          [str(kconfiglib), 'Kconfiglib'],
+                          cwd=net_tools)
     # Commit changes to the net_tools repo.
     add_commit(net_tools, 'net_tools submodule Kconfiglib commit')
 
     # Make net_tools to be zephyr project submodule.
-    subprocess.check_call(
-        [GIT, 'submodule', 'add', str(net_tools), 'net-tools'], cwd=zephyr)
+    subprocess.check_call(SUBMODULE_ADD +
+                          [str(net_tools), 'net-tools'],
+                          cwd=zephyr)
     # Commit changes to the zephyr repo.
     add_commit(zephyr, 'zephyr submodule net-tools commit')
 
@@ -780,14 +794,16 @@ def test_update_no_submodules(repos_tmpdir):
     cmd(f'init -l {manifest_repo}')
 
     # Make tagged_repo to be zephyr project submodule.
-    subprocess.check_call(
-        [GIT, 'submodule', 'add', str(tagged_repo), 'tagged_repo'], cwd=zephyr)
+    subprocess.check_call(SUBMODULE_ADD +
+                          [str(tagged_repo), 'tagged_repo'],
+                          cwd=zephyr)
     # Commit changes to the zephyr repo.
     add_commit(zephyr, 'zephyr submodule tagged_repo commit')
 
     # Make net_tools to be zephyr project submodule.
-    subprocess.check_call(
-        [GIT, 'submodule', 'add', str(net_tools), 'net-tools'], cwd=zephyr)
+    subprocess.check_call(SUBMODULE_ADD +
+                          [str(net_tools), 'net-tools'],
+                          cwd=zephyr)
     # Commit changes to the zephyr repo.
     add_commit(zephyr, 'zephyr submodule net-tools commit')
 
@@ -862,15 +878,16 @@ def test_update_submodules_strategy(repos_tmpdir):
     cmd(f'init -l {manifest_repo}')
 
     # Make tagged_repo to be zephyr project submodule.
-    subprocess.check_call(
-        [GIT, 'submodule', 'add', str(tagged_repo), 'tagged_repo'], cwd=zephyr)
+    subprocess.check_call(SUBMODULE_ADD +
+                          [str(tagged_repo), 'tagged_repo'],
+                          cwd=zephyr)
     # Commit changes to the zephyr repo.
     add_commit(zephyr, 'zephyr submodule change commit')
 
     # Make Kconfiglib to be net-tools project submodule.
-    subprocess.check_call(
-        [GIT, 'submodule', 'add', str(kconfiglib), 'Kconfiglib'],
-        cwd=net_tools)
+    subprocess.check_call(SUBMODULE_ADD +
+                          [str(kconfiglib), 'Kconfiglib'],
+                          cwd=net_tools)
     # Commit changes to the net-tools repo.
     add_commit(net_tools, 'net-tools submodule change commit')
 


### PR DESCRIPTION
Fixes: #619 

The user-visible fix is in `update: add --submodule-init-config option`: this allows users to clone submodules on a case-by-case basis using `west update --submodule-init-config protocol.file.allow=always ...` without having to globally change their git configuration to allow this unsafe protocol to be used everywhere.

The other fixes are for our CI and are due to fallout from the git change discussed in #619 and one other unrelated mypy issue.