### PR TITLE
forall: add --group argument

### DIFF
--- a/src/west/app/project.py
+++ b/src/west/app/project.py
@@ -1456,6 +1456,12 @@ class ForAll(_ProjectCommand):
                             required=True)
         parser.add_argument('-a', '--all', action='store_true',
                             help='include inactive projects'),
+        parser.add_argument('-g', '--group', dest='groups',
+                            default=[], action='append',
+                            help='''only run COMMAND if a project is
+                            in this group; if given more than once,
+                            the command will be run if the project is
+                            in any of the groups''')
         parser.add_argument('projects', metavar='PROJECT', nargs='*',
                             help='''projects (by name or path) to operate on;
                             defaults to active cloned projects''')
@@ -1465,7 +1471,10 @@ class ForAll(_ProjectCommand):
         self._setup_logging(args)
 
         failed = []
+        group_set = set(args.groups)
         for project in self._cloned_projects(args, only_active=not args.all):
+            if group_set and not group_set.intersection(set(project.groups)):
+                continue
             self.banner(
                 f'running "{args.subcommand}" in {project.name_and_path}:')
             rc = subprocess.Popen(args.subcommand, shell=True,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,6 +42,8 @@ manifest:
     - name: Kconfiglib
       revision: zephyr
       path: subdir/Kconfiglib
+      groups:
+        - Kconfiglib-group
     - name: tagged_repo
       revision: v1.0
     - name: net-tools

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -317,6 +317,11 @@ def test_forall(west_init_tmpdir):
         '=== running "echo foo" in net-tools (net-tools):',
         'foo']
 
+    assert cmd('forall --group Kconfiglib-group -c "echo foo"'
+               ).splitlines() == [
+                   '=== running "echo foo" in Kconfiglib (subdir/Kconfiglib):',
+                   'foo',
+               ]
 
 def test_update_projects(west_init_tmpdir):
     # Test the 'west update' command. It calls through to the same backend

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -288,20 +288,32 @@ def test_status(west_init_tmpdir):
 
 
 def test_forall(west_init_tmpdir):
-    # FIXME: Check output
-    # The 'echo' command is available in both 'shell' and 'batch'
+    # Note that the 'echo' command is available in both Unix shells
+    # and Windows .bat files.
 
     # 'forall' with no projects cloned shouldn't fail
 
-    cmd('forall -c "echo *"')
+    assert cmd('forall -c "echo foo"').splitlines() == [
+        '=== running "echo foo" in manifest (zephyr):',
+        'foo']
 
     # Neither should it fail after cloning one or both projects
 
     cmd('update net-tools')
-    cmd('forall -c "echo *"')
+    assert cmd('forall -c "echo foo"').splitlines() == [
+        '=== running "echo foo" in manifest (zephyr):',
+        'foo',
+        '=== running "echo foo" in net-tools (net-tools):',
+        'foo']
 
     cmd('update Kconfiglib')
-    cmd('forall -c "echo *"')
+    assert cmd('forall -c "echo foo"').splitlines() == [
+        '=== running "echo foo" in manifest (zephyr):',
+        'foo',
+        '=== running "echo foo" in Kconfiglib (subdir/Kconfiglib):',
+        'foo',
+        '=== running "echo foo" in net-tools (net-tools):',
+        'foo']
 
 
 def test_update_projects(west_init_tmpdir):

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -242,6 +242,8 @@ def test_manifest_freeze(west_update_tmpdir):
                     '^    url: .*$',
                     '^    revision: [a-f0-9]{40}$',
                     '^    path: subdir/Kconfiglib$',
+                    '^    groups:$',
+                    '^    - Kconfiglib-group$',
                     '^  - name: tagged_repo$',
                     '^    url: .*$',
                     '^    revision: [a-f0-9]{40}$',


### PR DESCRIPTION
This was requested by a user in a comment in issue #144. The purpose is to make it easy to run commands on interesting subsets of projects in a convenient way.

See help text for details.