### PR TITLE
app: improve manifest load errors

### DIFF
--- a/src/west/app/main.py
+++ b/src/west/app/main.py
@@ -223,11 +223,14 @@ class WestApp:
                 # level manifest is not found.
                 self.queued_io.append(
                     lambda cmd:
-                    cmd.die(f"file not found: {self.mle.filename}"))
+                    cmd.die(f"manifest file not found: {self.mle.filename}\n"
+                            "Please check manifest.file and manifest.path in "
+                            f"{self.topdir + '/' or ''}.west/config"))
             elif isinst(PermissionError):
                 self.queued_io.append(
                     lambda cmd:
-                    cmd.die(f"permission denied: {self.mle.filename}"))
+                    cmd.die("permission denied when loading manifest file: "
+                            f"{self.mle.filename}"))
             else:
                 self.queued_io.append(
                     lambda cmd:


### PR DESCRIPTION
For missing files, the new output looks like this:

FATAL ERROR: manifest file not found: /home/mbolivar/zp/zephyr/nosuchfile
Please check manifest.file and manifest.path in /home/mbolivar/zp/.west/config

The old output looks like this:

FATAL ERROR: file not found: /home/mbolivar/zp/zephyr/nosuchfile

The new output is clearly more helpful.

Make a similar improvement for permission errors.
