### PR TITLE
app: project: Allow updating only cloned projects

### DIFF
--- a/src/west/app/project.py
+++ b/src/west/app/project.py
@@ -952,6 +952,9 @@ class Update(_ProjectCommand):
         parser.add_argument('--stats', action='store_true',
                             help='''print performance statistics for
                             update operations''')
+        parser.add_argument('--cloned', action='store_true',
+                            help='''update the projects that are already cloned
+                            in the current workspace''')
 
         group = parser.add_argument_group(
             title='local project clone caches',
@@ -1048,6 +1051,7 @@ class Update(_ProjectCommand):
         self.name_cache = args.name_cache or config.get('update.name-cache')
         self.sync_submodules = config.getboolean('update.sync-submodules',
                                                  default=True)
+        self.cloned = args.cloned or config.getboolean('update.cloned')
 
         self.group_filter: List[str] = []
 
@@ -1092,6 +1096,9 @@ class Update(_ProjectCommand):
                     project.name in self.updated):
                 continue
             try:
+                if self.cloned and not project.is_cloned():
+                    self.dbg(f'{project.name}: skipping missing project')
+                    continue
                 if not self.project_is_active(project):
                     self.dbg(f'{project.name}: skipping inactive project')
                     continue
@@ -1163,6 +1170,9 @@ class Update(_ProjectCommand):
             if isinstance(project, ManifestProject):
                 continue
             try:
+                if self.cloned and not project.is_cloned():
+                    self.dbg(f'{project.name}: skipping missing project')
+                    continue
                 self.update(project)
             except subprocess.CalledProcessError:
                 failed.append(project)

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1521,6 +1521,28 @@ def test_update_narrow_depth1(tmpdir):
     assert len(refs) == 1
 
 
+def test_update_cloned(west_init_tmpdir):
+    # Manually update a single project
+    cmd('update Kconfiglib')
+
+    cmd('update --cloned')
+    assert (west_init_tmpdir / 'subdir' / 'Kconfiglib').check(dir=1)
+    assert (west_init_tmpdir / 'tagged_repo').check(dir=0)
+    assert (west_init_tmpdir / 'net-tools').check(dir=0)
+
+    cmd('config update.cloned true')
+    cmd('update')
+    assert (west_init_tmpdir / 'subdir' / 'Kconfiglib').check(dir=1)
+    assert (west_init_tmpdir / 'tagged_repo').check(dir=0)
+    assert (west_init_tmpdir / 'net-tools').check(dir=0)
+
+    cmd('config update.cloned false')
+    cmd('update')
+    assert (west_init_tmpdir / 'subdir' / 'Kconfiglib').check(dir=1)
+    assert (west_init_tmpdir / 'tagged_repo').check(dir=1)
+    assert (west_init_tmpdir / 'net-tools').check(dir=1)
+
+
 def test_init_again(west_init_tmpdir):
     # Test that 'west init' on an initialized tmpdir errors out
     # with a message that indicates it's already initialized.


### PR DESCRIPTION
Add an update command argument and configuration option to allow updating the currently cloned projects.

This can help in the scenario where a user updated an initial set of projects manually and would like to only update those in the future.