### PR TITLE
.github: upgrade to checkout@v4 and setup-python@v5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,9 +11,9 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.8, 3.9, '3.10']
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Display Python version


### PR DESCRIPTION
Long overdue; both where still at @v1!

Found by chance in
https://github.com/zephyrproject-rtos/west/actions/runs/9275086435/job/25518959121?pr=711 where all macos-latest configs failed like this:
```
Run actions/setup-python@v1
Error: Version 3.8 with arch x64 not found
Available versions:
  (empty)
```