### PR TITLE
test_project.py: fix test not to require a 500MB download.

### DIFF
--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1773,8 +1773,9 @@ def test_init_with_clone_option_depth_one(repos_tmpdir):
     # Test that 'west init -o=--depth=1' only clones depth 1
 
     west_tmpdir = repos_tmpdir / 'workspace'
+    mnft_url = str(repos_tmpdir / 'repos' / 'zephyr')
 
-    cmd(['init', '-o=--depth=1', west_tmpdir])
+    cmd(['init', '-o=--depth=1', '-o=--no-local', '-m', mnft_url, west_tmpdir])
     assert 1 == int(subprocess.check_output([GIT, 'rev-list', '--count', '--max-count=5', 'HEAD'],
                                             cwd=west_tmpdir / 'zephyr').decode().strip())
 


### PR DESCRIPTION
Fix "test_init_with_clone_option_depth_one(repos_tmpdir)" to actually use the local repos_tmpdir fixture instead of requiring a network connection to github.com/zephyr and using it to download rougly 500 MB (as of today).

This saves considerable time on slow connnections and makes it possible to run the whole test suite offline (when all dependencies are already available).

Fixes commit 1007557b92cad ("Add test cases for west init -o= option")

This wasn't obvious and was missed in code review because github.com/zephyr is the default manifest for "west init".

(and yes this was found on a plane...)

cc: @thorsten-klein 