### PR TITLE
README: Add badges for Python and CodeCov

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,11 @@
-.. raw:: html
+.. image:: https://img.shields.io/pypi/pyversions/west?logo=python
+   :target: https://pypi.org/project/west/
 
-   <a href="https://scorecard.dev/viewer/?uri=github.com/zephyrproject-rtos/west"><img src="https://api.securityscorecards.dev/projects/github.com/zephyrproject-rtos/west/badge"></a>
+.. image:: https://api.securityscorecards.dev/projects/github.com/zephyrproject-rtos/west/badge
+   :target: https://scorecard.dev/viewer/?uri=github.com/zephyrproject-rtos/west
+
+.. image:: https://codecov.io/gh/zephyrproject-rtos/west/graph/badge.svg
+   :target: https://codecov.io/gh/zephyrproject-rtos/west
 
 This is the Zephyr RTOS meta tool, ``west``.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,11 @@ version = "1.3.99"
 authors = [{name = "Zephyr Project", email = "devel@lists.zephyrproject.org"}]
 description = "Zephyr RTOS Project meta-tool"
 classifiers = [
-    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: POSIX :: Linux",
     "Operating System :: MacOS :: MacOS X",


### PR DESCRIPTION
Display the supported Python versions and CodeCov coverage on the README page.

Note: The python version badge will be updated once released on Pypi.