### PR TITLE
compare: add --decorate

### DIFF
--- a/src/west/app/project.py
+++ b/src/west/app/project.py
@@ -736,10 +736,19 @@ class Compare(_ProjectCommand):
             return
 
         def rev_info(rev):
-            return project.git(
-                ['log', '-1', '--color=never', '--pretty=%h %s', rev],
+            title = project.git(
+                ['log', '-1', '--color=never', '--pretty=%h%d %s',
+                 '--decorate-refs-exclude=refs/heads/manifest-rev',
+                 rev],
                 capture_stdout=True,
                 capture_stderr=True).stdout.decode().rstrip()
+            # "HEAD" is special; '--decorate-refs-exclude=HEAD' doesn't work.
+            # Fortunately it's always first.
+            return (
+                title.replace('(HEAD) ', '').replace('(HEAD, ', '(')
+                .replace('(HEAD -> ', '(')
+            )
+
         head_info = rev_info('HEAD')
         # If manifest-rev is missing, we already failed earlier.
         manifest_rev_info = rev_info('manifest-rev')


### PR DESCRIPTION
When a project is not on the `manifest-rev` it will often be on a branch or tag. Use the `%d` format to make `west compare` show that information.

As discussed in #643 and before, git status cannot be fully trusted to display branch information.

Sample new output:
```
west compare
=== zephyr (zephyr):
--- manifest-rev: e40859f78712 (some_tag) Revert "dma: dw: Do ...
            HEAD: e803b77463b4 (zephyrproject/main) samples: net: ...
--- status:
    HEAD detached at zephyrproject/main
    nothing to commit, working tree clean
```