### PR TITLE
schema: Document default revision value

### DIFF
--- a/src/west/manifest-schema.yml
+++ b/src/west/manifest-schema.yml
@@ -103,6 +103,7 @@ mapping:
             required: false
             type: str
           # Revision to check out. May be a branch, tag, or SHA.
+          # Default: "master"
           revision:
             required: false
             type: text        # SHAs could be only numbers


### PR DESCRIPTION
Document the default behavior of the `revision` key. The `revision` key is optional; if unspecified, west defaults to the `master` branch instead of the repository’s default branch. As a result, `west update` will fail when the repo’s default branch isn’t `master` and no revision is provided.

This fixes #821.