### PR TITLE
project: launch subprocesses without shell

### DIFF
--- a/src/west/app/project.py
+++ b/src/west/app/project.py
@@ -1731,8 +1731,7 @@ class ForAll(_ProjectCommand):
 
             self.banner(
                 f'running "{args.subcommand}" in {project.name_and_path}:')
-            rc = subprocess.Popen(args.subcommand, shell=True, env=env,
-                                  cwd=cwd).wait()
+            rc = subprocess.Popen(args.subcommand, env=env, cwd=cwd).wait()
             if rc:
                 failed.append(project)
         self._handle_failed(args, failed)


### PR DESCRIPTION
In the Project method `set_new_manifest_rev`, the `_update_manifest_rev` helper function tries to run the following git command:

```
git update-ref -m .. refs/heads/ref <commit-id>^{commit}
```

However, on Msys2's MinGW build of python handles the escaping of `...^{commit}` incorrectly, converting it into `...commit`.

This issue highlights the pitfalls of using the Python `subprocess` module's `shell=True` option, which can apply string conversions to commands that are unexpected by the calling code.