### PR TITLE
log.py: minor log level pydoc fix

### DIFF
--- a/src/west/log.py
+++ b/src/west/log.py
@@ -72,8 +72,9 @@ def dbg(*args, level=VERBOSE_NORMAL):
     :param args: sequence of arguments to print.
     :param level: verbosity level to set, e.g. VERBOSE_VERY.
 
-    The message is only printed if level is at least the current
-    verbosity level.'''
+    The message is only printed if the ``level`` parameter is at most
+    the current verbosity level.
+    '''
     deprecated()
     if level > VERBOSE:
         return


### PR DESCRIPTION
The message is only printed if the ``level`` parameter is _lower or equal to_ (not "at least) the current verbosity level.

We need a "sign errors" joke similar to this one:
https://www.martinfowler.com/bliki/TwoHardThings.html

Signed-off-by: Marc Herbert <marc.herbert@intel.com>