### PR TITLE
support environment variables `WEST_PATH_CACHE` and `WEST_NAME_CACHE`

### DIFF
--- a/src/west/app/project.py
+++ b/src/west/app/project.py
@@ -1066,11 +1066,15 @@ class Update(_ProjectCommand):
         group.add_argument('--name-cache',
                            help='''cached repositories are in subdirectories
                            matching the names of projects to update. This cache
-                           has highest priority (Prio 0).''')
+                           has highest priority (Prio 0). If not set, falls
+                           back to the value of west config update.name-cache,
+                           or WEST_NAME_CACHE environment variable.''')
         group.add_argument('--path-cache',
                            help='''cached repositories are in the same relative
                            paths as the workspace being updated. This cache has
-                           lower priority (Prio 1).''')
+                           lower priority (Prio 1). If not set, falls back to
+                           the value of west config update.path-cache, or
+                           WEST_PATH_CACHE environment variable.''')
 
         group = parser.add_argument_group(
             title='fetching behavior',
@@ -1151,8 +1155,16 @@ class Update(_ProjectCommand):
 
         config = self.config
         self.narrow = args.narrow or config.getboolean('update.narrow')
-        self.path_cache = args.path_cache or config.get('update.path-cache')
-        self.name_cache = args.name_cache or config.get('update.name-cache')
+        self.path_cache = (
+            args.path_cache or
+            config.get('update.path-cache') or
+            os.environ.get('WEST_PATH_CACHE')
+        )
+        self.name_cache = (
+            args.name_cache or
+            config.get('update.name-cache') or
+            os.environ.get('WEST_NAME_CACHE')
+        )
         self.sync_submodules = config.getboolean('update.sync-submodules',
                                                  default=True)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import contextlib
 import os
 import platform
 import shutil
@@ -301,6 +302,20 @@ def config_tmpdir(tmpdir):
 #
 # Helper functions
 #
+
+@contextlib.contextmanager
+def set_env(env_vars):
+    """
+    Temporarily updates the environment with the key-value pairs which are
+    provided in the env_vars dictionary.
+    """
+    old_environ = dict(os.environ)
+    os.environ.update(env_vars)
+    try:
+        yield
+    finally:
+        os.environ.clear()
+        os.environ.update(old_environ)
 
 def check_output(*args, **kwargs):
     # Like subprocess.check_output, but returns a string in the

--- a/tests/test_project_caching.py
+++ b/tests/test_project_caching.py
@@ -12,6 +12,7 @@ from conftest import (
     create_workspace,
     remote_get_url,
     rev_parse,
+    set_env,
 )
 
 assert 'TOXTEMPDIR' in os.environ, "you must run these tests using tox"
@@ -92,10 +93,23 @@ def test_update_name_cache(tmpdir):
 
     # Move the repositories out of the way and test the configuration option.
     # (We can't use shutil.rmtree here because Windows.)
-    shutil.move(os.fspath(foo), os.fspath(tmpdir))
-    shutil.move(os.fspath(bar), os.fspath(tmpdir))
+    shutil.move(os.fspath(foo), os.fspath(tmpdir / 'foo.moved1'))
+    shutil.move(os.fspath(bar), os.fspath(tmpdir / 'bar.moved1'))
     cmd(['config', 'update.name-cache', name_cache_dir])
     cmd('update')
+    assert foo.check(dir=1)
+    assert bar.check(dir=1)
+    assert rev_parse(foo, 'HEAD') == foo_head
+    assert rev_parse(bar, 'HEAD') == bar_head
+    assert remote_get_url(foo) == "file://" + os.fspath(Path('non-existent') / 'here')
+    assert remote_get_url(bar) == "file://" + os.fspath(Path('non-existent') / 'there')
+
+    # Move the repositories out of the way and test the environment variable.
+    # (We can't use shutil.rmtree here because Windows.)
+    shutil.move(os.fspath(foo), os.fspath(tmpdir / 'foo.moved2'))
+    shutil.move(os.fspath(bar), os.fspath(tmpdir / 'bar.moved2'))
+    with set_env({'WEST_NAME_CACHE': os.fspath(name_cache_dir)}):
+        cmd('update')
     assert foo.check(dir=1)
     assert bar.check(dir=1)
     assert rev_parse(foo, 'HEAD') == foo_head
@@ -148,10 +162,23 @@ def test_update_path_cache(tmpdir):
 
     # Move the repositories out of the way and test the configuration option.
     # (We can't use shutil.rmtree here because Windows.)
-    shutil.move(os.fspath(foo), os.fspath(tmpdir))
-    shutil.move(os.fspath(bar), os.fspath(tmpdir))
+    shutil.move(os.fspath(foo), os.fspath(tmpdir / 'foo.moved1'))
+    shutil.move(os.fspath(bar), os.fspath(tmpdir / 'bar.moved1'))
     cmd(['config', 'update.path-cache', path_cache_dir])
     cmd('update')
+    assert foo.check(dir=1)
+    assert bar.check(dir=1)
+    assert rev_parse(foo, 'HEAD') == foo_head
+    assert rev_parse(bar, 'HEAD') == bar_head
+    assert remote_get_url(foo) == "file://" + os.fspath(Path('non-existent') / 'here')
+    assert remote_get_url(bar) == "file://" + os.fspath(Path('non-existent') / 'there')
+
+    # Move the repositories out of the way and test the environment variable.
+    # (We can't use shutil.rmtree here because Windows.)
+    shutil.move(os.fspath(foo), os.fspath(tmpdir / 'foo.moved2'))
+    shutil.move(os.fspath(bar), os.fspath(tmpdir / 'bar.moved2'))
+    with set_env({'WEST_PATH_CACHE': os.fspath(path_cache_dir)}):
+        cmd('update')
     assert foo.check(dir=1)
     assert bar.check(dir=1)
     assert rev_parse(foo, 'HEAD') == foo_head


### PR DESCRIPTION
While working on #829 I found it helpful to be able to specify a auto cache directory via environment variable.
 
With this change the configuration of cache paths can be done more flexible via environment variables. This is especially helpful if the cache path is located in the user's home directory and users want to avoid that west config contains any absolute paths.