### PR TITLE
project+ci: Succeed ruff format check but keep a notice annotation

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -43,8 +43,6 @@ jobs:
     needs: find-changed-files
     if: ${{ needs.find-changed-files.outputs.files != '[]' }}
     runs-on: ubuntu-latest
-    # Allow the workflow run to pass when this job fails
-    continue-on-error: true
     strategy:
       fail-fast: false
       matrix:
@@ -55,13 +53,17 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run ruff format check for ${{ matrix.files.path }}
+        id: format-check
         uses: astral-sh/ruff-action@v1
+        # Allow the job run to pass when this step fails
+        continue-on-error: true
         with:
           args: "format --check --diff"
           src: "${{ matrix.files.path }}"
           version: 0.8.1
 
       - name: Annotate unformatted file
-        if: ${{ failure() }}
+        if: ${{ steps.format-check.outcome }} == 'failure'
         run: |
-          echo "::warning file=${{ matrix.files.path }},title=File format check failed::Run 'ruff format ${{ matrix.files.path }}'"
+          JOB_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          echo "::notice file=${{ matrix.files.path }},title=Unformatted file::Consider running 'ruff format ${{ matrix.files.path }}'%0ASee $JOB_URL for more details"

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -59,6 +59,7 @@ jobs:
         with:
           args: "format --check --diff"
           src: "${{ matrix.files.path }}"
+          version: 0.8.1
 
       - name: Annotate unformatted file
         if: ${{ failure() }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,9 +57,6 @@ extend-select = [
   "UP",  # pyupgrade
   "W",   # pycodestyle warnings
 ]
-ignore = [
-  "UP027", # deprecated pyupgrade rule
-]
 
 [tool.ruff.format]
 quote-style = "preserve"

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,7 @@ deps =
     types-PyYAML
     flake8
     mypy
-    ruff
+    ruff==0.8.1
 setenv =
     # For instance: ./.tox/py3/tmp/
     TOXTEMPDIR={envtmpdir}


### PR DESCRIPTION
Prevent ruff issues being reported by updates of the tool itself.
UP027 has been removed in version 0.8.0, remove it from the ignore list.

For CI move the `continue-on-error` to the format step instead of the job. This should set the job status to green, we only print a notice annotation.

See #771 how the result looks.