### PR TITLE
compare: always prefix `git status` output with manifest-rev

### DIFF
--- a/src/west/app/project.py
+++ b/src/west/app/project.py
@@ -704,8 +704,7 @@ class Compare(_ProjectCommand):
 
     def print_rev_info(self, project):
         # For non-manifest repositories, print HEAD's and
-        # manifest-rev's SHAs and commit titles, but only if they are
-        # different.
+        # manifest-rev's SHAs and commit titles.
         #
         # We force git not to print in color so west's colored
         # banner() separators stand out more in the output.
@@ -729,9 +728,8 @@ class Compare(_ProjectCommand):
         head_info = rev_info('HEAD')
         # If manifest-rev is missing, we already failed earlier.
         manifest_rev_info = rev_info('manifest-rev')
-        if head_info != manifest_rev_info:
-            self.small_banner(f'manifest-rev: {manifest_rev_info}')
-            self.inf(f'            HEAD: {head_info}')
+        self.small_banner(f'manifest-rev: {manifest_rev_info}')
+        self.inf(f'            HEAD: {head_info}')
 
     def print_status(self, project):
         # `git status` shows `manifest-rev` "sometimes", see #643.


### PR DESCRIPTION
It's not unusual to make "quick and dirty", temporary changes in a git
repo that is on the manifest: either add some untracked files or create
a branch. As expected, this makes the repository show in `west compare`.
If such repos and the manifest repo are the only repos
appearing in the `west compare` output, then no manifest-rev + HEAD
banner ever appeared. When no banner ever appears it's really not
obvious which repos are on the manifest-rev vs not. In other words: the
main `west compare` feature is defeated.

Clear this doubt by always showing the banner, even when `HEAD` and
`manifest-rev` are the same. See sample output below.

I think the original design idea was to follow diff's "spirit" not to
show anything that's identical and to save as many lines as
possible. However I don't think it works in this particular case because
invoking `git status` for a repo _without_ showing where its HEAD is at
is way too subtle, _especially_ when there is no other repo with a
banner to provide a comparison point and some contrast. Explicitly and
consistently prefixing every `git status` output with a manifest-rev
banner is much more clear and obvious.

Moreover, `git status` output is relatively verbose already so always
prefixing it with a 2 lines long banner makes negligible difference to
the total.

Before:
```
$ west compare

=== hal_xtensa (modules/hal/xtensa):
--- status:
    On branch somebranch
    nothing to commit, working tree clean
```

After:
```
$ west compare

=== hal_xtensa (modules/hal/xtensa):
--- manifest-rev: 41a631d4aeee (somebranch, upstream/master) cmake: enable using SOC_TOOLCHAIN_NAME ...
            HEAD: 41a631d4aeee (somebranch, upstream/master) cmake: enable using SOC_TOOLCHAIN_NAME ...
--- status:
    On branch somebranch
    nothing to commit, working tree clean
```
Signed-off-by: Marc Herbert <marc.herbert@intel.com>