### PR TITLE
app/commands: Remove unused `nonlocal/global` declarations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,10 +50,10 @@ line-length = 100
 
 [tool.ruff.lint]
 extend-select = [
-  "I",   # isort
   "B",   # flake8-bugbear
   "E",   # pycodestyle errors
   "F",   # Pyflakes
+  "I",   # isort
   "UP",  # pyupgrade
   "W",   # pycodestyle warnings
 ]

--- a/src/west/app/main.py
+++ b/src/west/app/main.py
@@ -106,8 +106,7 @@ def parse_early_args(argv: list[str]) -> EarlyArgs:
     def consume_more_args(rest):
         # Handle the 'Vv' portion of 'west -hVv'.
 
-        nonlocal help, version, zephyr_base, verbosity, command_name
-        nonlocal unexpected_arguments
+        nonlocal help, version, zephyr_base, verbosity
         nonlocal expecting_zephyr_base
 
         if not rest:

--- a/src/west/commands.py
+++ b/src/west/commands.py
@@ -696,8 +696,6 @@ def _commands_module_from_file(file):
     # returned from a cache if the same file is ever imported again,
     # to avoid a double import in case the file maintains module-level
     # state or defines multiple commands.
-    global _EXT_MODULES_CACHE
-    global _EXT_MODULES_NAME_IT
 
     # Use an absolute pathobj to handle canonicalization, e.g.:
     #


### PR DESCRIPTION
Some variables were declared with either `nonlocal` or `global` but never assigned any value in their scope.

Fixes #797 