### PR TITLE
commands: Show less generic error when no manifest is loaded

### DIFF
--- a/src/west/commands.py
+++ b/src/west/commands.py
@@ -25,7 +25,7 @@ import pykwalify
 import yaml
 
 from west.configuration import Configuration
-from west.manifest import Manifest, Project
+from west.manifest import Manifest, _ManifestRequired, Project
 from west.util import escapes_directory, quote_sh_list, PathType
 
 '''\
@@ -258,9 +258,7 @@ class WestCommand(ABC):
         Otherwise, a fatal error occurs.
         '''
         if self._manifest is None:
-            self.die(f"can't run west {self.name};",
-                     "it requires the manifest, which was not available.",
-                     'Try "west manifest --validate" to debug.')
+            raise _ManifestRequired
         return self._manifest
 
     def _set_manifest(self, manifest: Optional[Manifest]):

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -685,6 +685,10 @@ class _ManifestImportDepth(ManifestImportFailed):
     # A hack to signal to main.py what happened.
     pass
 
+class _ManifestRequired(Exception):
+    # A built-in command had to read the manifest but it wasn't loaded.
+    pass
+
 #
 # The main Manifest class and its public helper types, like Project
 # and ImportFlag.


### PR DESCRIPTION
Minor quirk that stuck out to me while testing the recent changes. Before https://github.com/zephyrproject-rtos/west/commit/23db6e1f3cc7fb50e0a3e0bda8235892db74c971, if I were to try `west manifest --resolve` in Zephyr without cloning `bsim`, I would see this:
```
FATAL ERROR: project bsim (tools/bsim): cannot import contents of west.yml; do you need to run "west update"?
```
which is helpful enough. Now, this generic message gets displayed:
```
FATAL ERROR: can't run west manifest; it requires the manifest, which was not available. Try "west manifest --validate" to debug.
```
Ironically, `west manifest --validate` produces the same error, which is not very helpful. So, I tried to fix that.