### PR TITLE
app: tell the user to use `-vv` when debugging "manifest --validate"

### DIFF
--- a/src/west/app/main.py
+++ b/src/west/app/main.py
@@ -982,7 +982,7 @@ class WestArgumentParser(argparse.ArgumentParser):
                     # warn them again.
                     append('Cannot load extension commands; '
                            'help for them is not available.')
-                    append('(To debug, try: "west manifest --validate".)')
+                    append('(To debug, try: "west -vv manifest --validate".)')
                     append('')
             else:
                 # TODO we may want to be more aggressive about loading

--- a/src/west/commands.py
+++ b/src/west/commands.py
@@ -260,7 +260,7 @@ class WestCommand(ABC):
         if self._manifest is None:
             self.die(f"can't run west {self.name};",
                      "it requires the manifest, which was not available.",
-                     'Try "west manifest --validate" to debug.')
+                     'Try "west -vv manifest --validate" to debug.')
         return self._manifest
 
     def _set_manifest(self, manifest: Optional[Manifest]):


### PR DESCRIPTION
It seems natural to recommend "debug" flags when telling the user to "debug".

More specifically, this makes a big difference in situations like the one reported in #671