### PR TITLE
app: point "handle_unknown_command()" error message to "west -vv status"

### DIFF
--- a/src/west/app/main.py
+++ b/src/west/app/main.py
@@ -573,9 +573,11 @@ class WestApp:
             self.handle_unknown_command(early_args.command_name)
 
     def handle_unknown_command(self, command_name):
+        # "status" needs "-vv" to show git errors like "dubious ownership"; see #726
         if self.topdir:
             extra_help = (f'workspace {self.topdir} does not define '
-                          'this extension command -- try "west help"')
+                          'this extension command -- try "west help"'
+                          ' and "west -vv status"')
         else:
             extra_help = 'do you need to run this inside a workspace?'
         self.print_usage_and_exit(f'west: unknown command "{command_name}"; '
@@ -1060,10 +1062,10 @@ def mie_msg(mie):
         # what west.manifest needs to happen before we can
         # resolve the missing import.
         ret += (f' from revision "{p.revision}"\n'
-                f'  Hint: {p.name} must be cloned and its '
+                f'  Hint: {p.name} must be cloned, owned by the user and its '
                 f'{MANIFEST_REV_BRANCH} ref must point to a '
                 'commit with the import data\n'
-                '  To fix, run "west update"')
+                '  To fix, run "west update. If it still fails, try "west -vv ..."')
 
     return ret
 


### PR DESCRIPTION
Commit d84237108992 ("app: handle unexpected command name better") intentionally created a big error handling difference between extensions and built-in commands. As an unfortunate side effect, it lost the relevant "manifest import failure" error messages for _extension_ commands.  This is especially ironic when the extension command is missing because the import failed, see example in #726.

Error handling is generally very hard to test comprehensively and even more so in this complex "bootstrap" area. Rather than trying to refactor it once again, tweak the existing error messages to gently steer the user away from (potentially missing) extensions and towards built-in commands that provide a simpler and better error handling out of the box: they still show relevant, manifest error messages! Always have.

Also recommand the -vv option which conveniently includes git error messages like "dubious ownership" since previous commit 23db6e1f3cc7 ("app: re-work logging yet again") from the same giant PR #664