### PR TITLE
West compare command

### DIFF
--- a/src/west/app/main.py
+++ b/src/west/app/main.py
@@ -31,7 +31,7 @@ from west import log
 import west.configuration
 from west.commands import WestCommand, extension_commands, \
     CommandError, ExtensionCommandError, Verbosity
-from west.app.project import List, ManifestCommand, Diff, Status, \
+from west.app.project import List, ManifestCommand, Compare, Diff, Status, \
     SelfUpdate, ForAll, Init, Update, Topdir
 from west.app.config import Config
 from west.manifest import Manifest, MalformedConfig, MalformedManifest, \
@@ -907,6 +907,7 @@ BUILTIN_COMMAND_GROUPS = {
         Update,
         List,
         ManifestCommand,
+        Compare,
         Diff,
         Status,
         ForAll,

--- a/src/west/app/project.py
+++ b/src/west/app/project.py
@@ -670,15 +670,6 @@ class Status(_ProjectCommand):
         # to print. We manually use Popen in order to try to exit as
         # quickly as possible if 'git status' prints anything.
 
-        # This technique fails when tested on Python 3.6, which west
-        # still supports at time of writing. This seems likely to be
-        # due to https://bugs.python.org/issue35182.
-        #
-        # Users of old python versions will have to deal with the
-        # verbose output.
-        if sys.version_info < (3, 7):
-            return True
-
         popen = subprocess.Popen(['git', 'status', '--porcelain'],
                                  stdout=subprocess.PIPE,
                                  stderr=subprocess.PIPE,
@@ -693,15 +684,6 @@ class Status(_ProjectCommand):
                 stdout, stderr = popen.communicate(timeout=0.1)
             except subprocess.TimeoutExpired:
                 pass
-            except ValueError:
-                # In case this isn't issue35182, handle the exception
-                # anyway.
-                self.wrn(
-                    f'{project.name}: internal error; got ValueError '
-                    'from Popen.communicate() when checking status. '
-                    'Ignoring it, but please report this to the west '
-                    'developers.')
-                return True
             return stdout or stderr
 
         while True:


### PR DESCRIPTION
Help text for the new command:

```
$ west help compare
usage: west compare [-h] [-a] [--exit-code] [--ignore-branches] [PROJECT ...]

Compare each project's working tree state against the results
of the most recent successful "west update" command.

This command prints "git status" output for a project if
(and only if) at least one of the following is true:

1. its checked out commit is different than the commit checked
   out by the most recent successful "west update"
2. its working tree is not clean (i.e. there are local uncommitted
   changes)
3. it has a local checked out branch

positional arguments:
  PROJECT            projects (by name or path) to operate on; defaults to active cloned projects

options:
  -h, --help         show this help message and exit
  -a, --all          include output for inactive projects
  --exit-code        exit with status code 1 if status output was printed for any project
  --ignore-branches  skip output for projects with checked out branches and clean
                     working trees if the branch is at the same commit as the
                     last "west update"

ACTIVE PROJECTS
---------------

Default output is limited to "active" projects as determined by the:

- "group-filter" manifest file section
- "manifest.group-filter" local configuration option in .west/config

To include inactive projects as well, use "--all" or give an explicit
list of projects (by name or path). See the west documentation for
more details on active projects.

Regardless of the above, output is limited to cloned projects.
```

Fixes: #642