### PR TITLE
project.py: request users to stop IDEs before running `west init`

### DIFF
--- a/src/west/app/project.py
+++ b/src/west/app/project.py
@@ -153,6 +153,16 @@ manifest repository. If --mr is not given, the remote's default
 branch will be used, if it exists.
 
 With neither, -m {MANIFEST_URL_DEFAULT} is assumed.
+
+Warning: 'west init' renames and/or deletes temporary files inside the
+workspace being created. This fails on some filesystems when some
+development tool or any other program is trying to read/index these
+temporary files at the same time. For instance, it is required to stop
+Visual Studio Code before running 'west init` on the Windows NTFS
+filesystem. Find other, similar "Access is denied" examples in west
+issue #558.
+This is not required on inode-based, Linux filesystems that wait and
+finalize the deletion until there is no concurrent user left.
 ''',
             requires_workspace=False)
 


### PR DESCRIPTION
There have been many users reports in #558 that `west init` fails on the Windows NTFS filesystem when some IDEs are running concurrently.

There is no simple and reliable fix for this because:

- The lack of concurrency is a core limitation in the NTFS design that will not change anytime soon,
- IDEs have no reliable way to know when they should pause scanning the filesystem.
- Placing temporary files outside the workspace would invite other, complex and nasty issues with cross-filesystem moves (#558)

Short of a fix, explain why this happens very briefly in `west init -h` and request users to temporarily close their IDEs. It's the only simple and universal mitigation available.

Mention the issue number in case someone needs more details, some evidence or smarter workarounds specific to certain IDEs.