### PR TITLE
manifest: Do not allow projects inside the west directory

### DIFF
--- a/src/west/app/project.py
+++ b/src/west/app/project.py
@@ -222,7 +222,7 @@ finalize the deletion until there is no concurrent user left.
                     This forces west to search for a workspace there.
                     Try unsetting ZEPHYR_BASE and re-running this command.''')
             else:
-                west_dir = Path(self.topdir) / '.west'
+                west_dir = Path(self.topdir) / WEST_DIR
                 msg = ("\n  Hint: if you do not want a workspace there, \n"
                        "  remove this directory and re-run this command:\n\n"
                        f"  {west_dir}")
@@ -2094,7 +2094,7 @@ def projects_unknown(manifest, projects):
 #
 
 # Top-level west directory, containing west itself and the manifest.
-WEST_DIR = '.west'
+WEST_DIR = util.WEST_DIR
 
 # Default manifest repository URL.
 MANIFEST_URL_DEFAULT = 'https://github.com/zephyrproject-rtos/zephyr'

--- a/src/west/configuration.py
+++ b/src/west/configuration.py
@@ -43,7 +43,7 @@ from enum import Enum
 from typing import Any, Dict, Iterable, List, Optional, Tuple, TYPE_CHECKING
 import warnings
 
-from west.util import west_dir, WestNotFound, PathType
+from west.util import WEST_DIR, west_dir, WestNotFound, PathType
 
 class MalformedConfig(Exception):
     '''The west configuration was malformed.
@@ -616,7 +616,7 @@ def _location(cfg: ConfigFile, topdir: Optional[PathType] = None,
             return env['WEST_CONFIG_LOCAL']
 
         if topdir:
-            return os.fspath(Path(topdir) / '.west' / 'config')
+            return os.fspath(Path(topdir) / WEST_DIR / 'config')
 
         if find_local:
             # Might raise WestNotFound!

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -2435,6 +2435,10 @@ class Manifest:
                             f'normalizes to {ret_norm}, which escapes '
                             f'the workspace topdir')
 
+        if Path(ret_norm).parts[0] == util.WEST_DIR:
+            self._malformed(f'project "{name}" path {ret.path} '
+                            f'is in the {util.WEST_DIR} directory')
+
         return ret
 
     def _validate_project_groups(self, project_name: str,

--- a/src/west/util.py
+++ b/src/west/util.py
@@ -20,6 +20,8 @@ from typing import List, Optional, Union
 # otherwise, but it doesn't seem worth it.
 PathType = Union[str, os.PathLike]
 
+WEST_DIR = '.west'
+
 def escapes_directory(path: PathType, directory: PathType) -> bool:
     '''Returns True if `path` escapes parent directory `directory`.
 
@@ -58,7 +60,7 @@ def west_dir(start: Optional[PathType] = None) -> str:
 
     Raises WestNotFound if no .west directory is found.
     '''
-    return os.path.join(west_topdir(start), '.west')
+    return os.path.join(west_topdir(start), WEST_DIR)
 
 def west_topdir(start: Optional[PathType] = None,
                 fall_back: bool = True) -> str:
@@ -69,7 +71,7 @@ def west_topdir(start: Optional[PathType] = None,
     cur_dir = pathlib.Path(start or os.getcwd())
 
     while True:
-        if (cur_dir / '.west').is_dir():
+        if (cur_dir / WEST_DIR).is_dir():
             return os.fspath(cur_dir)
 
         parent_dir = cur_dir.parent

--- a/tests/manifests/invalid_project_in_west_dir.yml
+++ b/tests/manifests/invalid_project_in_west_dir.yml
@@ -1,0 +1,7 @@
+# Project paths can't be .west.
+
+manifest:
+  projects:
+    - name: nope
+      url: ignore-me
+      path: .west

--- a/tests/manifests/invalid_project_in_west_reldir.yml
+++ b/tests/manifests/invalid_project_in_west_reldir.yml
@@ -1,0 +1,7 @@
+# Project paths can't be .west after normalization.
+
+manifest:
+  projects:
+    - name: nope
+      url: ignore-me
+      path: foo/../.west

--- a/tests/manifests/invalid_project_in_west_relsubdir.yml
+++ b/tests/manifests/invalid_project_in_west_relsubdir.yml
@@ -1,0 +1,7 @@
+# Project paths can't be in .west normalized.
+
+manifest:
+  projects:
+    - name: nope
+      url: ignore-me
+      path: foo/../.west/some/path

--- a/tests/manifests/invalid_project_in_west_subdir.yml
+++ b/tests/manifests/invalid_project_in_west_subdir.yml
@@ -1,0 +1,7 @@
+# Project paths can't be in .west/.
+
+manifest:
+  projects:
+    - name: nope
+      url: ignore-me
+      path: .west/some/path


### PR DESCRIPTION
It's not allowed to have projects inside the .west directory, add a check when parsing the manifest.

Fixes #102 