### PR TITLE
add typing information

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include src/west/west-commands-schema.yml
 include src/west/manifest-schema.yml
+include src/west/py.typed

--- a/setup.py
+++ b/setup.py
@@ -49,4 +49,5 @@ setuptools.setup(
     ],
     python_requires='>=3.8',
     entry_points={'console_scripts': ('west = west.app.main:main',)},
+    zip_safe=False
 )


### PR DESCRIPTION
The west package contains type annotations, but mypy doesn't know about them because of a missing metadata file. This prevents us from type-checking calls into the west APIs, which we should be able to do.

Add the necessary metadata to make this work.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>