### PR TITLE
pyproject.toml: Update license info for PEP 639

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.2"]
+requires = ["setuptools>=77.0.3"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -13,7 +13,6 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
-    "License :: OSI Approved :: Apache Software License",
     "Operating System :: POSIX :: Linux",
     "Operating System :: MacOS :: MacOS X",
     "Operating System :: Microsoft :: Windows",
@@ -25,9 +24,8 @@ dependencies = [
     "pykwalify",
     "packaging",
 ]
-
-[project.license]
-file = "LICENSE"
+license = "Apache-2.0"
+license-files = ["LICENSE"]
 
 [project.readme]
 file = "README.rst"


### PR DESCRIPTION
[PEP 639](https://peps.python.org/pep-0639/) describes how packages should improve license clarity. Add an SPDX license string alongside the LICENSE file reference.

See: https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files