### PR TITLE
project: Drop setuptools dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ dependencies = [
     "colorama",
     "PyYAML>=5.1",
     "pykwalify",
-    "setuptools",
     "packaging",
 ]
 


### PR DESCRIPTION
West does not depend on setuptools, this is only a build requirement.