### PR TITLE
.github: Update supported python versions

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
       - name: Install Python dependencies
         run: |
           pip3 install build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.8, 3.9, '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
       - uses: actions/checkout@v4
         # This is enough to find many quoting issues

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
     "Operating System :: MacOS :: MacOS X",
     "Operating System :: Microsoft :: Windows",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "colorama",
     "PyYAML>=5.1",

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -2421,7 +2421,10 @@ class Manifest:
         # symbolic links.
         ret_norm = os.path.normpath(ret.path)
 
-        if os.path.isabs(ret_norm):
+        # To be "really" absolute, a Windows path must include the "drive" like C:\\, D:\\.
+        # But here we also want to block drive-less "half-breeds".
+        # Note this question has confused Python which changed the `.isabs()` behavior in 3.13
+        if ret_norm[0] in '/\\' or os.path.isabs(ret_norm):
             self._malformed(f'project "{ret.name}" has absolute path '
                             f'{ret.path}; this must be relative to the '
                             f'workspace topdir' +


### PR DESCRIPTION
Python 3.8 is end-of-life, removed.
Python 3.13 is released, added.