### PR TITLE
commands: make die() print a stack trace when -vvv or more

### DIFF
--- a/src/west/commands.py
+++ b/src/west/commands.py
@@ -511,7 +511,11 @@ class WestCommand(ABC):
         Equivalent to ``die(*args, fatal=True)``, followed by an attempt to
         abort with the given *exit_code*.'''
         self.err(*args, fatal=True)
-        sys.exit(exit_code)
+        if self.verbosity >= Verbosity.DBG_EXTREME:
+            raise RuntimeError("die with -vvv or more shows a stack trace. "
+                               "exit_code argument is ignored.")
+        else:
+            sys.exit(exit_code)
 
     @property
     def color_ui(self) -> bool:


### PR DESCRIPTION
Print a stack trace when debugging with -vvv or more. This is MUCH faster than `git grep error_message` and it's even more useful when the same error message is used in multiple places! Example: die_already() in project.py