### PR TITLE
manifest: Support --active-only argument for --resolve/--freeze

### DIFF
--- a/src/west/app/project.py
+++ b/src/west/app/project.py
@@ -638,6 +638,8 @@ class ManifestCommand(_ProjectCommand):
         group = parser.add_argument_group('options for --resolve and --freeze')
         group.add_argument('-o', '--out',
                            help='output file, default is standard output')
+        group.add_argument('--active-only', action='store_true',
+                           help='only resolve active projects')
 
         return parser
 
@@ -649,11 +651,13 @@ class ManifestCommand(_ProjectCommand):
         if args.validate:
             pass              # nothing more to do
         elif args.resolve:
-            self._die_if_manifest_project_filter('resolve')
-            self._dump(args, manifest.as_yaml(**dump_kwargs))
+            if not args.active_only:
+                self._die_if_manifest_project_filter('resolve')
+            self._dump(args, manifest.as_yaml(active_only=args.active_only, **dump_kwargs))
         elif args.freeze:
-            self._die_if_manifest_project_filter('freeze')
-            self._dump(args, manifest.as_frozen_yaml(**dump_kwargs))
+            if not args.active_only:
+                self._die_if_manifest_project_filter('freeze')
+            self._dump(args, manifest.as_frozen_yaml(active_only=args.active_only, **dump_kwargs))
         elif args.untracked:
             self._untracked()
         elif args.path:
@@ -666,7 +670,9 @@ class ManifestCommand(_ProjectCommand):
         if self.config.get('manifest.project-filter') is not None:
             self.die(f'"west manifest --{action}" is not (yet) supported '
                      'when the manifest.project-filter option is set. '
-                     'Please clear the project-filter configuration '
+                     f'Add --active-only to {action} only the projects '
+                     'currently active in the workspace. Alternatively, '
+                     'please clear the project-filter configuration '
                      'option and re-run this command, or contact the '
                      'west developers if you have a use case for resolving '
                      'the manifest while projects are made inactive by the '

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -407,6 +407,77 @@ def test_manifest_freeze(west_update_tmpdir):
                     '^    path: zephyr$']
     _match_multiline_regex(expected_res, actual)
 
+def test_manifest_freeze_active(west_update_tmpdir):
+    # We should be able to freeze manifests with inactive projects.
+    cmd('config manifest.group-filter -- -Kconfiglib-group')
+
+    actual = cmd('manifest --freeze --active-only').splitlines()
+    # Same as test_manifest_freeze but without inactive projects
+    expected_res = ['^manifest:$',
+                    '^  projects:$',
+                    '^  - name: tagged_repo$',
+                    '^    url: .*$',
+                    '^    revision: [a-f0-9]{40}$',
+                    '^  - name: net-tools$',
+                    '^    description: Networking tools.$',
+                    '^    url: .*$',
+                    '^    revision: [a-f0-9]{40}$',
+                    '^    clone-depth: 1$',
+                    '^    west-commands: scripts/west-commands.yml$',
+                    '^  self:$',
+                    '^    path: zephyr$']
+    _match_multiline_regex(expected_res, actual)
+
+def test_manifest_resolve(west_update_tmpdir):
+    # We should be able to resolve manifests.
+    actual = cmd('manifest --resolve').splitlines()
+    # Similar as test_manifest_freeze but with resolved projects
+    expected_res = ['^manifest:$',
+                    '^  projects:$',
+                    '^  - name: Kconfiglib$',
+                    '^    description: |',
+                    '^      Kconfiglib is an implementation of$',
+                    '^      the Kconfig language written in Python.$',
+                    '^    url: .*$',
+                    '^    revision: zephyr$',
+                    '^    path: subdir/Kconfiglib$',
+                    '^    groups:$',
+                    '^    - Kconfiglib-group$',
+                    '^    submodules: true$',
+                    '^  - name: tagged_repo$',
+                    '^    url: .*$',
+                    '^    revision: v1.0$',
+                    '^  - name: net-tools$',
+                    '^    description: Networking tools.$',
+                    '^    url: .*$',
+                    '^    revision: master$',
+                    '^    clone-depth: 1$',
+                    '^    west-commands: scripts/west-commands.yml$',
+                    '^  self:$',
+                    '^    path: zephyr$']
+    _match_multiline_regex(expected_res, actual)
+
+def test_manifest_resolve_active(west_update_tmpdir):
+    # We should be able to resolve manifests with inactive projects.
+    cmd('config manifest.group-filter -- -Kconfiglib-group')
+
+    actual = cmd('manifest --resolve --active-only').splitlines()
+    # Same as test_manifest_resolve but without inactive projects
+    expected_res = ['^manifest:$',
+                    '^  projects:$',
+                    '^  - name: tagged_repo$',
+                    '^    url: .*$',
+                    '^    revision: v1.0$',
+                    '^  - name: net-tools$',
+                    '^    description: Networking tools.$',
+                    '^    url: .*$',
+                    '^    revision: master$',
+                    '^    clone-depth: 1$',
+                    '^    west-commands: scripts/west-commands.yml$',
+                    '^  self:$',
+                    '^    path: zephyr$']
+    _match_multiline_regex(expected_res, actual)
+
 def test_compare(config_tmpdir, west_init_tmpdir):
     # 'west compare' with no projects cloned should still work,
     # and not print anything.


### PR DESCRIPTION
EDIT: The discussions in #491 and #667 made it clear that `--freeze` and `--resolve` should not have their behavior changed.

Updated the PR to introduce `--active-only` for `--resolve/--freeze`.

~~Running `west manifest --freeze` expects projects to be cloned, but the purpose of inactive projects is to not clone these explicitly.~~

~~Currently it's not possible to call `west manifest --freeze` on a clean zephyr installment because of the `optional` projects.~~
