### PR TITLE
project.py: fix west diff --manifest to use `manifest-rev`

### DIFF
--- a/src/west/app/project.py
+++ b/src/west/app/project.py
@@ -788,7 +788,7 @@ class Diff(_ProjectCommand):
         parser.add_argument('-a', '--all', action='store_true',
                             help='include output for inactive projects')
         parser.add_argument('-m', '--manifest', action='store_true',
-                            help='show changes relative to the manifest revision')
+                            help='show changes relative to "manifest-rev"')
         return parser
 
     def do_run(self, args, user_args):
@@ -800,9 +800,16 @@ class Diff(_ProjectCommand):
         # which it won't do ordinarily since stdout is not a terminal.
         color = ['--color=always'] if self.color_ui else []
         for project in self._cloned_projects(args, only_active=not args.all):
+            diff_commit = (
+                ['manifest-rev'] # see #719 and #747
+                # Special-case the manifest repository while it's
+                # still showing up in the 'projects' list. Yet
+                # more evidence we should tackle #327.
+                if args.manifest and not isinstance(project, ManifestProject)
+                else []
+            )
             # Use paths that are relative to the base directory to make it
             # easier to see where the changes are
-            diff_commit = [project.revision] if args.manifest else []
             cp = project.git(['diff', f'--src-prefix={project.path}/',
                               f'--dst-prefix={project.path}/',
                               '--exit-code'] + color + diff_commit,

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -350,6 +350,7 @@ def test_diff(west_init_tmpdir):
     cmd('update net-tools')
     cmd('diff')
     cmd('diff --stat')
+    cmd('diff --manifest')
 
     cmd('update Kconfiglib')
 


### PR DESCRIPTION
Fixes new `west diff --manifest` option added by commit 0d5ee4eb0834 ("app: project: Allow to diff against manifest revision")

Do not pass `project.revision` to `git diff` because `project.revision` is unresolved user input and does not always resolve to a commit. For instance, `project.revision` can be the name of a remote branch like `v3.7-branch` that does not exist locally; then `git diff` fails. Or even worse: there could be a local branch of the same name which points to a totally different commit.

This bug was found when discussing issue #747, see 7th comment there for a longer description of what `manifest-rev` is and how it works.