### PR TITLE
grep: fix command hanging forever when grep.{tool}-args is empty

### DIFF
--- a/src/west/app/project.py
+++ b/src/west/app/project.py
@@ -1829,7 +1829,7 @@ class Grep(_ProjectCommand):
                 color = 'never'
 
         ret.extend([f'--color={color}'])
-        ret.extend(shlex.split(self.config.get(f'grep.{tool}-args'), '') or
+        ret.extend(shlex.split(self.config.get(f'grep.{tool}-args', '')) or
                    self.DEFAULT_TOOL_ARGS[tool])
 
         # The first '--' we see is "meant for" west grep. Take that


### PR DESCRIPTION
Fixes commit 1d220bbd627b ("commands: add grep") / #678 

Fix misplaced closing parenthese in:

```python
shlex.split(self.config.get(f'grep.{tool}-args'), '')
```

The empty string is meant as a default value for config.get() but it was passed as a second argument to shlex.split() by mistake.

Funny enough this hangs forever:

```python
>>> shlex.split(None, comments='')
<stdin>:1: DeprecationWarning: Passing None for 's' to shlex.split() is deprecated.
 (hangs forever)
```

PS: debuggers rulez