### PR TITLE
Always decode manifests with utf-8; not just most of the time

### DIFF
--- a/src/west/app/project.py
+++ b/src/west/app/project.py
@@ -321,7 +321,7 @@ finalize the deletion until there is no concurrent user left.
         # Parse the manifest to get "self: path:", if it declares one.
         # Otherwise, use the URL. Ignore imports -- all we really
         # want to know is if there's a "self: path:" or not.
-        manifest = Manifest.from_data(temp_manifest.read_text(),
+        manifest = Manifest.from_data(temp_manifest.read_text(encoding=Manifest.encoding),
                                       import_flags=ImportFlag.IGNORE)
         if manifest.yaml_path:
             manifest_path = manifest.yaml_path

--- a/src/west/app/project.py
+++ b/src/west/app/project.py
@@ -1049,7 +1049,7 @@ class Update(_ProjectCommand):
         self.updated.add(project.name)
 
         try:
-            return _manifest_content_at(project, path)
+            return _manifest_content_at(project, path, Manifest.encoding)
         except FileNotFoundError:
             # FIXME we need each project to have back-pointers
             # to the manifest file where it was defined, so we can

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -272,7 +272,9 @@ def _manifest_content_at(project: 'Project', path: PathType,
         # enough!
         raise OSError(errno.ENOENT, os.strerror(errno.ENOENT), path)
 
-    ptype = out.decode('utf-8').split()[1]
+    # TODO: does git always output utf-8? Test git config 'core.precomposeunicode' etc.
+    git_filenames_encoding = 'utf-8'
+    ptype = out.decode(git_filenames_encoding).split()[1]
 
     if ptype == 'blob':
         # Importing a file: just return its content.
@@ -283,7 +285,8 @@ def _manifest_content_at(project: 'Project', path: PathType,
         # Use a PurePosixPath because that's the form git seems to
         # store internally, even on Windows.
         pathobj = PurePosixPath(path)
-        for f in filter(_is_yml, project.listdir_at(path, rev=rev)):
+        for f in filter(_is_yml, project.listdir_at(path, rev=rev,
+                                                    encoding=git_filenames_encoding)):
             ret.append(project.read_at(pathobj / f, rev=rev).decode('utf-8'))
         return ret
     else:


### PR DESCRIPTION
3 commits.

- Two de-duplication commits with no effect
- Consistently decode manifests with utf-8

This is a "larger" alternative to #710 
