### PR TITLE
commands: add grep

### DIFF
--- a/src/west/app/main.py
+++ b/src/west/app/main.py
@@ -34,7 +34,7 @@ import west.configuration
 from west.commands import WestCommand, extension_commands, \
     CommandError, ExtensionCommandError, Verbosity
 from west.app.project import List, ManifestCommand, Compare, Diff, Status, \
-    SelfUpdate, ForAll, Init, Update, Topdir
+    SelfUpdate, ForAll, Grep, Init, Update, Topdir
 from west.app.config import Config
 from west.manifest import Manifest, MalformedConfig, MalformedManifest, \
     ManifestVersionError, ManifestImportFailed, _ManifestImportDepth, \
@@ -1097,6 +1097,7 @@ BUILTIN_COMMAND_GROUPS = {
         Diff,
         Status,
         ForAll,
+        Grep,
     ],
 
     'other built-in commands': [

--- a/src/west/commands.py
+++ b/src/west/commands.py
@@ -400,7 +400,7 @@ class WestCommand(ABC):
             return version
         return version + (int(patch),)
 
-    def dbg(self, *args, level: Verbosity = Verbosity.DBG):
+    def dbg(self, *args, level: Verbosity = Verbosity.DBG, end: str = '\n'):
         '''Print a verbose debug message.
 
         The message is only printed if *self.verbosity* is at least *level*.
@@ -410,9 +410,9 @@ class WestCommand(ABC):
         '''
         if level > self.verbosity:
             return
-        print(*args)
+        print(*args, end=end)
 
-    def inf(self, *args, colorize: bool = False):
+    def inf(self, *args, colorize: bool = False, end: str = '\n'):
         '''Print an informational message.
 
         The message is only printed if *self.verbosity* is at least INF.
@@ -432,7 +432,7 @@ class WestCommand(ABC):
         if colorize:
             print(INF_COLOR, end='')
 
-        print(*args)
+        print(*args, end=end)
 
         if colorize:
             self._reset_colors(sys.stdout)
@@ -448,7 +448,7 @@ class WestCommand(ABC):
         not colorized.'''
         self.inf('---', *args, colorize=False)
 
-    def wrn(self, *args):
+    def wrn(self, *args, end: str = '\n'):
         '''Print a warning.
 
         The message is only printed if *self.verbosity* is at least WRN.
@@ -464,12 +464,12 @@ class WestCommand(ABC):
             print(WRN_COLOR, end='', file=sys.stderr)
 
         print('WARNING: ', end='', file=sys.stderr)
-        print(*args, file=sys.stderr)
+        print(*args, end=end, file=sys.stderr)
 
         if self.color_ui:
             self._reset_colors(sys.stderr)
 
-    def err(self, *args, fatal: bool = False):
+    def err(self, *args, fatal: bool = False, end: str = '\n'):
         '''Print an error.
 
         The message is only printed if *self.verbosity* is at least ERR.
@@ -488,7 +488,7 @@ class WestCommand(ABC):
             print(ERR_COLOR, end='', file=sys.stderr)
 
         print('FATAL ERROR: ' if fatal else 'ERROR: ', end='', file=sys.stderr)
-        print(*args, file=sys.stderr)
+        print(*args, end=end, file=sys.stderr)
 
         if self.color_ui:
             self._reset_colors(sys.stderr)

--- a/src/west/commands.py
+++ b/src/west/commands.py
@@ -293,27 +293,35 @@ class WestCommand(ABC):
 
     config = property(_get_config, _set_config)
 
+    def _log_subproc(self, args, **kwargs):
+        self.dbg(f"running '{quote_sh_list(args)}' in "
+                 f"{kwargs.get('cwd') or os.getcwd()}",
+                 level=Verbosity.DBG_MORE)
+
     #
     # Other public methods
     #
 
-    def check_call(self, args, cwd=None):
-        '''Runs subprocess.check_call(args, cwd=cwd) after
+    def check_call(self, args, **kwargs):
+        '''Runs subprocess.check_call(args, **kwargs) after
         logging the call at Verbosity.DBG_MORE level.'''
 
-        cmd_str = quote_sh_list(args)
-        self.dbg(f"running '{cmd_str}' in {cwd or os.getcwd()}",
-                 level=Verbosity.DBG_MORE)
-        subprocess.check_call(args, cwd=cwd)
+        self._log_subproc(args, **kwargs)
+        subprocess.check_call(args, **kwargs)
 
-    def check_output(self, args, cwd=None):
-        '''Runs subprocess.check_output(args, cwd=cwd) after
+    def check_output(self, args, **kwargs):
+        '''Runs subprocess.check_output(args, **kwargs) after
         logging the call at Verbosity.DBG_MORE level.'''
 
-        cmd_str = quote_sh_list(args)
-        self.dbg(f"running '{cmd_str}' in {cwd or os.getcwd()}",
-                 level=Verbosity.DBG_MORE)
-        return subprocess.check_output(args, cwd=cwd)
+        self._log_subproc(args, **kwargs)
+        return subprocess.check_output(args, **kwargs)
+
+    def run_subprocess(self, args, **kwargs):
+        '''Runs subprocess.run(args, **kwargs) after logging
+        the call at Verbosity.DBG_MORE level.'''
+
+        self._log_subproc(args, **kwargs)
+        return subprocess.run(args, **kwargs)
 
     def die_if_no_git(self):
         '''Abort if git is not installed on PATH.

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -389,6 +389,30 @@ def test_forall(west_init_tmpdir):
                    'foo',
                ]
 
+
+def test_grep(west_init_tmpdir):
+    # Make sure we don't find things we don't expect, and do find
+    # things we do.
+
+    actual_before_update = cmd('grep net-').strip()
+    actual_before_update_lines = actual_before_update.splitlines()
+    assert len(actual_before_update_lines) == 2
+    assert re.fullmatch(r'=== manifest \(zephyr\):',
+                        actual_before_update_lines[0])
+    assert re.search('net-tools',
+                     actual_before_update_lines[1])
+
+    assert not re.search('hello', cmd('grep hello'))
+
+    cmd('update')
+    assert re.search('hello', cmd('grep hello'))
+
+    # Make sure '--' is handled properly: the first one is for
+    # west, and the second one is for the tool
+
+    assert re.search('west-commands', cmd('grep -- -- -commands'))
+
+
 def test_update_projects(west_init_tmpdir):
     # Test the 'west update' command. It calls through to the same backend
     # functions that are used for automatic updates and 'west init'


### PR DESCRIPTION
This has been requested various times, but its lack never bothered me up until now, etc. Anyway, here it is.

Fixes: https://github.com/zephyrproject-rtos/west/issues/337

```
EXAMPLES
--------

To get "git grep foo" results from all cloned, active projects:

  west grep foo

To do the same with:

- git grep --untracked: west grep --untracked foo
- ripgrep:              west grep --tool ripgrep foo
- grep --recursive:     west grep --tool grep foo

To switch the default tool to:

- ripgrep:  west config grep.tool ripgrep
- grep:     west config grep.tool grep

GREP TOOLS
----------

This command runs a "grep tool" command in the top directory of each project.
Supported tools:

- git-grep (default)
- ripgrep
- grep

Set the "grep.tool" configuration option to change the default.

Use "--tool" to switch the tool from its default.

TOOL PATH
---------

Use --tool-path to override the path to the tool. For example:

  west grep --tool ripgrep --tool-path /my/special/ripgrep

Without --tool-path, the "grep.<TOOL>-path" configuration option
is checked next. For example, to set the default path to ripgrep:

  west config grep.ripgrep-path /my/special/ripgrep

If the option is not set, "west grep" searches for the tool as follows:

- git-grep: search for "git" (and run as "git grep")
- ripgrep: search for "rg", then "ripgrep"
- grep: search for "grep"

TOOL ARGUMENTS
--------------

The "grep.<TOOL>-args" configuration options, if set, contain arguments
that are always passed to the tool. The defaults for these are:

- git-grep: (none)
- ripgrep: (none)
- grep: "--recursive"

Command line options or arguments not recognized by "west grep" are
passed to the tool after that. This applies to --foo here, for example:

  west grep --foo --project=myproject

To force arguments to be given to the tool instead of west, put them
after a "--", like the --project and --tool-path options here:

  west grep -- --project=myproject --tool-path=mypath

Arguments before '--' that aren't recognized by west grep are still
passed to the grep tool.

To pass '--' to the grep tool, pass one for 'west grep' first.
For example, to search for '--foo' with grep, you can run:

  west grep --tool grep -- -- --foo

The first '--' separates west grep args from tool args. The second '--'
separates options from positional arguments in the 'grep' command line.

COLORS
------

By default, west will force the tool to print colored output as long
as the "color.ui" configuration option is true. If color.ui is false,
west forces the tool not to print colored output.

Since all supported tools have similar --color options, you can
override this behavior on the command line, for example with:

  west grep --color=never

To do this permanently, set "grep.color":

  west config grep.color never
```