### PR TITLE
West v1.0.1

### DIFF
--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -46,15 +46,21 @@ QUAL_REFS_WEST = 'refs/west/'
 
 #: The latest manifest schema version supported by this west program.
 #:
-#: This value changes when a new version of west includes new manifest
-#: file features not supported by earlier versions of west.
-SCHEMA_VERSION = '0.13'
+#: This value will change whenever a new version of west includes new
+#: manifest file features not supported by earlier versions of west.
+#: (Its value changed to 1.0 following the release of west versions
+#: v1.0.x, so that users can say "I want schema version 1" instead of
+#: having to keep using '0.13', which was the previous version this
+#: changed.)
+SCHEMA_VERSION = '1.0'
 # MAINTAINERS:
 #
 # - Make sure to update _VALID_SCHEMA_VERS if you change this.
 #
-# - When changing this, make sure that it has the exact same value as
-#   west.version.__version__ when the next release is cut.
+# - When changing this, make sure that it matches the major.minor
+#   version of west itself. E.g. if you add a new manifest feature for
+#   west 1.6, then SCHEMA_VERSION above should be 1.6, and west's
+#   release version numbers should be 1.6.x.
 
 #
 # Internal helpers
@@ -115,7 +121,7 @@ _SCHEMA_VER = parse_version(SCHEMA_VERSION)
 _EARLIEST_VER_STR = '0.6.99'  # we introduced the version feature after 0.6
 _VALID_SCHEMA_VERS = [
     _EARLIEST_VER_STR,
-    '0.7', '0.8', '0.9', '0.10', '0.12',
+    '0.7', '0.8', '0.9', '0.10', '0.12', '0.13',
     SCHEMA_VERSION
 ]
 

--- a/src/west/version.py
+++ b/src/west/version.py
@@ -5,7 +5,7 @@
 # This is the Python 3 version of option 3 in:
 # https://packaging.python.org/guides/single-sourcing-package-version/#single-sourcing-the-version
 
-__version__ = '1.0.0'
+__version__ = '1.0.1'
 #
 # MAINTAINERS:
 #


### PR DESCRIPTION
Backport https://github.com/zephyrproject-rtos/west/commit/9789617cd5becaf2b7d75aee996e9e3477cbc4a2 to the release branch. I don't think it's worth bothering with going through the entire testing procedure in an "alpha" 1.0.1a1 release as described in MAINTAINERS.rst since this is an isolated change that has been tested in its own right.