### PR TITLE
tests: stop using shlex.split() and use lists instead

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,7 @@
+---
 name: Python Test
 
+# yamllint disable-line rule:truthy
 on: [push, pull_request]
 
 jobs:
@@ -12,6 +14,10 @@ jobs:
         python-version: [3.8, 3.9, '3.10']
     steps:
       - uses: actions/checkout@v4
+        # This is enough to find many quoting issues
+        with:
+          path: "./check out"
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -21,4 +27,4 @@ jobs:
       - name: install tox
         run: pip3 install tox
       - name: tox
-        run: tox
+        run: tox -c 'check out'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,6 @@
 import os
 from pathlib import Path, PurePath
 import platform
-import shlex
 import shutil
 import subprocess
 import sys
@@ -227,7 +226,7 @@ def west_init_tmpdir(repos_tmpdir):
     py.path.local, with the current working directory set there.'''
     west_tmpdir = repos_tmpdir / 'workspace'
     manifest = repos_tmpdir / 'repos' / 'zephyr'
-    cmd(f'init -m "{manifest}" "{west_tmpdir}"')
+    cmd(['init', '-m', str(manifest), str(west_tmpdir)])
     west_tmpdir.chdir()
     config.read_config()
     return west_tmpdir
@@ -327,9 +326,11 @@ def cmd(cmd, cwd=None, stderr=None, env=None):
     # stdout from cmd is captured and returned. The command is run in
     # a python subprocess so that program-level setup and teardown
     # happen fresh.
-    cmd = 'west ' + cmd
-    if not WINDOWS:
-        cmd = shlex.split(cmd)
+
+    # If you have quoting issues: do NOT quote. It's not portable.
+    # Instead, pass `cmd` as a list.
+    cmd = ['west'] + (cmd.split() if isinstance(cmd, str) else cmd)
+
     print('running:', cmd)
     if env:
         print('with non-default environment:')

--- a/tox.ini
+++ b/tox.ini
@@ -34,8 +34,9 @@ deps =
     flake8
     mypy
 setenv =
+    # For instance: ./.tox/py3/tmp/
     TOXTEMPDIR={envtmpdir}
 commands =
-  python -m pytest --cov=west {posargs:tests}
-  python -m flake8 --config={toxinidir}/tox.ini {toxinidir}
-  python -m mypy --config-file={toxinidir}/tox.ini --package=west
+  python -m pytest --cov=west {posargs:tests} --basetemp='{envtmpdir}/pytest with space/'
+  python -m flake8 --config='{toxinidir}'/tox.ini '{toxinidir}'
+  python -m mypy --config-file='{toxinidir}'/tox.ini --package=west


### PR DESCRIPTION
3 commits. main one:


Stop using `shlex.split()` in conftest.py as a way to prepare test
commands for subprocess.run() because it does not always work. When we
have quoting issues, just avoid them entirely by passing the test
command as a list.

Replace shlex.split() with a simple str.split() for convenience in
simple cases. This simple split() will immediately fail when trying to
use quote which is working exactly as intended.

This also makes the cmd() interface more similar to subprocess.run() and
its many friends, which is good thing.

This is similar to commit https://github.com/zephyrproject-rtos/west/commit/41007648d993b84144bbab54a26ac3416e2aef1d ("Project.git(list/str): reduce
reliance on shlex.split()") but applied to tests/

Before commit https://github.com/zephyrproject-rtos/west/commit/624880e8ffd2c4853f3ae3324cebaaf7f20bffc8, shlex.split() was used unconditionally in
conftest.py. As expected, this eventually broke on Windows: shlex is
not compatible across all operating systems and shells.

https://docs.python.org/3/library/subprocess.html#security-considerations

> If the shell is invoked explicitly, via shell=True, it is the
> application’s responsibility to ensure that all whitespace and
> metacharacters are quoted appropriately to avoid shell injection
> vulnerabilities. On _some_ platforms, it is possible to use shlex.quote()
> for this escaping.

(Emphasis mine)

Then commit https://github.com/zephyrproject-rtos/west/commit/624880e8ffd2c4853f3ae3324cebaaf7f20bffc8 made the "interesting" decision to stop using
shlex.split()... only on Windows. This was discussed in
https://github.com/zephyrproject-rtos/west/pull/266#discussion_r284670076

So after this commit, parsing of test commands was delegated to the
shell but... only on Windows! This worked for a long time but eventually
broke testing white spaces for the new `west alias` https://github.com/zephyrproject-rtos/west/pull/716. Rather than
making that Windows-specific hack even more complex with a special case,
finally do the right thing and ask more complex test commands to use a
list. Now we can drop shlex.