### PR TITLE
main: handle ManifestImportError from extensions better

### DIFF
--- a/src/west/app/main.py
+++ b/src/west/app/main.py
@@ -843,8 +843,9 @@ class WestArgumentParser(argparse.ArgumentParser):
     def error(self, message):
         if self.west_app and self.west_app.mle:
             # If we have a known WestApp instance and the manifest
-            # failed to load, then try to specialize the error message
-            # to handle west-specific situations.
+            # failed to load, then try to specialize the generic error
+            # message we're getting from argparse to handle west-specific
+            # errors better.
 
             app = self.west_app
             mle = self.west_app.mle

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -565,12 +565,14 @@ class ManifestImportFailed(Exception):
         self.imp = imp
 
     def __str__(self):
-        if self.project is not None:
-            return (f'ManifestImportFailed: project {self.project} '
-                    f'value {self.imp}')
+        if self.project is None:
+            # This happens when imports fail in the manifest repository
+            return (f'cannot import {self.imp}; is it present '
+                    'in your manifest repository?')
         else:
-            return (f'ManifestImportFailed: manifest repository '
-                    f'value {self.imp}')
+            return (f'project {self.project.name_and_path}: '
+                    f'cannot import contents of {self.imp}; '
+                    'do you need to run "west update"?')
 
 
 class ManifestVersionError(Exception):


### PR DESCRIPTION
The default west manifest file in zephyrproject-rtos/zephyr recently added a project with an 'import'.

That means that 'west build' will fail with the confusing 'invalid choice: "build"' error if you pull zephyr without running 'west update'. This is a worse experience than what happens when you run e.g. 'west list': running a built-in command that needs the manifest to do its work will happily tell you you need to run 'west update' to resolve the failed import.

This is confusing people who pull and run 'west build', and we do have enough information to do better from WestArgumentParser.error(), which is the official argparse callback API invoked when parse_known_arguments() fails in this situation.

Extract the error message formatting for this situation into a helper function and use it from error() to print the same message when we get ManifestImportError in these situations.

Make the error message take up fewer lines while we are here.