### PR TITLE
repo: Patch coverage with subprocess

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ where = ["src"]
 namespaces = false
 
 [tool.coverage.run]
+patch = ["subprocess"]
 relative_files = true
 omit = [
   "*/tmp/*",


### PR DESCRIPTION
Coverage subprocess has been removed in pytest-cov 7.0. To migrate the `patch` option has to be added.
See https://pytest-cov.readthedocs.io/en/latest/subprocess-support.html

@marc-hb the [coverage](https://app.codecov.io/gh/zephyrproject-rtos/west) plummeted to 48% for no apparent reason because, in CI, we simply install the latest versions of all tools. 
As it took quite some time to figure this out, I intend to come back to locking dependency versions in CI. But with a better proposal, stay tuned.