### PR TITLE
Support `west config --update <file>`

### DIFF
--- a/src/west/app/config.py
+++ b/src/west/app/config.py
@@ -108,6 +108,9 @@ class Config(WestCommand):
                            help="delete an option everywhere it's set")
         group.add_argument('-a', '--append', action='store_true',
                            help='append to an existing value')
+        group.add_argument('-u', '--update', action='append', metavar='FROM_FILE',
+                           help='''update the config with all options and
+                           values from one or more other config files''')
 
         group = parser.add_argument_group(
             "configuration file to use (give at most one)"
@@ -135,6 +138,9 @@ class Config(WestCommand):
         if args.list:
             if args.name:
                 self.parser.error('-l cannot be combined with name argument')
+        elif args.update:
+            if args.name:
+                self.parser.error('-u cannot be combined with name argument')
         elif not args.name:
             self.parser.error('missing argument name '
                               '(to list all options and values, use -l)')
@@ -146,10 +152,12 @@ class Config(WestCommand):
             self.list(args)
         elif delete:
             self.delete(args)
-        elif args.value is None:
+        elif args.name and args.value is None:
             self.read(args)
         elif args.append:
             self.append(args)
+        elif args.update:
+            self.update(args)
         else:
             self.write(args)
 
@@ -157,6 +165,10 @@ class Config(WestCommand):
         what = args.configfile or ALL
         for option, value in self.config.items(configfile=what):
             self.inf(f'{option}={value}')
+
+    def update(self, args):
+        for path in args.update:
+            self.config.update(other=path, configfile=args.configfile or LOCAL)
 
     def delete(self, args):
         self.check_config(args.name)


### PR DESCRIPTION
## Use case
We need an easy way to update the user config (local, global or system) with all options and values from another given config.
This is especially helpful when users want to share configuration files within their repository.


## New flag `-u` (`--update`)
Added support for `west config -u` (`--update`), which can be used to update the user's west config with all options and values from another given config file. The `-u`/`--update` argument can be specified multiple times, whereby values from later files override earlier ones.

## Example

command:
```
west config --global -u shared/config.default
west config -u shared/aliases.default -u shared/aliases.jamie -u shared/aliases.pieter # default: local config
```

Whereby the configs could look like this for example: 
`shared/config.default`
```
[update]
auto-cache = /usr/tmp/west/auto-cache

[build]
cmake-args = -DCMAKE_COLOR_DIAGNOSTICS=ON
```

`shared/aliases.default`
```
[alias]
menuconfig = build --pristine=never --target menuconfig
```

`shared/aliases.jamie`
```
[alias]
jamie-board = build -b sama7g54_ek --pristine=always
```

`shared/aliases.pieter`
```
[alias]
pieter-board = build -b acn52832
```



