### PR TITLE
support 'west init --topdir'

### DIFF
--- a/src/west/app/project.py
+++ b/src/west/app/project.py
@@ -24,10 +24,8 @@ from urllib.parse import urlparse
 from west import util
 from west.commands import CommandError, Verbosity, WestCommand
 from west.configuration import Configuration
-from west.manifest import MANIFEST_REV_BRANCH as MANIFEST_REV
-from west.manifest import QUAL_MANIFEST_REV_BRANCH as QUAL_MANIFEST_REV
-from west.manifest import QUAL_REFS_WEST as QUAL_REFS
 from west.manifest import (
+    _WEST_YML,
     ImportFlag,
     Manifest,
     ManifestImportFailed,
@@ -35,6 +33,9 @@ from west.manifest import (
     Submodule,
     _manifest_content_at,
 )
+from west.manifest import MANIFEST_REV_BRANCH as MANIFEST_REV
+from west.manifest import QUAL_MANIFEST_REV_BRANCH as QUAL_MANIFEST_REV
+from west.manifest import QUAL_REFS_WEST as QUAL_REFS
 from west.manifest import is_group as is_project_group
 from west.util import expand_path
 
@@ -236,19 +237,58 @@ class Init(_ProjectCommand):
             'init',
             'create a west workspace',
             f'''\
-Creates a west workspace.
+Initialize a west workspace (topdir) from a west manifest (`west.yml`) by
+creating a `.west` directory in the topdir and a local configuration file
+`.west/config`.
+The West manifest can come from either a git repository (that will be cloned
+during workspace initialization) or from an already existing local directory.
 
-With -l, creates a workspace around an existing local repository;
-without -l, creates a workspace by cloning a manifest repository
-by URL.
+Arguments
+---------
+--mf / --manifest-file
+    The relative path to the manifest file within the manifest repository
+    or directory. Config option `manifest.file` will be set to this value.
+    Defaults to '{_WEST_YML}' if not provided.
 
-With -m, clones the repository at that URL and uses it as the
-manifest repository. If --mr is not given, the remote's default
-branch will be used, if it exists.
+-t / --topdir
+    Specifies the directory where west should create the workspace.
+    The `.west` folder will be created inside this directory.
+    If it is an already existing directory, it must not contain a .west folder.
 
-With neither, -m {MANIFEST_URL_DEFAULT} is assumed.
 
-Warning: 'west init' renames and/or deletes temporary files inside the
+1. Using a Manifest Repository (default)
+----------------------------------------
+West clones the given repository (provided via `-m / --manifest-url`).
+Note, that the repository must contain a west manifest.
+
+If no `-m / --manifest-url` is provided, west uses Zephyr URL by default:
+  {MANIFEST_URL_DEFAULT}.
+
+The topdir (where `.west` is created) is determined as follows:
+- argument `-t / --topdir` if provided
+- otherwise: the positional argument `directory` if provided
+- otherwise: the current working directory
+
+If both `-t / --topdir` and `directory` are provided, `-t / --topdir`
+specifies the workspace directory, while positional argument `directory`
+specifies the exact path where the manifest repository is cloned
+(it must be inside the workspace).
+With `--mr`, the revision (branch, tag, or sha) of the repository can be
+specified that will be used. It defaults to the repository's default branch.
+
+2. Using a Local Manifest
+-------------------------
+If `-l / --local` is given, west initializes a workspace from an already
+existing `west.yml`. Its location can be specified in the `manifest_directory`
+positional argument, which defaults to current working directory.
+
+The topdir (where `.west` is created) is determined as follows:
+- argument `-t / --topdir` if provided
+- otherwise: `manifest_directory`'s parent
+
+Known Issues
+------------
+'west init' renames and/or deletes temporary files inside the
 workspace being created. This fails on some filesystems when some
 development tool or any other program is trying to read/index these
 temporary files at the same time. For instance, it is required to stop
@@ -273,9 +313,11 @@ below.
         parser = self._parser(
             parser_adder,
             usage='''
+  init with a repository:
+  %(prog)s [-m URL] [--mr REVISION] [--mf FILE] [-o=GIT_CLONE_OPTION] [-t WORKSPACE_DIR] [directory]
 
-  %(prog)s [-m URL] [--mr REVISION] [--mf FILE] [-o=GIT_CLONE_OPTION] [directory]
-  %(prog)s -l [--mf FILE] directory
+  init with an existing local manifest:
+  %(prog)s -l [-t WORKSPACE_DIR] [--mf FILE] [manifest_directory]
 ''',
         )
 
@@ -284,6 +326,7 @@ below.
         parser.add_argument(
             '-m',
             '--manifest-url',
+            metavar='URL',
             help='''manifest repository URL to clone;
                     cannot be combined with -l''',
         )
@@ -292,6 +335,7 @@ below.
             '--clone-opt',
             action='append',
             default=[],
+            metavar='GIT_CLONE_OPTION',
             help='''additional option to pass to 'git clone'
                     (e.g. '-o=--depth=1'); may be given more than once;
                     cannot be combined with -l''',
@@ -300,21 +344,36 @@ below.
             '--mr',
             '--manifest-rev',
             dest='manifest_rev',
+            metavar='REVISION',
             help='''manifest repository branch or tag name
                     to check out first; cannot be combined with -l''',
-        )
-        parser.add_argument(
-            '--mf', '--manifest-file', dest='manifest_file', help='manifest file name to use'
         )
         parser.add_argument(
             '-l',
             '--local',
             action='store_true',
-            help='''use "directory" as an existing local
-                    manifest repository instead of cloning one from
-                    MANIFEST_URL; .west is created next to "directory"
-                    in this case, and manifest.path points at
-                    "directory"''',
+            help='''initialize workspace from an already existing local
+                    manifest instead of cloning a manifest;
+                    cannot be combined with -m''',
+        )
+        parser.add_argument(
+            '--mf',
+            '--manifest-file',
+            dest='manifest_file',
+            metavar='FILE',
+            help=f'''manifest file to use. It is the relative
+                     path to the manifest file within the manifest_directory.
+                     Defaults to {_WEST_YML}.''',
+        )
+        parser.add_argument(
+            '-t',
+            '--topdir',
+            dest='topdir',
+            metavar='WORKSPACE_DIR',
+            help='''the workspace directory where .west directory
+                    will be created (WORKSPACE_DIR/.west);
+                    the workspace directory may already exist
+                    and WORKSPACE_DIR/.west must not exist''',
         )
         parser.add_argument(
             '--rename-delay',
@@ -330,9 +389,15 @@ below.
             'directory',
             nargs='?',
             default=None,
-            help='''with -l, the path to the local manifest repository;
-            without it, the directory to create the workspace in (defaulting
-            to the current working directory in this case)''',
+            metavar='directory',
+            help='''With --local: the path to a local directory which contains
+                    a west manifest (west.yml);
+                    Otherwise, if no --topdir is provided:
+                    the location of the west workspace where .west directory
+                    will be created (<directory>/.west)
+                    Otherwise:
+                    the location where west will clone the manifest repository
+                    ''',
         )
 
         return parser
@@ -385,7 +450,7 @@ below.
         # Path('..').
         #
         # https://docs.python.org/3/library/pathlib.html#pathlib.PurePath.parent
-        manifest_dir = Path(args.directory or os.getcwd()).resolve()
+        manifest_dir = Path(args.directory or '.').resolve()
 
         try:
             already = util.west_topdir(manifest_dir, fall_back=False)
@@ -393,16 +458,26 @@ below.
         except util.WestNotFound:
             pass
 
-        manifest_filename = args.manifest_file or 'west.yml'
+        manifest_filename = args.manifest_file or _WEST_YML
         manifest_file = manifest_dir / manifest_filename
-        topdir = manifest_dir.parent
-        rel_manifest = manifest_dir.name
-        west_dir = topdir / WEST_DIR
-
         if not manifest_file.is_file():
             self.die(f'can\'t init: no {manifest_filename} found in {manifest_dir}')
 
-        self.banner('Initializing from existing manifest repository', rel_manifest)
+        topdir = Path(args.topdir or manifest_dir.parent).resolve()
+
+        if not manifest_file.is_relative_to(topdir):
+            self.die(f'{manifest_file} must be relative to west topdir {topdir}')
+
+        try:
+            already = util.west_topdir(manifest_dir, fall_back=False)
+            self.die_already(already)
+        except util.WestNotFound:
+            pass
+
+        rel_manifest = manifest_dir.relative_to(topdir)
+        west_dir = topdir / WEST_DIR
+
+        self.banner('Initializing with existing manifest', rel_manifest)
         self.small_banner(f'Creating {west_dir} and local configuration file')
         self.create(west_dir, exist_ok=False)
         os.chdir(topdir)
@@ -413,8 +488,25 @@ below.
         return topdir
 
     def bootstrap(self, args) -> Path:
-        topdir = Path(abspath(args.directory or os.getcwd()))
-        self.banner('Initializing in', topdir)
+        manifest_subdir = Path()
+        if args.topdir:
+            topdir = Path(args.topdir).resolve()
+            if args.directory:
+                directory = Path(args.directory)
+                if not directory.is_absolute():
+                    directory = directory.resolve()
+                if not directory.is_relative_to(topdir):
+                    self.die(
+                        f"directory '{args.directory}' must be inside west topdir '{args.topdir}'"
+                    )
+                manifest_subdir = directory.relative_to(topdir)
+        elif args.directory:
+            # This case will be deprecated later in favor of --topdir.
+            topdir = Path(args.directory)
+        else:
+            topdir = Path()
+        topdir = topdir.resolve()
+        self.banner(f'Initializing in {topdir}')
 
         manifest_url = args.manifest_url or MANIFEST_URL_DEFAULT
         if args.manifest_rev:
@@ -469,7 +561,7 @@ below.
             raise
 
         # Verify the manifest file exists.
-        temp_manifest_filename = args.manifest_file or 'west.yml'
+        temp_manifest_filename = args.manifest_file or _WEST_YML
         temp_manifest = tempdir / temp_manifest_filename
         if not temp_manifest.is_file():
             self.die(
@@ -486,15 +578,17 @@ below.
         manifest = Manifest.from_data(
             temp_manifest.read_text(encoding=Manifest.encoding), import_flags=ImportFlag.IGNORE
         )
+
         if manifest.yaml_path:
-            manifest_path = manifest.yaml_path
+            yaml_path = manifest.yaml_path
         else:
             # We use PurePath() here in case manifest_url is a
             # windows-style path. That does the right thing in that
             # case, without affecting POSIX platforms, where PurePath
             # is PurePosixPath.
-            manifest_path = PurePath(urlparse(manifest_url).path).name
+            yaml_path = PurePath(urlparse(manifest_url).path).name
 
+        manifest_path = manifest_subdir if manifest_subdir != Path() else Path(yaml_path)
         manifest_abspath = topdir / manifest_path
 
         # We already looked for old .west/ pollution earlier but only at the highest
@@ -531,7 +625,7 @@ below.
             self.die(e)
         self.small_banner('setting manifest.path to', manifest_path)
         self.config = Configuration(topdir=topdir)
-        self.config.set('manifest.path', manifest_path)
+        self.config.set('manifest.path', str(manifest_path))
         self.config.set('manifest.file', temp_manifest_filename)
 
         return topdir

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -665,3 +665,15 @@ def check_proj_consistency(actual, expected):
     assert actual.clone_depth == expected.clone_depth
     assert actual.revision == expected.revision
     assert actual.west_commands == expected.west_commands
+
+
+def tree(path: Path, prefix="") -> str:
+    lines = []
+    entries = sorted(path.iterdir(), key=lambda p: (p.is_file(), p.name))
+    for i, entry in enumerate(entries):
+        connector = "└── " if i == len(entries) - 1 else "├── "
+        lines.append(prefix + connector + entry.name)
+        if entry.is_dir():
+            indent = "    " if i == len(entries) - 1 else "│   "
+            lines.extend(tree(entry, prefix + indent))
+    return "\n".join(lines)

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -25,6 +25,7 @@ from conftest import (
     create_repo,
     create_workspace,
     rev_parse,
+    tree,
     yaml_editor,
 )
 
@@ -2038,6 +2039,146 @@ def test_init_local_with_manifest_filename(repos_tmpdir):
     workspace.chdir()
     cmd('update')
 
+
+def _setup_test_init(manifest_repo, local_dir, directory, manifest_file):
+    flags = []
+    if local_dir:
+        # for the test: ensure that manifest_repo is present at local_dir
+        clone(str(manifest_repo), str(local_dir))
+        flags += ['-l']
+    else:
+        # clone from remote manifest
+        flags += ["-m", manifest_repo]
+
+    # extend west init flags according to specified test case
+    if manifest_file:
+        flags += ['--mf', manifest_file]
+    if directory:
+        flags += [directory]
+    return flags
+
+
+TEST_CASES_INIT = [
+    # (local_dir, directory, manifest_file)
+    ######################################
+    # REMOTE MANIFEST
+    ######################################
+    # init from remote repository (without any parameters)
+    (None, None, None),
+    # use deprecated [directory] to specify topdir
+    (None, Path('subdir'), None),
+    ######################################
+    # LOCAL MANIFEST
+    ######################################
+    # init workspace in current working directory (without --topdir)
+    (Path('workspace') / 'zephyr', Path('workspace') / 'zephyr', None),
+]
+
+
+@pytest.mark.parametrize("test_case", TEST_CASES_INIT)
+def test_init(repos_tmpdir, test_case):
+    local_dir, directory, manifest_file = test_case
+
+    repos_tmpdir.chdir()
+    manifest_repo = repos_tmpdir / 'repos' / 'zephyr'
+    flags = _setup_test_init(manifest_repo, local_dir, directory, manifest_file)
+
+    # initialize west workspace
+    cmd(['init'] + flags)
+
+    # cd into the workspace
+    if local_dir:
+        workspace = directory.parent
+    else:
+        workspace = directory or Path.cwd()
+    workspace_abs = workspace.absolute()
+    os.chdir(workspace)
+
+    # check if config option 'manifest.path' is correctly set
+    actual = cmd('config manifest.path')
+    if local_dir:
+        assert Path(actual.rstrip()) == directory.relative_to(workspace)
+    else:
+        if directory:
+            # zephyr is cloned into specified subdirectory in workspace
+            subdir = directory.relative_to(workspace)
+            assert Path(actual.rstrip()) == Path(subdir) / 'zephyr'
+        else:
+            # zephyr is cloned directly to workspace
+            assert Path(actual.rstrip()) == Path('zephyr')
+
+    # check if config option 'manifest.file' is correctly set
+    actual = cmd('config manifest.file')
+    expected = manifest_file or Path('west.yml')
+    assert Path(actual.rstrip()) == Path(expected)
+
+    # re-initialization of a workspace must always fail
+    _, stderr = cmd_raises(['init'] + flags, SystemExit)
+    assert "FATAL ERROR: already initialized" in stderr
+
+
+TEST_CASES_INIT_FAILS = [
+    # (local_dir, directory, manifest_file, expected_error, expected_error)
+    ######################################
+    # REMOTE MANIFEST
+    ######################################
+    # specify a non-existent manifest file
+    (
+        None,
+        None,
+        Path('non-existent.yml'),
+        SystemExit,
+        "FATAL ERROR: can't init: no non-existent.yml found",
+    ),
+    ######################################
+    # LOCAL MANIFEST
+    ######################################
+    # init workspace without a directory
+    (
+        Path('workspace') / 'zephyr',
+        None,
+        None,
+        SystemExit,
+        "FATAL ERROR: can't init: no west.yml found",
+    ),
+    # init workspace from non-existent manifest
+    (
+        Path('workspace') / 'zephyr',
+        Path('non-existent.yml'),
+        None,
+        SystemExit,
+        "FATAL ERROR: can't init: no west.yml found",
+    ),
+]
+
+
+@pytest.mark.parametrize("test_case", TEST_CASES_INIT_FAILS)
+def test_init_fails(repos_tmpdir, test_case):
+    local_dir, directory, manifest_file, expected_error, expected_stderr = test_case
+
+    manifest_repo = repos_tmpdir / 'repos' / 'zephyr'
+    repos_tmpdir.chdir()
+    flags = _setup_test_init(manifest_repo, local_dir, directory, manifest_file)
+    _, stderr = cmd_raises(['init'] + flags, expected_error)
+    assert expected_stderr in stderr
+
+
+def test_init_topdir_again(repos_tmpdir):
+    repos_tmpdir.chdir()
+    workspace = Path(repos_tmpdir) / 'ws'
+    zephyr = repos_tmpdir / 'repos' / 'zephyr'
+
+    # initial clone
+    cmd(['init', 'ws', '-m', zephyr])
+
+    # initialize west workspace again
+    _, stderr = cmd_raises(['init', 'ws', '-m', zephyr], SystemExit)
+    assert "FATAL ERROR: already initialized" in stderr
+
+    # initialize west workspace again
+    os.chdir(workspace)
+    _, stderr = cmd_raises(['init', '--local', 'zephyr'], SystemExit)
+    assert "FATAL ERROR: already initialized" in stderr
 
 def test_init_local_with_empty_path(repos_tmpdir):
     # Test "west init -l ." + "west update".

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -2040,7 +2040,7 @@ def test_init_local_with_manifest_filename(repos_tmpdir):
     cmd('update')
 
 
-def _setup_test_init(manifest_repo, local_dir, directory, manifest_file):
+def _setup_test_init(manifest_repo, local_dir, topdir, directory, manifest_file):
     flags = []
     if local_dir:
         # for the test: ensure that manifest_repo is present at local_dir
@@ -2051,6 +2051,8 @@ def _setup_test_init(manifest_repo, local_dir, directory, manifest_file):
         flags += ["-m", manifest_repo]
 
     # extend west init flags according to specified test case
+    if topdir:
+        flags += ['-t', topdir]
     if manifest_file:
         flags += ['--mf', manifest_file]
     if directory:
@@ -2059,38 +2061,75 @@ def _setup_test_init(manifest_repo, local_dir, directory, manifest_file):
 
 
 TEST_CASES_INIT = [
-    # (local_dir, directory, manifest_file)
+    # (local_dir, topdir, directory, manifest_file)
     ######################################
     # REMOTE MANIFEST
     ######################################
     # init from remote repository (without any parameters)
-    (None, None, None),
+    (None, None, None, None),
+    # specify topdir in current directory
+    (None, Path('.'), None, None),
+    # specify topdir in a subfolder
+    (None, Path('subdir'), None, None),
     # use deprecated [directory] to specify topdir
-    (None, Path('subdir'), None),
+    (None, None, Path('subdir'), None),
+    # specify topdir and [directory]: manifest cloned to the given directory
+    (None, Path('subdir'), Path('subdir') / 'extra' / 'level', None),
+    # specify topdir and [directory]: manifest cloned to the given directory
+    (None, Path('.'), Path('extra') / 'level', None),
     ######################################
     # LOCAL MANIFEST
     ######################################
     # init workspace in current working directory (without --topdir)
-    (Path('workspace') / 'zephyr', Path('workspace') / 'zephyr', None),
+    (Path('workspace') / 'zephyr', None, Path('workspace') / 'zephyr', None),
+    # init workspace in current working directory
+    (Path('workspace') / 'zephyr', Path('.'), Path('workspace') / 'zephyr', None),
+    # init workspace in a subfolder of current working directory
+    (Path('workspace') / 'zephyr', Path('workspace'), Path('workspace') / 'zephyr', None),
+    # init workspace in current working directory by providing a manifest file
+    (Path('workspace') / 'zephyr', Path('.'), Path('workspace'), Path('zephyr') / 'west.yml'),
+    # init workspace in itself by providing manifest file
+    (
+        Path('workspace') / 'zephyr',
+        Path('.'),
+        Path('.'),
+        Path('workspace') / 'zephyr' / 'west.yml',
+    ),
+    # init workspace in a subfolder by providing manifest file
+    (
+        Path('workspace') / 'subdir' / 'zephyr',
+        Path('workspace'),
+        Path('workspace') / 'subdir',
+        Path('zephyr') / 'west.yml',
+    ),
+    # init workspace in a subfolder by providing manifest file
+    (
+        Path('workspace') / 'subdir' / 'zephyr',
+        Path('workspace'),
+        Path('workspace'),
+        Path('subdir') / 'zephyr' / 'west.yml',
+    ),
 ]
 
 
 @pytest.mark.parametrize("test_case", TEST_CASES_INIT)
 def test_init(repos_tmpdir, test_case):
-    local_dir, directory, manifest_file = test_case
+    local_dir, topdir, directory, manifest_file = test_case
 
     repos_tmpdir.chdir()
     manifest_repo = repos_tmpdir / 'repos' / 'zephyr'
-    flags = _setup_test_init(manifest_repo, local_dir, directory, manifest_file)
+    flags = _setup_test_init(manifest_repo, local_dir, topdir, directory, manifest_file)
 
     # initialize west workspace
     cmd(['init'] + flags)
 
     # cd into the workspace
     if local_dir:
-        workspace = directory.parent
+        # topdir is either specified or default (directory.parent)
+        workspace = topdir or directory.parent
     else:
-        workspace = directory or Path.cwd()
+        # topdir is either specified, directory or default (cwd)
+        workspace = topdir or directory or Path.cwd()
     workspace_abs = workspace.absolute()
     os.chdir(workspace)
 
@@ -2099,12 +2138,11 @@ def test_init(repos_tmpdir, test_case):
     if local_dir:
         assert Path(actual.rstrip()) == directory.relative_to(workspace)
     else:
-        if directory:
-            # zephyr is cloned into specified subdirectory in workspace
-            subdir = directory.relative_to(workspace)
-            assert Path(actual.rstrip()) == Path(subdir) / 'zephyr'
+        if topdir and directory:
+            # manifest is cloned to the specified directory within workspace
+            assert Path(actual.rstrip()) == directory.relative_to(topdir)
         else:
-            # zephyr is cloned directly to workspace
+            # manifest is cloned directly to workspace, using the name from the manifest
             assert Path(actual.rstrip()) == Path('zephyr')
 
     # check if config option 'manifest.file' is correctly set
@@ -2115,20 +2153,44 @@ def test_init(repos_tmpdir, test_case):
     # re-initialization of a workspace must always fail
     _, stderr = cmd_raises(['init'] + flags, SystemExit)
     assert "FATAL ERROR: already initialized" in stderr
+    os.chdir(workspace.parent)
+    _, stderr = cmd_raises(['init', '-l', '--topdir', workspace_abs, manifest_repo], SystemExit)
+    assert "FATAL ERROR: already initialized" in stderr
+    _, stderr = cmd_raises(['init', '--topdir', workspace_abs, '-m', manifest_repo], SystemExit)
+    assert "FATAL ERROR: already initialized" in stderr
 
 
 TEST_CASES_INIT_FAILS = [
-    # (local_dir, directory, manifest_file, expected_error, expected_error)
+    # (local_dir, topdir, directory, manifest_file, expected_error, expected_error)
     ######################################
     # REMOTE MANIFEST
     ######################################
     # specify a non-existent manifest file
     (
         None,
+        Path('.'),
         None,
         Path('non-existent.yml'),
         SystemExit,
         "FATAL ERROR: can't init: no non-existent.yml found",
+    ),
+    # specify topdir and [directory] (but directory is not inside topdir)
+    (
+        None,
+        Path('subdir'),
+        Path('sibling'),
+        None,
+        SystemExit,
+        "FATAL ERROR: directory 'sibling' must be inside west topdir 'subdir'",
+    ),
+    # specify topdir and [directory] (but directory is not inside topdir)
+    (
+        None,
+        Path('somedir').absolute(),
+        Path('extra') / 'dir',
+        None,
+        SystemExit,
+        f"FATAL ERROR: directory '{Path('extra') / 'dir'}' must be inside west topdir",
     ),
     ######################################
     # LOCAL MANIFEST
@@ -2136,49 +2198,102 @@ TEST_CASES_INIT_FAILS = [
     # init workspace without a directory
     (
         Path('workspace') / 'zephyr',
+        Path('.'),
         None,
         None,
         SystemExit,
         "FATAL ERROR: can't init: no west.yml found",
     ),
+    # init workspace in a sibling repository path
+    (
+        Path('workspace') / 'zephyr',
+        Path('sibling'),
+        Path('workspace') / 'zephyr',
+        None,
+        SystemExit,
+        "west.yml must be relative to west topdir",
+    ),
     # init workspace from non-existent manifest
     (
         Path('workspace') / 'zephyr',
+        Path('.'),
         Path('non-existent.yml'),
         None,
         SystemExit,
         "FATAL ERROR: can't init: no west.yml found",
+    ),
+    # init workspace from a manifest not inside the workspace
+    (
+        Path('..') / 'zephyr',
+        Path('.'),
+        Path('..') / 'zephyr',
+        None,
+        SystemExit,
+        "west.yml must be relative to west topdir",
     ),
 ]
 
 
 @pytest.mark.parametrize("test_case", TEST_CASES_INIT_FAILS)
 def test_init_fails(repos_tmpdir, test_case):
-    local_dir, directory, manifest_file, expected_error, expected_stderr = test_case
+    local_dir, topdir, directory, manifest_file, expected_error, expected_stderr = test_case
 
     manifest_repo = repos_tmpdir / 'repos' / 'zephyr'
     repos_tmpdir.chdir()
-    flags = _setup_test_init(manifest_repo, local_dir, directory, manifest_file)
+    flags = _setup_test_init(manifest_repo, local_dir, topdir, directory, manifest_file)
     _, stderr = cmd_raises(['init'] + flags, expected_error)
     assert expected_stderr in stderr
+
+
+def test_init_result_in_similar_worktree(repos_tmpdir):
+    zephyr_remote = repos_tmpdir / 'repos' / 'zephyr'
+    repos_tmpdir.chdir()
+    zephyr_subdir = Path('extra') / 'level' / 'zephyr'
+
+    # init a workspace from an existing local manifest
+    topdir_l = Path(repos_tmpdir) / 'topdir_l'
+    clone(str(repos_tmpdir / 'repos' / 'zephyr'), topdir_l / 'extra' / 'level' / 'zephyr')
+    flags_l = ['-l', f'-t={topdir_l}', topdir_l / zephyr_subdir]
+    _ = cmd(['init'] + flags_l)
+
+    # init a workspace from a remote manifest using the same directory argument
+    topdir_r = Path(repos_tmpdir) / 'topdir_r'
+    flags_r = [f'-m={zephyr_remote}', f'-t={topdir_r}', topdir_r / zephyr_subdir]
+    _ = cmd(['init'] + flags_r)
+
+    # Check that both resulting worktrees look the same
+    tree_l = tree(topdir_l)
+    tree_r = tree(topdir_r)
+    assert tree_l == tree_r
 
 
 def test_init_topdir_again(repos_tmpdir):
     repos_tmpdir.chdir()
     workspace = Path(repos_tmpdir) / 'ws'
     zephyr = repos_tmpdir / 'repos' / 'zephyr'
+    err_msg = "FATAL ERROR: already initialized"
 
-    # initial clone
-    cmd(['init', 'ws', '-m', zephyr])
+    # initial clone using --topdir
+    cmd(['init', '--topdir', 'ws', '-m', zephyr])
 
     # initialize west workspace again
     _, stderr = cmd_raises(['init', 'ws', '-m', zephyr], SystemExit)
-    assert "FATAL ERROR: already initialized" in stderr
+    assert err_msg in stderr
+
+    # initialize west workspace again
+    _, stderr = cmd_raises(['init', '--topdir', 'ws', '-m', zephyr], SystemExit)
+    assert err_msg in stderr
 
     # initialize west workspace again
     os.chdir(workspace)
     _, stderr = cmd_raises(['init', '--local', 'zephyr'], SystemExit)
-    assert "FATAL ERROR: already initialized" in stderr
+    assert err_msg in stderr
+
+    # initialize west workspace again
+    os.chdir(workspace.parent)
+    _, stderr = cmd_raises(['init', '-l', '--topdir', 'ws', Path('ws') / 'zephyr'], SystemExit)
+    assert err_msg in stderr
+
 
 def test_init_local_with_empty_path(repos_tmpdir):
     # Test "west init -l ." + "west update".


### PR DESCRIPTION
Fixes #774  (Successor of #775)

This PR introduces a new `--topdir` option for `west init`, allowing users to explicitly specify the west workspace directory (topdir) during initialization.  

This is particularly useful when using `--local`, as the current behavior always sets the parent of the given directory as the topdir. In addition, west is currently unable to determine both `manifest.path` and `manifest.file` from a single `directory` argument as the path can be interpreted in multiple ways (e.g. it can be split at various places).

With the new `--topdir` argument, users can now directly control where the west workspace is created.  

Parameterized tests for `west init --topdir` are added as well.

Moreover, the help texts and descriptions are (hopefully) simplified.


EDIT: superseded by:
- #953