### PR TITLE
app: config: Add support for appending to the config string

### DIFF
--- a/src/west/app/config.py
+++ b/src/west/app/config.py
@@ -88,12 +88,17 @@ class Config(WestCommand):
             description=self.description,
             epilog=CONFIG_EPILOG)
 
-        parser.add_argument('-l', '--list', action='store_true',
-                            help='list all options and their values')
-        parser.add_argument('-d', '--delete', action='store_true',
-                            help='delete an option in one config file')
-        parser.add_argument('-D', '--delete-all', action='store_true',
-                            help="delete an option everywhere it's set")
+        group = parser.add_argument_group(
+            "action to perform (give at most one)"
+        ).add_mutually_exclusive_group()
+
+
+        group.add_argument('-l', '--list', action='store_true',
+                           help='list all options and their values')
+        group.add_argument('-d', '--delete', action='store_true',
+                           help='delete an option in one config file')
+        group.add_argument('-D', '--delete-all', action='store_true',
+                           help="delete an option everywhere it's set")
 
         group = parser.add_argument_group(
             "configuration file to use (give at most one)"
@@ -121,13 +126,9 @@ class Config(WestCommand):
         if args.list:
             if args.name:
                 self.parser.error('-l cannot be combined with name argument')
-            elif delete:
-                self.parser.error('-l cannot be combined with -d or -D')
         elif not args.name:
             self.parser.error('missing argument name '
                               '(to list all options and values, use -l)')
-        elif args.delete and args.delete_all:
-            self.parser.error('-d cannot be combined with -D')
 
         if args.list:
             self.list(args)


### PR DESCRIPTION
In some cases, and specifically in the manifest.group-filter and manifest.project-filter options, it is sometimes useful to be able to append to a value instead of replacing it completely.

For example, assuming one wants to add to an existing group filter, without this patch the user needs to do:

(assuming the group filter is currently +unstable,-optional, and the
user wants to add +extras).
$ west config manifest.group-filter
$ west config manifest.group-filter +unstable,-optional,+extras

With this patch instead:

$ west config -a manifest.group-filter ,+extras