### PR TITLE
Initial import filtering implementation

### DIFF
--- a/src/west/app/project.py
+++ b/src/west/app/project.py
@@ -17,6 +17,7 @@ import subprocess
 import sys
 import textwrap
 from time import perf_counter
+from typing import List as ListType
 from urllib.parse import urlparse
 
 from west.configuration import Configuration
@@ -962,7 +963,7 @@ class Update(_ProjectCommand):
         else:
             self.update_some()
 
-    def init_state(self, args):
+    def init_state(self, args: argparse.Namespace):
         # Helper for initializing instance state in response to
         # command line args and configuration files.
 
@@ -977,7 +978,7 @@ class Update(_ProjectCommand):
         self.sync_submodules = config.getboolean('update.sync-submodules',
                                                  default=True)
 
-        self.group_filter: List[str] = []
+        self.group_filter: ListType[str] = []
 
         def handle(group_filter_item):
             item = group_filter_item.strip()

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -2191,10 +2191,11 @@ class Manifest:
             groups = []
 
         if imp and groups:
-            # Maybe there is a sensible way to combine the two of these.
-            # but it's not clear what it is. Let's avoid weird edge cases
-            # like "what do I do about a project whose group is disabled
-            # that I need to import data from?".
+            # There isn't a sensible way to handle this case. We can't
+            # decide whether or not to import because we don't know if
+            # the project is active or not until after all group filters
+            # are resolved, which won't happen until we're done resolving
+            # the manifest.
             self._malformed(
                 f'project {name}: "groups" cannot be combined with "import"')
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -21,66 +21,11 @@ LOCAL = config.ConfigFile.LOCAL
 ALL = config.ConfigFile.ALL
 
 @pytest.fixture(autouse=True)
-def config_tmpdir(tmpdir):
-    # Fixture for running from a temporary directory with
-    # environmental overrides in place so all configuration files
-    # live inside of it. This makes sure we don't touch
-    # the user's actual files.
-    #
-    # We also set ZEPHYR_BASE (to avoid complaints in subcommand
-    # stderr), but to a spurious location (so that attempts to read
-    # from inside of it are caught here).
-    #
-    # Using this makes the tests run faster than if we used
-    # west_init_tmpdir from conftest.py, and also ensures that the
-    # configuration code doesn't depend on features like the existence
-    # of a manifest file, helping separate concerns.
-    system = tmpdir / 'config.system'
-    glbl = tmpdir / 'config.global'
-    local = tmpdir / 'config.local'
-
-    os.environ['ZEPHYR_BASE'] = str(tmpdir.join('no-zephyr-here'))
-    os.environ['WEST_CONFIG_SYSTEM'] = str(system)
-    os.environ['WEST_CONFIG_GLOBAL'] = str(glbl)
-    os.environ['WEST_CONFIG_LOCAL'] = str(local)
-
-    # Make sure our environment variables (as well as other topdirs)
-    # are respected from tmpdir, and we aren't going to touch the
-    # user's real files.
-    start_dir = os.getcwd()
-    tmpdir.chdir()
-
-    try:
-        assert config._location(SYSTEM) == str(system)
-        assert config._location(GLOBAL) == str(glbl)
-        td = tmpdir / 'test-topdir'
-        td.ensure(dir=True)
-        (td / '.west').ensure(dir=True)
-        (td / '.west' / 'config').ensure(file=True)
-        assert config._location(LOCAL) == str(local)
-        assert config._location(LOCAL, topdir=str(td)) == str(local)
-        td.remove(rec=1)
-        assert not td.exists()
-
-        assert not local.exists()
-
-        # All clear: switch to the temporary directory and run the test.
-        yield tmpdir
-    finally:
-        # Go back to where we started, for repeatability of results.
-        os.chdir(start_dir)
-
-        # Clean up after ourselves so other test cases don't know
-        # about this tmpdir. It's OK if test cases deleted these
-        # settings already.
-        if 'ZEPHYR_BASE' in os.environ:
-            del os.environ['ZEPHYR_BASE']
-        if 'WEST_CONFIG_SYSTEM' in os.environ:
-            del os.environ['WEST_CONFIG_SYSTEM']
-        if 'WEST_CONFIG_GLOBAL' in os.environ:
-            del os.environ['WEST_CONFIG_GLOBAL']
-        if 'WEST_CONFIG_LOCAL' in os.environ:
-            del os.environ['WEST_CONFIG_LOCAL']
+def autouse_config_tmpdir(config_tmpdir):
+    # Since this module tests west's configuration file features,
+    # adding autouse=True to the config_tmpdir fixture saves typing
+    # and is less error-prone than using it below in every test case.
+    pass
 
 def cfg(f=ALL, topdir=None):
     # Load a fresh configuration object at the given level, and return it.

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -85,6 +85,10 @@ def MF(**kwargs):
     # A convenience to save typing
     return Manifest.from_file(**kwargs)
 
+def MT(**kwargs):
+    # A convenience to save typing
+    return Manifest.from_topdir(**kwargs)
+
 #########################################
 # The very basics
 #


### PR DESCRIPTION
This feature provides a way to prevent west from performing an import
depending on a condition.

There are a variety of use cases for this:

- CI system maintainers want to be able to define an 'import' that
  contains repositories that contain test cases and which should be
  easy for developers to fetch with 'west update', but which are not
  distributed to users by default (by 'turning off' the import
  somehow)

- Similarly, but for projects which provide optional features that can
  be safely ignored unless the user takes an explicit action to enable
  the import. The main use case here isn't limiting visibility of
  the feature, but rather limiting the storage size and network
  bandwidth required to initialize a basic workspace

Provide this feature by extending the 'import: <map>' syntax with a
new key, 'if':

```yaml
  projects:
    - name: foo
      import:
        if:
          <condition>
```

Where the value of `<condition>` is itself a map, so that we can add
features to it over time. In this commit, we add the infrastructure
for the 'if' key and one simple way to write `<condition>`:

```yaml
  import:
    if:
      config-enabled: foo.bar
```

Here, the import will be resolved if and only if the west
configuration option 'foo.bar' is defined and set to a true boolean
value (see the python configparser docs for all the ways to write a
boolean option; "west config foo.bar true" is one way to set this up).

The configuration option can be set in any configuration file: local,
global, or system. This makes it easier for users who will want the
import performed but regularly set up workspaces in various places to
set it up permanently, without having to enable foo.bar every time
they set up a workspace, before the first "west update".

Design notes for the record:

- I was originally trying to do something like "import: if:
  group-enabled: bsim", but that runs into possibilities for
  self-contradiction, because a project that is imported later than
  you can disable a group, so you don't really know if a group is
  enabled or not until you are done parsing the manifest.

- It thus made sense to me to define a syntax for conditional
  imports that doesn't rely on groups at all. Configuration options
  are independent of groups and are set once and for all by the time
  we are loading the manifest, so it seemed like a good place to
  start.

- People are still rapidly ideating new ways to do import
  filtering for different use cases, so a one-size-fits-all solution
  seems unlikely. Making a flexible syntax that we can extend later
  therefore seemed more future-proof. In the future, we can do things
  like:

```yaml
    import:
      if:
        env: SOME_ENV_VAR=1
```

```yaml
    import:
      if:
        anyOf:
          config-enabled: foo.bar
          env: SOME_ENV_VAR=1
```
