### PR TITLE
support running and debugging `pytest` for local tree

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -156,8 +156,11 @@ Then, run the test suite locally from the top level directory::
   # Recommended in an active virtual environment
   poe all
 
-  # Manually
+  # Manually (test the installed west version)
   pytest
+
+  # Manually (test the local copy)
+  pytest -o pythonpath=src
 
 The ``all`` target from ``poe`` runs multiple tasks sequentially. Run ``poe -h``
 to get the list of configured tasks.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,8 +76,8 @@ omit = [
 [tool.coverage.report]
 omit = [
   "*/tmp/*",
-  "net-tools/scripts/test.py",
-  "subdir/Kconfiglib/scripts/test.py",
+  "*/net-tools/scripts/test.py",
+  "*/subdir/Kconfiglib/scripts/test.py",
 ]
 
 [tool.coverage.paths]

--- a/src/west/app/main.py
+++ b/src/west/app/main.py
@@ -30,6 +30,13 @@ from typing import NamedTuple
 
 import colorama
 
+if __name__ == "__main__":
+    # Prepend the west src directory to sys.path so that running this script
+    # directly in a local tree always uses the according local 'west' modules
+    # instead of any installed modules.
+    src_dir = Path(__file__).resolve().parents[2]
+    sys.path.insert(0, os.fspath(src_dir))
+
 import west.configuration
 from west import log
 from west.app.config import Config

--- a/tests/test_alias.py
+++ b/tests/test_alias.py
@@ -2,10 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import subprocess
-
 import pytest
-from conftest import cmd
+from conftest import cmd, cmd_raises
 
 
 @pytest.fixture(autouse=True)
@@ -50,10 +48,8 @@ def test_alias_infinite_recursion():
     cmd('config alias.test2 test3')
     cmd('config alias.test3 test1')
 
-    with pytest.raises(subprocess.CalledProcessError) as excinfo:
-        cmd('test1', stderr=subprocess.STDOUT)
-
-    assert 'unknown command "test1";' in str(excinfo.value.stdout)
+    exc, _ = cmd_raises('test1', SystemExit)
+    assert 'unknown command "test1";' in str(exc.value)
 
 
 def test_alias_empty():
@@ -62,10 +58,8 @@ def test_alias_empty():
     # help command shouldn't fail
     cmd('help')
 
-    with pytest.raises(subprocess.CalledProcessError) as excinfo:
-        cmd('empty', stderr=subprocess.STDOUT)
-
-    assert 'empty alias "empty"' in str(excinfo.value.stdout)
+    exc, _ = cmd_raises('empty', SystemExit)
+    assert 'empty alias "empty"' in str(exc.value)
 
 
 def test_alias_early_args():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,7 +5,6 @@
 import configparser
 import os
 import pathlib
-import subprocess
 import textwrap
 from typing import Any
 
@@ -351,13 +350,13 @@ def test_append():
 
 
 def test_append_novalue():
-    err_msg = cmd_raises('config -a pytest.foo', subprocess.CalledProcessError)
+    _, err_msg = cmd_raises('config -a pytest.foo', SystemExit)
     assert '-a requires both name and value' in err_msg
 
 
 def test_append_notfound():
     update_testcfg('pytest', 'key', 'val', configfile=LOCAL)
-    err_msg = cmd_raises('config -a pytest.foo bar', subprocess.CalledProcessError)
+    _, err_msg = cmd_raises('config -a pytest.foo bar', SystemExit)
     assert 'option pytest.foo not found in the local configuration file' in err_msg
 
 
@@ -497,7 +496,7 @@ def test_delete_cmd_all():
     assert cfg(f=ALL)['pytest']['key'] == 'local'
     cmd('config -D pytest.key')
     assert 'pytest' not in cfg(f=ALL)
-    with pytest.raises(subprocess.CalledProcessError):
+    with pytest.raises(SystemExit):
         cmd('config -D pytest.key')
 
 
@@ -511,7 +510,7 @@ def test_delete_cmd_none():
     assert cmd('config pytest.key').rstrip() == 'global'
     cmd('config -d pytest.key')
     assert cmd('config pytest.key').rstrip() == 'system'
-    with pytest.raises(subprocess.CalledProcessError):
+    with pytest.raises(SystemExit):
         cmd('config -d pytest.key')
 
 
@@ -521,7 +520,7 @@ def test_delete_cmd_system():
     cmd('config --global pytest.key global')
     cmd('config --local pytest.key local')
     cmd('config -d --system pytest.key')
-    with pytest.raises(subprocess.CalledProcessError):
+    with pytest.raises(SystemExit):
         cmd('config --system pytest.key')
     assert cmd('config --global pytest.key').rstrip() == 'global'
     assert cmd('config --local pytest.key').rstrip() == 'local'
@@ -534,7 +533,7 @@ def test_delete_cmd_global():
     cmd('config --local pytest.key local')
     cmd('config -d --global pytest.key')
     assert cmd('config --system pytest.key').rstrip() == 'system'
-    with pytest.raises(subprocess.CalledProcessError):
+    with pytest.raises(SystemExit):
         cmd('config --global pytest.key')
     assert cmd('config --local pytest.key').rstrip() == 'local'
 
@@ -547,17 +546,17 @@ def test_delete_cmd_local():
     cmd('config -d --local pytest.key')
     assert cmd('config --system pytest.key').rstrip() == 'system'
     assert cmd('config --global pytest.key').rstrip() == 'global'
-    with pytest.raises(subprocess.CalledProcessError):
+    with pytest.raises(SystemExit):
         cmd('config --local pytest.key')
 
 
 def test_delete_cmd_error():
     # Verify illegal combinations of flags error out.
-    err_msg = cmd_raises('config -l -d pytest.key', subprocess.CalledProcessError)
+    _, err_msg = cmd_raises('config -l -d pytest.key', SystemExit)
     assert 'argument -d/--delete: not allowed with argument -l/--list' in err_msg
-    err_msg = cmd_raises('config -l -D pytest.key', subprocess.CalledProcessError)
+    _, err_msg = cmd_raises('config -l -D pytest.key', SystemExit)
     assert 'argument -D/--delete-all: not allowed with argument -l/--list' in err_msg
-    err_msg = cmd_raises('config -d -D pytest.key', subprocess.CalledProcessError)
+    _, err_msg = cmd_raises('config -d -D pytest.key', SystemExit)
     assert 'argument -D/--delete-all: not allowed with argument -d/--delete' in err_msg
 
 
@@ -591,19 +590,19 @@ def test_config_precedence():
 
 
 def test_config_missing_key():
-    err_msg = cmd_raises('config pytest', subprocess.CalledProcessError)
+    _, err_msg = cmd_raises('config pytest', SystemExit)
     assert 'invalid configuration option "pytest"; expected "section.key" format' in err_msg
 
 
 def test_unset_config():
     # Getting unset configuration options should raise an error.
     # With verbose output, the exact missing option should be printed.
-    err_msg = cmd_raises('-v config pytest.missing', subprocess.CalledProcessError)
+    _, err_msg = cmd_raises('-v config pytest.missing', SystemExit)
     assert 'pytest.missing is unset' in err_msg
 
 
 def test_no_args():
-    err_msg = cmd_raises('config', subprocess.CalledProcessError)
+    _, err_msg = cmd_raises('config', SystemExit)
     assert 'missing argument name' in err_msg
 
 
@@ -611,7 +610,7 @@ def test_list():
     def sorted_list(other_args=''):
         return list(sorted(cmd('config -l ' + other_args).splitlines()))
 
-    err_msg = cmd_raises('config -l pytest.foo', subprocess.CalledProcessError)
+    _, err_msg = cmd_raises('config -l pytest.foo', SystemExit)
     assert '-l cannot be combined with name argument' in err_msg
 
     assert cmd('config -l').strip() == ''

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -1,8 +1,6 @@
 # Copyright (c) 2020, Nordic Semiconductor ASA
 
 import itertools
-import os
-import sys
 
 from conftest import cmd
 
@@ -33,13 +31,6 @@ def test_extension_help_and_dash_h(west_init_tmpdir):
     ext2out = cmd('test-extension -h')
 
     expected = EXTENSION_EXPECTED
-    if sys.platform == 'win32':
-        # Manage gratuitous incompatibilities:
-        #
-        # - multiline python strings are \n separated even on windows
-        # - the windows command help output gets an extra newline
-        expected = [os.linesep.join(case.splitlines()) + os.linesep for case in EXTENSION_EXPECTED]
-
     assert ext1out == ext2out
     assert ext1out in expected
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,5 +1,4 @@
-import subprocess
-import sys
+from conftest import cmd, cmd_subprocess
 
 import west.version
 
@@ -11,7 +10,14 @@ def test_main():
     # sane (i.e. the actual version number is printed instead of
     # simply an error message to stderr).
 
-    output_as_module = subprocess.check_output([sys.executable, '-m', 'west', '--version']).decode()
-    output_directly = subprocess.check_output(['west', '--version']).decode()
-    assert west.version.__version__ in output_as_module
-    assert output_as_module == output_directly
+    expected_version = west.version.__version__
+
+    # call west executable directly
+    output_directly = cmd(['--version'])
+    assert expected_version in output_directly
+
+    output_subprocess = cmd_subprocess('--version')
+    assert expected_version in output_subprocess
+
+    # output must be same in both cases
+    assert output_subprocess.rstrip() == output_directly.rstrip()


### PR DESCRIPTION
### Why?
I'm not sure how tests for the local source tree are currently debugged.
In my setup, I’m unable to run `pytest` directly on the local tree, and debugging is difficult because it’s not possible to step through since `subprocess` is used in the current test setup.

### Proposed Changes
This change allows running `pytest` directly, instead of only being able to run it via `uv run poe test`.
`pytest` can test either the installed West package or the local source tree, depending on how it’s invoked.
This simplifies test execution and improves compatibility with `pytest` integrations (e.g. in IDEs).

With this setup, `pytest` is fully in charge for setting up the Python environment, so testing becomes straightforward:

```bash
# Test the installed West package
pytest

# Test the local source tree
pytest -o pythonpath=src
# or
PYTHONPATH=src pytest
```

### Background
During this work, I faced that many tests used `subprocess`, which interfered with testing the local copy.
Subprocesses do not inherit the full Python environment configured by `pytest`, causing a mix between modules from the installed West package and those from the local source tree. Therefore I removed the use of subprocesses in tests wherever possible. Where subprocesses are still used, the python module (`west/app/main.py`) is called instead of `west` whereby it is ensured now that its correct modules are used by prepending correct PYTHONPATH. With those changes only one Python environment managed by `pytest` is used, ensuring consistent behavior and enabling proper debugging.

### Additional infos
`cmd()` captures only Python-level stdout and does not include output from any subprocesses launched internally.

If the code under test starts one or more subprocesses and the test verifies this combined stdout, the older `cmd_subprocess()` behavior must be used, as this function captures all stdout, both from Python itself and from any spawned subprocesses.

To simplify invoking west with corresponding modules, the `main.py` script can now be executed directly. 
This approach is used in tests by `cmd_subprocess()`, but also end users can also invoke `main.py` directly in their local tree if needed.