### PR TITLE
manifest: Use faster yaml CLoader if available

### DIFF
--- a/src/west/commands.py
+++ b/src/west/commands.py
@@ -22,6 +22,12 @@ from typing import Callable, NoReturn, Optional
 
 import colorama
 import pykwalify
+
+try:
+    from yaml import CSafeLoader as SafeLoader
+except ImportError:
+    from yaml import SafeLoader  # type: ignore
+
 import yaml
 
 from west.configuration import Configuration
@@ -649,7 +655,7 @@ def _ext_specs(project):
         # Load the spec file and check the schema.
         with open(spec_file) as f:
             try:
-                commands_spec = yaml.safe_load(f.read())
+                commands_spec = yaml.load(f.read(), Loader=SafeLoader)
             except yaml.YAMLError as e:
                 raise ExtensionCommandError from e
         try:

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -22,6 +22,12 @@ from typing import TYPE_CHECKING, Any, Callable, NamedTuple, NoReturn, Optional,
 
 import pykwalify.core
 import yaml
+
+try:
+    from yaml import CSafeLoader as SafeLoader
+except ImportError:
+    from yaml import SafeLoader  # type: ignore
+
 from packaging.version import parse as parse_version
 
 from west import util
@@ -204,7 +210,7 @@ def _is_yml(path: PathType) -> bool:
 
 def _load(data: str) -> Any:
     try:
-        return yaml.safe_load(data)
+        return yaml.load(data, Loader=SafeLoader)
     except yaml.scanner.ScannerError as e:
         raise MalformedManifest(data) from e
 


### PR DESCRIPTION
Speed up the yaml parsing used by west by using LibYAML if available, as specified in the [docs](https://pyyaml.org/wiki/PyYAMLDocumentation).

On Zephyr `main` with optional modules enabled;

Before
```shell
$ hyperfine --warmup 3 'west -q forall -c "true"'
Benchmark 1: west -q forall -c "true"
  Time (mean ± σ):     218.6 ms ±   1.8 ms    [User: 184.8 ms, System: 17.1 ms]
  Range (min … max):   215.7 ms … 223.0 ms    13 runs
```

After
```shell
$ hyperfine --warmup 3 'west -q forall -c "true"'
Benchmark 1: west -q forall -c "true"
  Time (mean ± σ):     200.9 ms ±   1.6 ms    [User: 166.2 ms, System: 16.6 ms]
  Range (min … max):   198.9 ms … 204.4 ms    15 runs
```

An ~8% speedup for a simple command that loads the manifest and loops the modules.