### PR TITLE
.github: Add job names and don't persist checkout credentials

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,6 +33,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        persist-credentials: false
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@60168efe1c415ce0f5521ea06d5c2062adbeed1b # v3.28.17

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: 'Checkout Repository'
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@8805179dc9a63c54224914839d370dd93bd37b2e # v4

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -15,6 +15,7 @@ permissions:
 
 jobs:
   dependency-review:
+    name: Review Dependencies
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Create json diff
         uses: GrantBirki/git-diff-action@f65a78c343ee50737aebbe653e35f3067752c7b3 # v2.8.0
@@ -54,6 +55,8 @@ jobs:
     name: Check file ${{ matrix.files.path }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Run ruff format check for ${{ matrix.files.path }}
         id: format-check

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -7,6 +7,7 @@ permissions:
 
 jobs:
   package:
+    name: Python Package
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/test-distros.yml
+++ b/.github/workflows/test-distros.yml
@@ -68,6 +68,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Display Python version
         run: python3 -c "import sys; print(sys.version); print(sys.platform)"

--- a/.github/workflows/test-distros.yml
+++ b/.github/workflows/test-distros.yml
@@ -35,6 +35,7 @@ permissions:
 
 jobs:
   build:
+    name: Run Python Tests on Linux distros
     runs-on: ubuntu-latest
     container: ${{ matrix.container }}
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ concurrency:
 
 jobs:
   build:
+    name: Build python tests
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -48,6 +49,7 @@ jobs:
           include-hidden-files: true
 
   coverage-report:
+    name: Report test coverage
     runs-on: ubuntu-latest
     needs: ["build"]
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,7 @@ jobs:
         # This is enough to find many quoting issues
         with:
           path: "./check out"
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
@@ -52,6 +53,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0


### PR DESCRIPTION
I reviewed the workflows and noticed that we could avoid the default behavior of the auth token being persisted in the local git confg for subsequent steps of the git checkout action.
Additionally I added a few names to jobs that didn't have any yet.
    
