### PR TITLE
.github: Pypi release workflows

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,25 @@
+name: Python Package
+
+on: [push, pull_request, workflow_call]
+
+jobs:
+  package:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install Python dependencies
+        run: |
+          pip3 install build
+      - name: Build a binary wheel and a source tarball
+        run: |
+          python -m build
+      - name: Store the distribution packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+name: Release
+
+# This workflow follows Pypi guidelines for publishing using trusted publishers
+# See https://docs.pypi.org/trusted-publishers/using-a-publisher/ for more details.
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  package:
+    name: Package
+    uses: ./.github/workflows/package.yml
+
+  release:
+    name: Release
+    needs: [package]
+    runs-on: ubuntu-latest
+
+    # Make the GH environment explicit
+    environment: release
+
+    # Mandatory for trusted publishing
+    permissions:
+      contents: write
+      id-token: write
+
+    steps:
+    - name: Download build artifacts
+      uses: actions/download-artifact@v4
+      with:
+        path: dist/
+
+    - name: Upload release assets
+      uses: softprops/action-gh-release@v2
+      with:
+        files: dist/*.whl
+
+    - name: Publish package to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.8, 3.9, '3.10']
+        python-version: [3.8, 3.9, '3.10', '3.11', '3.12']
     steps:
       - uses: actions/checkout@v4
         # This is enough to find many quoting issues

--- a/MAINTAINERS.rst
+++ b/MAINTAINERS.rst
@@ -100,11 +100,16 @@ Pre-release test plan
 Building and uploading the release wheels
 -----------------------------------------
 
-You need the zephyr-project PyPI credentials for the 'twine upload' command. ::
+Creating Pypi releases is done automatically from Github. After publishing
+a release on Github a release build is packaged and uploaded with the
+version specified in pyproject.toml.
+
+To do these steps manually, you need the zephyr-project PyPI credentials
+for the 'twine upload' command. ::
 
   git clean -ffdx
   pip3 install --upgrade build twine
-  pyproject-build
+  python -m build
   twine upload -u zephyr-project dist/*
 
 The 'git clean' step is important. We've anecdotally observed broken wheels


### PR DESCRIPTION
Add Github workflows to create Pypi packages and upload to Pypi when a release is published.