### PR TITLE
manifest: Add submodule representation in as_dict

### DIFF
--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -882,6 +882,15 @@ class Project:
                 _west_commands_maybe_delist(self.west_commands)
         if self.groups:
             ret['groups'] = self.groups
+        if isinstance(self.submodules, bool) and self.submodules:
+            ret['submodules'] = True
+        elif isinstance(self.submodules, list):
+            ret['submodules'] = []
+            for s in self.submodules:
+                obj: Dict = {'path': s.path}
+                if s.name:
+                    obj['name'] = s.name
+                ret['submodules'].append(obj)
         if self.userdata:
             ret['userdata'] = self.userdata
 
@@ -1143,7 +1152,7 @@ class ManifestProject(Project):
         # Pretending that this is a Project, even though it's not (#327)
         self.description: Optional[str] = None
         self.url: str = ''
-        self.submodules = False
+        self.submodules: SubmodulesType = False
         self.revision: str = 'HEAD'
         self.remote_name: str = ''
         self.clone_depth: Optional[int] = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,6 +46,7 @@ manifest:
       path: subdir/Kconfiglib
       groups:
         - Kconfiglib-group
+      submodules: true
     - name: tagged_repo
       revision: v1.0
     - name: net-tools
@@ -189,6 +190,7 @@ def repos_tmpdir(tmpdir, _session_repos):
         - name: Kconfiglib
           revision: zephyr
           path: subdir/Kconfiglib
+          submodules: true
         - name: tagged_repo
           revision: v1.0
         - name: net-tools

--- a/tests/manifests/invalid_submodule_no_path.yml
+++ b/tests/manifests/invalid_submodule_no_path.yml
@@ -1,0 +1,10 @@
+# Submodule entries require a path
+manifest:
+  remotes:
+    - name: remote1
+      url-base: https://example.com
+  projects:
+    - name: project1
+      remote: remote1
+      submodules:
+        - name: project2

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -3176,6 +3176,74 @@ def test_group_filter_imports(manifest_repo):
     assert hasattr(m, '_legacy_group_filter_warned')
 
 
+def test_submodule_manifest():
+    m = M('''\
+    projects:
+    - name: project1
+      url: url
+    - name: project2
+      url: url
+      submodules: true
+    - name: project3
+      url: url
+      submodules:
+      - path: path
+    - name: project4
+      url: url
+      submodules:
+      - path: path
+        name: subproject1
+    - name: project5
+      url: url
+      submodules:
+      - path: path
+        name: subproject1
+      - path: path
+        name: subproject2
+    - name: project6
+      url: url
+      submodules: false
+    ''').as_dict()['manifest']
+
+    mp = m['projects'][0]
+    assert 'submodules' not in mp
+
+    mp = m['projects'][1]
+    assert 'submodules' in mp
+    assert isinstance(mp['submodules'], bool)
+    assert mp['submodules']
+
+    mp = m['projects'][2]
+    assert isinstance(mp['submodules'], list)
+    assert len(mp['submodules']) == 1
+    assert 'path' in mp['submodules'][0]
+    assert mp['submodules'][0]['path'] == 'path'
+    assert 'name' not in mp['submodules'][0]
+
+    mp = m['projects'][3]
+    assert isinstance(mp['submodules'], list)
+    assert len(mp['submodules']) == 1
+    assert 'path' in mp['submodules'][0]
+    assert mp['submodules'][0]['path'] == 'path'
+    assert 'name' in mp['submodules'][0]
+    assert mp['submodules'][0]['name'] == 'subproject1'
+
+    mp = m['projects'][4]
+    assert isinstance(mp['submodules'], list)
+    assert len(mp['submodules']) == 2
+    assert 'path' in mp['submodules'][0]
+    assert mp['submodules'][0]['path'] == 'path'
+    assert 'name' in mp['submodules'][0]
+    assert mp['submodules'][0]['name'] == 'subproject1'
+    assert 'path' in mp['submodules'][1]
+    assert mp['submodules'][1]['path'] == 'path'
+    assert 'name' in mp['submodules'][1]
+    assert mp['submodules'][1]['name'] == 'subproject2'
+
+    mp = m['projects'][5]
+    assert 'submodules' not in mp
+
+
 #########################################
 # Various invalid manifests
 


### PR DESCRIPTION
Submodules were missing when calling --freeze or --resolve

Fixes #739 