### PR TITLE
config: upgrade dbg to err on missing option

### DIFF
--- a/src/west/app/config.py
+++ b/src/west/app/config.py
@@ -191,7 +191,7 @@ class Config(WestCommand):
         if value is not None:
             self.inf(value)
         else:
-            self.dbg(f'{args.name} is unset')
+            self.err(f'{args.name} is unset')
             raise CommandError(returncode=1)
 
     def append(self, args):


### PR DESCRIPTION
A user has pointed out that west's behavior in the following case is confusing:

```
  west config foo.bar=baz
```

The desired behavior is "set foo.bar to baz". Instead, west exits 1 without printing anything on the console.

Let's make it clearer that the user is inadventently asking for the value of an option called "foo.bar=baz", since right now there is no rule forbidding "=" in option names, so the above confusing case is actually asking for section "foo", key "bar=baz".

With this patch, west prints:

```
  ERROR: foo.bar=baz is unset
```

to stderr along with exiting 1, making it clearer that something went wrong.

