### PR TITLE
project: Report coverage in PRs without blocking

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -9,3 +9,13 @@ comment:
   hide_project_coverage: false
   branches:
     - "main"
+
+# Do not block PRs (yet)
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
Code coverage with CodeCov is still a work in progress, do not block PRs.