### PR TITLE
'import-group-filters' top level manifest key

### DIFF
--- a/src/west/app/project.py
+++ b/src/west/app/project.py
@@ -576,8 +576,7 @@ class ManifestCommand(_ProjectCommand):
         except _ManifestImportDepth:
             self.die("cannot resolve manifest -- is there a loop?")
         except ManifestImportFailed as mif:
-            self.die(f"manifest import failed\n  Project: {mif.project}\n  "
-                     f"File: {mif.filename}")
+            self.die(str(mif))
         except (MalformedManifest, ManifestVersionError) as e:
             self.die('\n  '.join(str(arg) for arg in e.args))
         dump_kwargs = {'default_flow_style': False,

--- a/src/west/manifest-schema.yml
+++ b/src/west/manifest-schema.yml
@@ -35,6 +35,16 @@ mapping:
     required: false
     type: text
 
+  # The "import-group-filters" key is an optional boolean that defaults
+  # to 'true'. If it's 'false', then the group filter for this manifest
+  # will not depend on the group filters of any manifests it imports.
+  # If it's 'true', it will represent the combination of its own group
+  # filter and the group filters of imported manifests. Setting this to
+  # 'false' is the only way to combine 'import:' with 'groups:' in a project
+  # element.
+  import-group-filters:
+    type: bool
+
   # The "defaults" key specifies some default values used in the
   # rest of the manifest.
   defaults:

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -1788,7 +1788,15 @@ class Manifest:
 
             current_relpath = manifest_path / manifest_file
             current_abspath = topdir_abspath / current_relpath
-            current_data = current_abspath.read_text(encoding='utf-8')
+            try:
+                current_data = current_abspath.read_text(encoding='utf-8')
+            except FileNotFoundError:
+                raise MalformedConfig(
+                    f'file not found: manifest file {current_abspath} '
+                    '(from configuration options '
+                    f'manifest.path="{manifest_path_option}", '
+                    f'manifest.file="{manifest_file}")')
+
             current_repo_abspath = topdir_abspath / manifest_path
 
             self.abspath = os.fspath(current_abspath)

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -1356,7 +1356,8 @@ class Manifest:
         self._projects: List[Project] = []
         # The "raw" (unparsed) manifest.group-filter configuration
         # option in the local configuration file. See
-        # _config_group_filter().
+        # _config_group_filter(); only initialized if self._top_level
+        # is True and if we're loading from a file in a workspace.
         self._raw_config_group_filter: Optional[str] = None
         # A helper attribute we use for schema version v0.9 compatibility.
         self._top_level_group_filter: GroupFilterType = []

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -2770,6 +2770,7 @@ def test_group_filter_self_import(manifest_repo):
     self_import_helper('', [])
     self_import_helper('version: 0.9', ['-foo'])
 
+@pytest.mark.xfail
 def test_group_filter_imports(manifest_repo):
     # More complex test that ensures group filters are imported correctly:
     #
@@ -2827,7 +2828,7 @@ def test_group_filter_imports(manifest_repo):
     sha2 = setup_project('project2', '[+gy,+gy,-gz]')
 
     v0_9_expected = ['+ga', '-gc']
-    v0_10_expected = ['-ga', '-gb', '-gc', '-gw', '-gy', '-gz']
+    v0_10_expected = ['-ga', '-gb', '-gc', '-gw', '-gz']
 
     #
     # Basic tests of the above setup.

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1015,7 +1015,7 @@ def test_bad_topdir_fails(tmp_workspace):
     # Make sure we get expected failure using Manifest.from_topdir()
     # with the topdir kwarg when no west.yml exists.
 
-    with pytest.raises(FileNotFoundError):
+    with pytest.raises(MalformedConfig):
         MT(topdir=tmp_workspace)
 
 def test_from_bad_topdir(tmpdir):

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -85,6 +85,10 @@ def MF(**kwargs):
     # A convenience to save typing
     return Manifest.from_file(**kwargs)
 
+def MT(**kwargs):
+    # A convenience to save typing
+    return Manifest.from_topdir(**kwargs)
+
 #########################################
 # The very basics
 #
@@ -774,7 +778,7 @@ def test_from_topdir(tmp_workspace):
           - name: my-cool-project
             url: from-manifest-dir
         ''')
-    m = Manifest.from_topdir(topdir=topdir)
+    m = MT(topdir=topdir)
     # Path-related Manifest attribute tests.
     assert Path(m.abspath) == mf
     assert m.posixpath == mf.as_posix()
@@ -803,7 +807,7 @@ def test_from_topdir(tmp_workspace):
           self:
             path: something/else
         ''')
-    m = Manifest.from_topdir(topdir=topdir)
+    m = MT(topdir=topdir)
     # Path-related Manifest attribute tests.
     assert Path(m.abspath) == abspath
     assert m.posixpath == abspath.as_posix()
@@ -835,7 +839,7 @@ def test_from_topdir(tmp_workspace):
           self:
             path: something/else
         ''')
-    m = Manifest.from_topdir(topdir=topdir)
+    m = MT(topdir=topdir)
     p1 = m.projects[1]
     assert p1.path == 'project-path'
     assert Path(p1.abspath) == topdir / 'project-path'
@@ -867,7 +871,7 @@ def test_manifest_path_conflicts(tmp_workspace):
         ''')
 
     with pytest.raises(MalformedManifest) as e:
-        Manifest.from_topdir(topdir=tmp_workspace)
+        MT(topdir=tmp_workspace)
     assert 'p path "mp" is taken by the manifest repository' in str(e.value)
 
     m = M('''\
@@ -914,7 +918,7 @@ def test_manifest_repo_discovery(manifest_repo):
     assert PurePath(p.topdir) == topdir
 
     # Manifest.from_topdir() should work similarly.
-    manifest = Manifest.from_topdir()
+    manifest = MT()
     assert Path(manifest.topdir) == topdir
 
 def test_parse_multiple_manifest_files(manifest_repo):
@@ -1012,14 +1016,14 @@ def test_bad_topdir_fails(tmp_workspace):
     # with the topdir kwarg when no west.yml exists.
 
     with pytest.raises(FileNotFoundError):
-        Manifest.from_topdir(topdir=tmp_workspace)
+        MT(topdir=tmp_workspace)
 
 def test_from_bad_topdir(tmpdir):
     # If we give a bad temporary directory that isn't a workspace
     # root, that should also fail.
 
     with pytest.raises(MalformedConfig) as e:
-        Manifest.from_topdir(topdir=tmpdir)
+        MT(topdir=tmpdir)
     assert 'local configuration file not found' in str(e.value)
 
 #########################################
@@ -1073,7 +1077,7 @@ def test_get_projects(tmp_workspace):
 
     # Asking for an uncloned project should fail if only_cloned=False.
     # The ValueError args are (unknown, uncloned).
-    manifest = Manifest.from_topdir(topdir=tmp_workspace)
+    manifest = MT(topdir=tmp_workspace)
     with pytest.raises(ValueError) as e:
         manifest.get_projects(['foo'], only_cloned=True)
     unknown, uncloned = e.value.args
@@ -1147,7 +1151,7 @@ def test_as_dict_and_yaml(manifest_repo):
     # produces.
     manifest = MF()
 
-    manifest_topdir = Manifest.from_topdir(
+    manifest_topdir = MT(
         topdir=os.path.dirname(manifest_repo))
 
     # We can always call as_dict() and as_yaml(), regardless of what's
@@ -1841,9 +1845,9 @@ def test_import_self_directory(content, tmp_workspace):
 
     # Resolve the manifest. The mp/west.d content comes
     # from the file system in this case.
-    actual = Manifest.from_topdir(topdir=tmp_workspace,
-                                  importer=make_importer(call_map),
-                                  import_flags=FPI).projects
+    actual = MT(topdir=tmp_workspace,
+                importer=make_importer(call_map),
+                import_flags=FPI).projects
 
     expected = [
         ManifestProject(path='mp', topdir=tmp_workspace),
@@ -2317,7 +2321,7 @@ def test_import_path_prefix_basics(manifest_repo):
                reconfigure=False)
 
     # Check semantics for directly imported projects and nested imports.
-    actual = Manifest.from_topdir(topdir=topdir).projects
+    actual = MT(topdir=topdir).projects
     expected = [ManifestProject(path='mp', topdir=topdir),
                 # Projects in main west.yml with proper path-prefixing
                 # applied.
@@ -2374,7 +2378,7 @@ def test_import_path_prefix_self(manifest_repo):
                reconfigure=False)
 
     # Check semantics for directly imported projects and nested imports.
-    actual = Manifest.from_topdir(topdir=topdir).projects[0]
+    actual = MT(topdir=topdir).projects[0]
     expected = ManifestProject(path='mp', topdir=topdir)
     check_proj_consistency(actual, expected)
 
@@ -2421,7 +2425,7 @@ def test_import_path_prefix_propagation(manifest_repo):
                reconfigure=False)
 
     # Check semantics for directly imported projects and nested imports.
-    actual = Manifest.from_topdir(topdir=topdir).projects[1:]
+    actual = MT(topdir=topdir).projects[1:]
     expected = [Project('project-1', 'https://example.com/project-1',
                         path='prefix/1/prefix-2/project-one-path',
                         topdir=topdir),
@@ -2453,7 +2457,7 @@ def test_import_path_prefix_no_escape(manifest_repo):
     add_commit(manifest_repo, 'OK',
                files={'west.yml': mfst('ext')},
                reconfigure=False)
-    m = Manifest.from_topdir(topdir=topdir, import_flags=ImportFlag.IGNORE)
+    m = MT(topdir=topdir, import_flags=ImportFlag.IGNORE)
     assert (Path(m.projects[1].abspath) ==
             Path(topdir) / 'ext' / 'project')
 
@@ -2462,7 +2466,7 @@ def test_import_path_prefix_no_escape(manifest_repo):
                files={'west.yml': mfst('..')},
                reconfigure=False)
     with pytest.raises(MalformedManifest) as excinfo:
-        Manifest.from_topdir(topdir=topdir, import_flags=ImportFlag.IGNORE)
+        MT(topdir=topdir, import_flags=ImportFlag.IGNORE)
     assert 'escapes the workspace topdir' in str(excinfo.value)
 
 def test_import_loop_detection_self(manifest_repo):

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -2774,9 +2774,9 @@ def test_group_filter_self_import(manifest_repo):
     self_import_helper('', [])
     self_import_helper('version: 0.9', ['-foo'])
 
-@pytest.mark.xfail
 def test_group_filter_imports(manifest_repo):
-    # More complex test that ensures group filters are imported correctly:
+    # More complex test that ensures group filters are imported correctly
+    # when 'import-group-filters:' is true / not set.
     #
     #   - imports from self have highest precedence
     #   - the top level manifest comes next


### PR DESCRIPTION
**Abandoned**

@tejlmand has pointed out that this feature, if implemented, means that `west manifest --resolve` is no longer possible to implement. The semantics in this proposed feature would make the set of enabled/disabled groups context-specific, differing at different points in time when resolving imports. This in turn makes it impossible to write a single "equivalent" manifest file. We want to continue to support `west manifest --resolve` and believe the extra complexity and poorly specified semantics points to this idea being a nonstarter.

----------------------------------------------------------------------

This is the agreed upon approach for how we're going to handle the babblesim module in zephyr/west.yml (#656, #652, #653, #543).

The new 'import-group-filters' feature is a top level manifest key that takes a boolean. The default
value is 'true' and is west's current behavior. The behavior when this value is false can be shown by this example:

```yaml
  manifest:
    group-filter: [-foo]
    import-group-filters: false
    projects:
      - name: proj
        import: true
    self:
      import: submanifest.yml
```

Here, the final Manifest.group_filter attribute for the manifest whose data are shown above will always be [-foo], regardless of what the imported manifest data from 'proj' or 'submanifest.yml' are.

The purpose of this extension is to allow the combination of 'groups' and 'import':

- In previous versions of west, we could not combine the two, because
  in pathological edge cases, we could end up resolving an import for a
  group which was later disabled by an import that happened later on.

- With this new backwards-compatible enhancement to the manifest file
  format, we can combine 'import:' with 'groups:' in a single project
  whenever 'import-group-filters:' is 'false'. This is because we will
  know the final 'group_filter' attribute for the entire Manifest at
  the time we perform the import, and it cannot be changed later by
  any imports we might perform.

Since this new behavior would break backwards compatibility if made the default, we make it explicitly opt-in by requiring 'import-group-filters: false'.

Implementing this feature exposed a bug in the current group filter handling. The new implementation does not have this bug.

Fixes: #663
Fixes: #652
