### PR TITLE
tests: Wrap or remove deprecated functions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,4 +27,4 @@ jobs:
       - name: install tox
         run: pip3 install tox
       - name: tox
-        run: tox -c 'check out'
+        run: tox -c 'check out' -- -W error

--- a/src/west/configuration.py
+++ b/src/west/configuration.py
@@ -40,7 +40,7 @@ import os
 from pathlib import PureWindowsPath, Path
 import platform
 from enum import Enum
-from typing import Any, Dict, Iterable, List, Optional, Tuple, TYPE_CHECKING
+from typing import Any, Dict, Iterable, List, Optional, Tuple, TYPE_CHECKING, Union
 import warnings
 
 from west.util import WEST_DIR, west_dir, WestNotFound, PathType
@@ -491,7 +491,7 @@ def update_config(section: str, key: str, value: Any,
         config.write(f)
 
 def delete_config(section: str, key: str,
-                  configfile: Optional[ConfigFile] = None,
+                  configfile: Union[Optional[ConfigFile], List[ConfigFile]] = None,
                   topdir: Optional[PathType] = None) -> None:
     '''Delete the option section.key from the given file or files.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -230,7 +230,6 @@ def west_init_tmpdir(repos_tmpdir):
     manifest = repos_tmpdir / 'repos' / 'zephyr'
     cmd(['init', '-m', str(manifest), str(west_tmpdir)])
     west_tmpdir.chdir()
-    config.read_config()
     return west_tmpdir
 
 @pytest.fixture

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -10,7 +10,6 @@ from pathlib import Path, PurePath
 
 import pytest
 
-from west import configuration as config
 from west.manifest import Manifest, ManifestProject, Project, \
     ManifestImportFailed
 from west.manifest import ImportFlag as MIF
@@ -1631,7 +1630,6 @@ def test_init_local_with_manifest_filename(repos_tmpdir):
     # success
     cmd(['init', '--mf', 'project.yml', '-l', zephyr_install_dir])
     workspace.chdir()
-    config.read_config()
     cmd('update')
 
 
@@ -1823,7 +1821,6 @@ def test_init_with_manifest_filename(repos_tmpdir):
     # success
     cmd(['init', '-m', manifest, '--mf', 'project.yml', west_tmpdir])
     west_tmpdir.chdir()
-    config.read_config()
     cmd('update')
 
 def test_init_with_manifest_in_subdir(repos_tmpdir):
@@ -1915,7 +1912,6 @@ def test_extension_command_multiproject(repos_tmpdir):
     zephyr = repos_tmpdir / 'repos' / 'zephyr'
     cmd(['init', '-m', zephyr, west_tmpdir])
     west_tmpdir.chdir()
-    config.read_config()
     cmd('update')
 
     # The newline shenanigans are for Windows.
@@ -1995,7 +1991,6 @@ def test_extension_command_duplicate(repos_tmpdir):
     zephyr = repos_tmpdir / 'repos' / 'zephyr'
     cmd(['init', '-m', zephyr, west_tmpdir])
     west_tmpdir.chdir()
-    config.read_config()
     cmd('update')
 
     actual = cmd('test-extension', stderr=subprocess.STDOUT).splitlines()


### PR DESCRIPTION
Make deprecated calls explicit during testing or remove them if unnecessary.

This allows us to promote warnings to errors with `pytest`.