### PR TITLE
compare: add a blank line after each project

### DIFF
--- a/src/west/app/project.py
+++ b/src/west/app/project.py
@@ -680,6 +680,7 @@ class Compare(_ProjectCommand):
                         project.git('log --oneline -n 1 HEAD')
                         self.small_banner('status:')
                         project.git('status')
+                        print()
                         printed_status = True
                     except subprocess.CalledProcessError:
                         failed.append(project)
@@ -722,6 +723,7 @@ class Compare(_ProjectCommand):
                 project.git('log --oneline -n 1 manifest-rev')
                 self.small_banner('status:')
                 project.git('status')
+                print()
                 printed_status = True
             except subprocess.CalledProcessError:
                 failed.append(project)


### PR DESCRIPTION
`git status` adds one annoying blank line just before its last line of output:

```
Untracked files:
  (use "git add <file>..." to include in what will be committed)
	foo

nothing added to commit but untracked files present (use "git add" to track)
=== mbedtls (modules/crypto/mbedtls):
--- manifest-rev:
7fed49c9b9f9 (HEAD, manifest-rev) CC3XX: Hardcode entry points for the CC3XX driver
--- status:
```

This makes it harder to visualize the separation between projects.

Counters this by separating projects with one blank line:

```
Untracked files:
  (use "git add <file>..." to include in what will be committed)
	foo

nothing added to commit but untracked files present (use "git add" to track)

=== mbedtls (modules/crypto/mbedtls):
--- manifest-rev:
7fed49c9b9f9 (HEAD, manifest-rev) CC3XX: Hardcode entry points for the CC3XX driver
--- status:
```