### PR TITLE
commands: fix "no workspace" and other error paths

### DIFF
--- a/src/west/commands.py
+++ b/src/west/commands.py
@@ -182,13 +182,13 @@ class WestCommand(ABC):
         :param config: `west.configuration.Configuration` or ``None``,
             accessible as ``self.config`` from `WestCommand.do_run`
         '''
+        self.config = config
         if unknown and not self.accepts_unknown_args:
             self.parser.error(f'unexpected arguments: {unknown}')
         if not topdir and self.requires_workspace:
             self.die(_no_topdir_msg(os.getcwd(), self.name))
         self.topdir = os.fspath(topdir) if topdir else None
         self.manifest = manifest
-        self.config = config
         for hook in self._hooks:
             hook(self)
         self.do_run(args, unknown)


### PR DESCRIPTION
Commit 2ac3e279ff98a4e62ed449430dfdf327881bff84
("WestCommand: use Configuration objects") introduced a configuration attribute to WestCommand instances, and used it to look up configuration options.

However, it stored this attribute at the wrong time in WestCommand.run(). We need to stash the configuration before doing anything else, because otherwise calls like self.die() in the same method will look up self.color_ui, which looks up the configuration, which isn't present, which calls self.die(), leading to an infinite recursion.

If we stash the configuration immediately, we instead have a valid configuration option and we get an error printed instead.