### PR TITLE
python: Drop 3.9 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ version = "1.5.99"
 authors = [{name = "Zephyr Project", email = "devel@lists.zephyrproject.org"}]
 description = "Zephyr RTOS Project meta-tool"
 classifiers = [
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -17,7 +16,7 @@ classifiers = [
     "Operating System :: MacOS :: MacOS X",
     "Operating System :: Microsoft :: Windows",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "colorama",
     "PyYAML>=5.1",

--- a/src/west/app/main.py
+++ b/src/west/app/main.py
@@ -26,7 +26,7 @@ from collections import OrderedDict
 from io import StringIO
 from pathlib import Path, PurePath
 from subprocess import CalledProcessError
-from typing import NamedTuple, Optional
+from typing import NamedTuple
 
 import colorama
 
@@ -84,9 +84,9 @@ class EarlyArgs(NamedTuple):
     # Expected arguments:
     help: bool                  # True if -h was given
     version: bool               # True if -V was given
-    zephyr_base: Optional[str]  # -z argument value
+    zephyr_base: str | None     # -z argument value
     verbosity: int              # 0 if not given, otherwise counts
-    command_name: Optional[str]
+    command_name: str | None
 
     # Other arguments are appended here.
     unexpected_arguments: list[str]

--- a/src/west/commands.py
+++ b/src/west/commands.py
@@ -14,11 +14,12 @@ import subprocess
 import sys
 from abc import ABC, abstractmethod
 from collections import OrderedDict
+from collections.abc import Callable
 from dataclasses import dataclass
 from enum import IntEnum
 from pathlib import Path
 from types import ModuleType
-from typing import Callable, NoReturn
+from typing import NoReturn
 
 import colorama
 import pykwalify

--- a/src/west/commands.py
+++ b/src/west/commands.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass
 from enum import IntEnum
 from pathlib import Path
 from types import ModuleType
-from typing import Callable, NoReturn, Optional
+from typing import Callable, NoReturn
 
 import colorama
 import pykwalify
@@ -152,7 +152,7 @@ class WestCommand(ABC):
         self.accepts_unknown_args: bool = accepts_unknown_args
         self.requires_workspace = requires_workspace
         self.verbosity = verbosity
-        self.topdir: Optional[str] = None
+        self.topdir: str | None = None
         self.manifest = None
         self.config = None
         self._hooks: list[Callable[[WestCommand], None]] = []
@@ -170,8 +170,8 @@ class WestCommand(ABC):
 
     def run(self, args: argparse.Namespace, unknown: list[str],
             topdir: PathType,
-            manifest: Optional[Manifest] = None,
-            config: Optional[Configuration] = None) -> None:
+            manifest: Manifest | None = None,
+            config: Configuration | None = None) -> None:
         '''Run the command.
 
         This raises `west.commands.CommandContextError` if the command
@@ -269,7 +269,7 @@ class WestCommand(ABC):
                      'Try "west -vv manifest --validate" to debug.')
         return self._manifest
 
-    def _set_manifest(self, manifest: Optional[Manifest]):
+    def _set_manifest(self, manifest: Manifest | None):
         self._manifest = manifest
 
     # Do not use @property decorator syntax to avoid a false positive
@@ -294,7 +294,7 @@ class WestCommand(ABC):
                      "variables, which were not available.")
         return self._config
 
-    def _set_config(self, config: Optional[Configuration]):
+    def _set_config(self, config: Configuration | None):
         self._config = config
 
     config = property(_get_config, _set_config)
@@ -602,7 +602,7 @@ class WestExtCommandSpec:
     factory: _ExtFactory
 
 def extension_commands(config: Configuration,
-                       manifest: Optional[Manifest] = None):
+                       manifest: Manifest | None = None):
     # Get descriptions of available extension commands.
     #
     # The return value is an ordered map from project paths to lists of

--- a/src/west/configuration.py
+++ b/src/west/configuration.py
@@ -42,7 +42,7 @@ import warnings
 from collections.abc import Iterable
 from enum import Enum
 from pathlib import Path, PureWindowsPath
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any
 
 from west.util import WEST_DIR, PathType, WestNotFound, west_dir
 
@@ -67,7 +67,7 @@ class _InternalCF:
         return section_child
 
     @staticmethod
-    def from_path(path: Optional[Path]) -> Optional['_InternalCF']:
+    def from_path(path: Path | None) -> '_InternalCF | None':
         return _InternalCF(path) if path and path.exists() else None
 
     def __init__(self, path: Path):
@@ -160,7 +160,7 @@ class Configuration:
 
     '''
 
-    def __init__(self, topdir: Optional[PathType] = None):
+    def __init__(self, topdir: PathType | None = None):
         '''Load the system, global, and workspace configurations and
         make them available for the user.
 
@@ -179,8 +179,8 @@ class Configuration:
         self._local = _InternalCF.from_path(self._local_path)
 
     def get(self, option: str,
-            default: Optional[str] = None,
-            configfile: ConfigFile = ConfigFile.ALL) -> Optional[str]:
+            default: str | None = None,
+            configfile: ConfigFile = ConfigFile.ALL) -> str | None:
         '''Get a configuration option's value as a string.
 
         :param option: option to get, in 'foo.bar' form
@@ -204,8 +204,8 @@ class Configuration:
         return self._get(lambda cf: cf.getboolean(option), default, configfile)
 
     def getint(self, option: str,
-               default: Optional[int] = None,
-               configfile: ConfigFile = ConfigFile.ALL) -> Optional[int]:
+               default: int | None = None,
+               configfile: ConfigFile = ConfigFile.ALL) -> int | None:
         '''Get a configuration option's value as an int.
 
         :param option: option to get, in 'foo.bar' form
@@ -215,8 +215,8 @@ class Configuration:
         return self._get(lambda cf: cf.getint(option), default, configfile)
 
     def getfloat(self, option: str,
-                 default: Optional[float] = None,
-                 configfile: ConfigFile = ConfigFile.ALL) -> Optional[float]:
+                 default: float | None = None,
+                 configfile: ConfigFile = ConfigFile.ALL) -> float | None:
         '''Get a configuration option's value as a float.
 
         :param option: option to get, in 'foo.bar' form
@@ -306,7 +306,7 @@ class Configuration:
         return ret
 
     def delete(self, option: str,
-               configfile: Optional[ConfigFile] = None) -> None:
+               configfile: ConfigFile | None = None) -> None:
         '''Delete an option from the given file or files.
 
         If *option* is not set in the given *configfile*, KeyError is raised.
@@ -401,7 +401,7 @@ class Configuration:
         return self._cf_to_dict(self._local)
 
     @staticmethod
-    def _cf_to_dict(cf: Optional[_InternalCF]) -> dict[str, Any]:
+    def _cf_to_dict(cf: _InternalCF | None) -> dict[str, Any]:
         ret: dict[str, Any] = {}
         if cf is None:
             return ret
@@ -423,9 +423,9 @@ def _deprecated(old_function):
                   'use a west.configuration.Configuration object',
                   DeprecationWarning, stacklevel=2)
 
-def read_config(configfile: Optional[ConfigFile] = None,
+def read_config(configfile: ConfigFile | None = None,
                 config: configparser.ConfigParser = config,
-                topdir: Optional[PathType] = None) -> None:
+                topdir: PathType | None = None) -> None:
     '''Read configuration files into *config*.
 
     Reads the files given by *configfile*, storing the values into the
@@ -458,7 +458,7 @@ def read_config(configfile: Optional[ConfigFile] = None,
 
 def update_config(section: str, key: str, value: Any,
                   configfile: ConfigFile = ConfigFile.LOCAL,
-                  topdir: Optional[PathType] = None) -> None:
+                  topdir: PathType | None = None) -> None:
     '''Sets ``section.key`` to *value* in the given configuration file.
 
     :param section: config section; will be created if it does not exist
@@ -493,8 +493,8 @@ def update_config(section: str, key: str, value: Any,
         config.write(f)
 
 def delete_config(section: str, key: str,
-                  configfile: Union[Optional[ConfigFile], list[ConfigFile]] = None,
-                  topdir: Optional[PathType] = None) -> None:
+                  configfile: ConfigFile | list[ConfigFile] | None = None,
+                  topdir: PathType | None = None) -> None:
     '''Delete the option section.key from the given file or files.
 
     :param section: section whose key to delete
@@ -556,7 +556,7 @@ def delete_config(section: str, key: str,
     if not found:
         raise KeyError(f'{section}.{key}')
 
-def _location(cfg: ConfigFile, topdir: Optional[PathType] = None,
+def _location(cfg: ConfigFile, topdir: PathType | None = None,
               find_local: bool = True) -> str:
     # Making this a function that gets called each time you ask for a
     # configuration file makes it respect updated environment
@@ -628,7 +628,7 @@ def _location(cfg: ConfigFile, topdir: Optional[PathType] = None,
     else:
         raise ValueError(f'invalid configuration file {cfg}')
 
-def _gather_configs(cfg: ConfigFile, topdir: Optional[PathType]) -> list[str]:
+def _gather_configs(cfg: ConfigFile, topdir: PathType | None) -> list[str]:
     # Find the paths to the given configuration files, in increasing
     # precedence order.
     ret = []
@@ -645,7 +645,7 @@ def _gather_configs(cfg: ConfigFile, topdir: Optional[PathType]) -> list[str]:
 
     return ret
 
-def _ensure_config(configfile: ConfigFile, topdir: Optional[PathType]) -> str:
+def _ensure_config(configfile: ConfigFile, topdir: PathType | None) -> str:
     # Ensure the given configfile exists, returning its path. May
     # raise permissions errors, WestNotFound, etc.
     loc = _location(configfile, topdir=topdir)

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -16,9 +16,9 @@ import shlex
 import subprocess
 import sys
 from collections import deque
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from pathlib import Path, PurePosixPath
-from typing import TYPE_CHECKING, Any, Callable, NamedTuple, NoReturn
+from typing import TYPE_CHECKING, Any, NamedTuple, NoReturn
 
 import pykwalify.core
 import yaml

--- a/src/west/util.py
+++ b/src/west/util.py
@@ -9,7 +9,6 @@ import os
 import pathlib
 import shlex
 import textwrap
-from typing import Optional, Union
 
 # What west's APIs accept for paths.
 #
@@ -18,7 +17,7 @@ from typing import Optional, Union
 # taken in https://github.com/python/mypy/issues/5264 to annotate that
 # as os.PathLike[str] if TYPE_CHECKING and plain os.PathLike
 # otherwise, but it doesn't seem worth it.
-PathType = Union[str, os.PathLike]
+PathType = str | os.PathLike
 
 WEST_DIR = '.west'
 
@@ -51,7 +50,7 @@ def wrap(text: str, indent: str) -> list[str]:
 class WestNotFound(RuntimeError):
     '''Neither the current directory nor any parent has a west workspace.'''
 
-def west_dir(start: Optional[PathType] = None) -> str:
+def west_dir(start: PathType | None = None) -> str:
     '''Returns the absolute path of the workspace's .west directory.
 
     Starts the search from the start directory, and goes to its
@@ -62,7 +61,7 @@ def west_dir(start: Optional[PathType] = None) -> str:
     '''
     return os.path.join(west_topdir(start), WEST_DIR)
 
-def west_topdir(start: Optional[PathType] = None,
+def west_topdir(start: PathType | None = None,
                 fall_back: bool = True) -> str:
     '''
     Like west_dir(), but returns the path to the parent directory of the .west/

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,7 +6,7 @@ import configparser
 import os
 import pathlib
 import subprocess
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 from conftest import cmd, cmd_raises
@@ -38,13 +38,13 @@ def cfg(f=ALL, topdir=None):
 
 def update_testcfg(section: str, key: str, value: Any,
                    configfile: config.ConfigFile = LOCAL,
-                   topdir: Optional[PathType] = None) -> None:
+                   topdir: PathType | None = None) -> None:
     c = config.Configuration(topdir)
     c.set(option=f'{section}.{key}', value=value, configfile=configfile)
 
 def delete_testcfg(section: str, key: str,
-                   configfile: Optional[config.ConfigFile] = None,
-                   topdir: Optional[PathType] = None) -> None:
+                   configfile: config.ConfigFile | None = None,
+                   topdir: PathType | None = None) -> None:
     c = config.Configuration(topdir)
     c.delete(option=f'{section}.{key}', configfile=configfile)
 

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -393,7 +393,7 @@ def test_project_revisions():
     ''')
     expected = [Project('p1', 'u1', revision='defaultrev'),
                 Project('p2', 'u2', revision='rev')]
-    for p, e in zip(m.projects[1:], expected):
+    for p, e in zip(m.projects[1:], expected, strict=True):
         check_proj_consistency(p, e)
 
     # The default revision, if not given in a defaults section, is
@@ -776,7 +776,7 @@ def test_self_tag():
                 Project('testproject2', 'https://example2.com/testproject2')]
 
     # Check the projects are as expected.
-    for p, e in zip(m.projects, expected):
+    for p, e in zip(m.projects, expected, strict=True):
         check_proj_consistency(p, e)
 
     # With a "self: path:" value, that will be available in the
@@ -1726,7 +1726,7 @@ def test_import_basics(content):
                 revision='segger-upstream-rev',
                 path='modules/debug/segger')]
 
-    for a, e in zip(actual, expected):
+    for a, e in zip(actual, expected, strict=True):
         check_proj_consistency(a, e)
 
 def test_import_with_fork_and_proj():
@@ -1766,7 +1766,7 @@ def test_import_with_fork_and_proj():
                 revision='segger-upstream-rev',
                 path='modules/debug/segger')]
 
-    for a, e in zip(actual, expected):
+    for a, e in zip(actual, expected, strict=True):
         check_proj_consistency(a, e)
 
 def test_import_project_list(manifest_repo):
@@ -1815,7 +1815,7 @@ def test_import_project_list(manifest_repo):
                 Project('p2', 'p2-url', topdir=topdir),
                 Project('p3', 'p3-url', topdir=topdir)]
 
-    for a, e in zip(actual, expected):
+    for a, e in zip(actual, expected, strict=True):
         check_proj_consistency(a, e)
 
 def test_import_project_directory(manifest_repo):
@@ -1867,7 +1867,7 @@ def test_import_project_directory(manifest_repo):
                 Project('p2', 'p2-url', topdir=topdir),
                 Project('p3', 'p3-url', topdir=topdir)]
 
-    for a, e in zip(actual, expected):
+    for a, e in zip(actual, expected, strict=True):
         check_proj_consistency(a, e)
 
 def test_import_project_err_malformed(manifest_repo):
@@ -2211,7 +2211,7 @@ def test_import_self_directory(content, tmp_workspace):
     assert [a.name for a in actual] == [e.name for e in expected]
 
     # With the basic check done, do a more detailed check.
-    for a, e in zip(actual, expected):
+    for a, e in zip(actual, expected, strict=True):
         check_proj_consistency(a, e)
 
 def test_import_self_bool():
@@ -2674,7 +2674,7 @@ def test_import_path_prefix_basics(manifest_repo):
                         path='prefix/2/not-cloned-2', topdir=topdir),
                 Project('not-cloned-3', 'https://example.com/not-cloned-3',
                         path='pre/fix/3/not-cloned-3', topdir=topdir)]
-    for a, e in zip(actual, expected):
+    for a, e in zip(actual, expected, strict=True):
         check_proj_consistency(a, e)
 
 def test_import_path_prefix_self(manifest_repo):
@@ -2760,7 +2760,7 @@ def test_import_path_prefix_propagation(manifest_repo):
                 Project('project-2', 'https://example.com/project-2',
                         path='prefix/1/prefix-2/project-2',
                         topdir=topdir)]
-    for a, e in zip(actual, expected):
+    for a, e in zip(actual, expected, strict=True):
         check_proj_consistency(a, e)
 
 def test_import_path_prefix_no_escape(manifest_repo):

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -92,7 +92,7 @@ def _list_f(format):
 
 
 def _match_multiline_regex(expected, actual):
-    for eline_re, aline in zip(expected, actual):
+    for eline_re, aline in zip(expected, actual, strict=True):
         assert re.match(eline_re, aline) is not None, (aline, eline_re)
 
 
@@ -2374,7 +2374,7 @@ def test_import_project_release(repos_tmpdir):
                 Project('net-tools', remotes / 'net-tools',
                         clone_depth=1, topdir=ws,
                         west_commands='scripts/west-commands.yml')]
-    for a, e in zip(actual, expected):
+    for a, e in zip(actual, expected, strict=True):
         check_proj_consistency(a, e)
 
     # Add a commit in the remote zephyr repository and make sure it
@@ -2389,7 +2389,7 @@ def test_import_project_release(repos_tmpdir):
 
     assert head_before == rev_parse(zephyr_ws, 'HEAD')
     actual = Manifest.from_topdir(topdir=ws).projects
-    for a, e in zip(actual, expected):
+    for a, e in zip(actual, expected, strict=True):
         check_proj_consistency(a, e)
     assert (zephyr_ws / 'should-not-clone').check(file=0)
 
@@ -2443,7 +2443,7 @@ def test_import_project_release_fork(repos_tmpdir):
                 Project('net-tools', remotes / 'net-tools',
                         clone_depth=1, topdir=ws,
                         west_commands='scripts/west-commands.yml')]
-    for a, e in zip(actual, expected):
+    for a, e in zip(actual, expected, strict=True):
         check_proj_consistency(a, e)
 
     zephyr_ws = ws / 'zephyr'
@@ -2455,7 +2455,7 @@ def test_import_project_release_fork(repos_tmpdir):
 
     assert head_before == rev_parse(zephyr_ws, 'HEAD')
     actual = Manifest.from_topdir(topdir=ws).projects
-    for a, e in zip(actual, expected):
+    for a, e in zip(actual, expected, strict=True):
         check_proj_consistency(a, e)
     assert (zephyr_ws / 'should-not-clone').check(file=0)
 
@@ -2514,7 +2514,7 @@ def test_import_project_release_dir(tmpdir):
                 Project('west.d_1.yml-p1', empty_project, topdir=ws),
                 Project('west.d_1.yml-p2', empty_project, topdir=ws),
                 Project('west.d_2.yml-p1', empty_project, topdir=ws)]
-    for a, e in zip(actual, expected):
+    for a, e in zip(actual, expected, strict=True):
         check_proj_consistency(a, e)
 
 def test_import_project_rolling(repos_tmpdir):
@@ -2557,7 +2557,7 @@ def test_import_project_rolling(repos_tmpdir):
                 Project('net-tools', remotes / 'net-tools',
                         clone_depth=1, topdir=ws,
                         west_commands='scripts/west-commands.yml')]
-    for a, e in zip(actual, expected):
+    for a, e in zip(actual, expected, strict=True):
         check_proj_consistency(a, e)
 
     # Add a commit in the remote zephyr repository and make sure it

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,7 @@ deps =
     types-PyYAML
     flake8
     mypy
-    ruff==0.8.1
+    ruff==0.13.0
 setenv =
     # For instance: ./.tox/py3/tmp/
     TOXTEMPDIR={envtmpdir}


### PR DESCRIPTION
Python 3.9 is almost EOL, remove it from the supported versions.

Firstly bump the `ruff` version to make sure we have latest versions of linters.
With the minimum required version set to 3.10, some linter changes are needed, namely:

- Replace `Optional[Type]` with `Type | None` [Ruff UP045](https://docs.astral.sh/ruff/rules/non-pep604-annotation-optional/)
- Replace `Union[X, Y]` with `X | Y` [Ruff UP007](https://docs.astral.sh/ruff/rules/non-pep604-annotation-union/)
- Add `strict` argument to `zip` calls [Ruff B905](https://docs.astral.sh/ruff/rules/zip-without-explicit-strict/)
- Import `Callable` from `collections.abc` instead of `typing` [Ruff UP035](https://docs.astral.sh/ruff/rules/deprecated-import/)