### PR TITLE
app: Allow passing arguments to git status/diff

### DIFF
--- a/src/west/app/project.py
+++ b/src/west/app/project.py
@@ -769,7 +769,10 @@ class Diff(_ProjectCommand):
         super().__init__(
             'diff',
             '"git diff" for one or more projects',
-            'Runs "git diff" on each of the specified projects.')
+            '''Runs "git diff" on each of the specified projects.
+            Unknown arguments are passed to "git diff".''',
+            accepts_unknown_args=True,
+        )
 
     def do_add_parser(self, parser_adder):
         parser = self._parser(parser_adder,
@@ -783,7 +786,7 @@ class Diff(_ProjectCommand):
                             help='show changes relative to the manifest revision')
         return parser
 
-    def do_run(self, args, ignored):
+    def do_run(self, args, user_args):
         self.die_if_no_git()
 
         failed = []
@@ -798,6 +801,7 @@ class Diff(_ProjectCommand):
             cp = project.git(['diff', f'--src-prefix={project.path}/',
                               f'--dst-prefix={project.path}/',
                               '--exit-code'] + color + merge_base,
+                             extra_args=user_args,
                              capture_stdout=True, capture_stderr=True,
                              check=False)
             if cp.returncode == 0:
@@ -817,7 +821,10 @@ class Status(_ProjectCommand):
         super().__init__(
             'status',
             '"git status" for one or more projects',
-            "Runs 'git status' for each of the specified projects.")
+            '''Runs "git status" for each of the specified projects.
+            Unknown arguments are passed to "git status".''',
+            accepts_unknown_args=True,
+        )
 
     def do_add_parser(self, parser_adder):
         parser = self._parser(parser_adder,

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -336,11 +336,13 @@ def test_diff(west_init_tmpdir):
 
     cmd('diff')
     cmd('diff --manifest')
+    cmd('diff --stat')
 
     # Neither should it fail after fetching one or both projects
 
     cmd('update net-tools')
     cmd('diff')
+    cmd('diff --stat')
 
     cmd('update Kconfiglib')
 
@@ -351,11 +353,13 @@ def test_status(west_init_tmpdir):
     # Status with no projects cloned shouldn't fail
 
     cmd('status')
+    cmd('status --short --branch')
 
     # Neither should it fail after fetching one or both projects
 
     cmd('update net-tools')
     cmd('status')
+    cmd('status --short --branch')
 
     cmd('update Kconfiglib')
 


### PR DESCRIPTION
`west` should pass unknown arguments to `git status` and `git diff` commands.

This allows things like:

```shell
$ west status --short --branch
$ west diff --stat
```