### PR TITLE
README.rst: add pytest examples and mention tox limitations

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -78,6 +78,23 @@ Then, run the test suite locally from the top level directory::
 
   tox
 
+You can use ``--`` to tell tox to pass arguments to ``pytest``. This is
+especially useful to focus on specific tests and save time. Examples::
+
+  # Run a subset of tests
+  tox  --  tests/test_project.py
+
+  # Debug the ``test_update_narrow()`` code with ``pdb`` (but _not_ the
+  # west code which is running in subprocesses)
+  tox  --  --verbose --exitfirst --trace -k test_update_narrow
+
+  # Run all tests with "import" in their name and let them log to the
+  # current terminal
+  tox  --  -v -k import --capture=no
+
+The tests cannot be run with ``pytest`` directly, they require the tox
+environment.
+
 See the tox configuration file, tox.ini, for more details.
 
 Hacking on West

--- a/tox.ini
+++ b/tox.ini
@@ -35,6 +35,6 @@ deps =
 setenv =
     TOXTEMPDIR={envtmpdir}
 commands =
+  python -m pytest --cov=west {posargs:tests}
   python -m flake8 --config={toxinidir}/tox.ini {toxinidir}
   python -m mypy --config-file={toxinidir}/tox.ini --package=west
-  python -m pytest --cov=west {posargs:tests}


### PR DESCRIPTION
The tox indirection layer is convenient except for the usual problems
caused by too many layers of indirection:

- Add some examples and show how it is still possible to use important
  pytest features. This is also useful to boost people familiar with
  Python but not with pytest.

- To stop developers wasting their time trying, document a major
  limitation with the current approach: impossible to run the west
  code in a debugger when it's started from a test.

- Show how the "printf" alternative can work.