### PR TITLE
project.py: Add new 'joblib' dependency to parallelize update

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "pykwalify",
     "setuptools",
     "packaging",
+    "joblib",
 ]
 
 [project.license]

--- a/src/west/app/project.py
+++ b/src/west/app/project.py
@@ -36,6 +36,12 @@ from west.manifest import (
 )
 from west.manifest import is_group as is_project_group
 
+JOBLIB_PRESENT = True
+try:
+    from joblib import Parallel, delayed
+except ModuleNotFoundError:
+    JOBLIB_PRESENT = False
+
 #
 # Project-related or multi-repo commands, like "init", "update",
 # "diff", etc.
@@ -952,6 +958,12 @@ class Update(_ProjectCommand):
         parser.add_argument('--stats', action='store_true',
                             help='''print performance statistics for
                             update operations''')
+        if JOBLIB_PRESENT:
+            parser.add_argument('-j', '--jobs', nargs='?', const=-1,
+                                default=1, type=int, action='store',
+                                help='''Use multiple jobs to parallelize the update process.
+                                Pass -1 to use all available jobs.
+                                ''')
 
         group = parser.add_argument_group(
             title='local project clone caches',
@@ -1087,18 +1099,26 @@ class Update(_ProjectCommand):
             import_flags=ImportFlag.FORCE_PROJECTS)
 
         failed = []
-        for project in self.manifest.projects:
+
+        def project_update(project):
             if (isinstance(project, ManifestProject) or
                     project.name in self.updated):
-                continue
+                return
             try:
                 if not self.project_is_active(project):
                     self.dbg(f'{project.name}: skipping inactive project')
-                    continue
-                self.update(project)
+                    return
                 self.updated.add(project.name)
+                self.update(project)
             except subprocess.CalledProcessError:
                 failed.append(project)
+
+        if not JOBLIB_PRESENT or self.args.jobs == 1:
+            for project in self.manifest.projects:
+                project_update(project)
+        else:
+            Parallel(n_jobs=self.args.jobs, require='sharedmem')(
+                delayed(project_update)(project) for project in self.manifest.projects)
         self._handle_failed(self.args, failed)
 
     def update_importer(self, project, path):
@@ -1159,13 +1179,22 @@ class Update(_ProjectCommand):
             projects = self._projects(self.args.projects)
 
         failed = []
-        for project in projects:
+
+        def project_update_some(project):
             if isinstance(project, ManifestProject):
-                continue
+                return
             try:
                 self.update(project)
             except subprocess.CalledProcessError:
                 failed.append(project)
+
+        if not JOBLIB_PRESENT or self.args.jobs == 1:
+            for project in projects:
+                project_update_some(project)
+        else:
+            Parallel(n_jobs=self.args.jobs, require='sharedmem')(
+                delayed(project_update_some)(project) for project in projects)
+
         self._handle_failed(self.args, failed)
 
     def toplevel_projects(self):


### PR DESCRIPTION
The projects from manifests were updated one by one. The parallel approach has potential to fully utilize CPU and network connection to speed up the update.

Needs more testing, I checked only few common cases and it seems fine. 


Performance tests:
`west init -m https://github.com/nrfconnect/sdk-nrf --mr main`
`time west update`

> real    14m35.399s
> user    6m2.368s
> sys     1m34.562s

system and network load during update:
![image](https://github.com/zephyrproject-rtos/west/assets/77001564/ab961f92-88e4-4ae5-b976-ca8d7479e545)


Clean up and replace west for version from this PR
`rm -rf <.west and all downloaded repositories>`
`pip3 uninstall west`
`cd <west_source_dir>`
`pip3 install -e .`
`cd .. `

repeat the test
`west init -m https://github.com/nrfconnect/sdk-nrf --mr main`
`time west update`

> real    6m34.408s
> user    9m25.977s
> sys     2m7.339s

system and network load during parallel update:
![image](https://github.com/zephyrproject-rtos/west/assets/77001564/527a9a21-3154-4ac2-8834-6edd4d5a499f)

As we can see, the result is substantially faster. The same operation finishes in less than half of the original time  (from 14.5 minutest down to 6.5 minutes).
