### PR TITLE
ci: Cancel ongoing builds on new changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,11 @@ on: [push, pull_request]
 permissions:
   contents: read
 
+# Cancel ongoing builds on new changes
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Reduce the amount of CI cycles by canceling ongoing builds if a PR is updated.