### PR TITLE
.github: Harden action workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci: github: "
+    labels: []
+    groups:
+      actions-deps:
+        patterns:
+          - "*"

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -7,6 +7,9 @@ on:
     paths:
       - '**.py'
 
+permissions:
+  contents: read
+
 jobs:
   find-changed-files:
     runs-on: ubuntu-latest

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -15,12 +15,12 @@ jobs:
     name: Detect added and changed files
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
       - name: Create json diff
-        uses: GrantBirki/git-diff-action@v2
+        uses: GrantBirki/git-diff-action@f65a78c343ee50737aebbe653e35f3067752c7b3 # v2.8.0
         id: git-diff
         with:
           base_branch: origin/main
@@ -50,11 +50,11 @@ jobs:
 
     name: Check file ${{ matrix.files.path }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Run ruff format check for ${{ matrix.files.path }}
         id: format-check
-        uses: astral-sh/ruff-action@v1
+        uses: astral-sh/ruff-action@d0a0e814ec17e92d33be7d24dd922b479f1bcd38 # v1.1.1
         # Allow the job run to pass when this step fails
         continue-on-error: true
         with:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -6,10 +6,10 @@ jobs:
   package:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: "3.13"
       - name: Install Python dependencies
@@ -19,7 +19,7 @@ jobs:
         run: |
           python -m build
       - name: Store the distribution packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: python-package-distributions
           path: dist/

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -2,6 +2,9 @@ name: Python Package
 
 on: [push, pull_request, workflow_call]
 
+permissions:
+  contents: read
+
 jobs:
   package:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,16 +28,16 @@ jobs:
 
     steps:
     - name: Download build artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
       with:
         name: python-package-distributions
         path: dist/
 
     # The assets can be attached to an existing release, if a matching tag is found
     - name: Upload release assets
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2.2.1
       with:
         files: dist/*.whl
 
     - name: Publish package to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # release/v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,13 +13,13 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         # This is enough to find many quoting issues
         with:
           path: "./check out"
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Display Python version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,9 @@
----
 name: Python Test
 
-# yamllint disable-line rule:truthy
 on: [push, pull_request]
+
+permissions:
+  contents: read
 
 jobs:
   build:


### PR DESCRIPTION
Some improvements to the Github workflows:

- Pin action version hashes
- Set explicit default permission
- Add a dependabot configuration to check for updates