### PR TITLE
.github: use bad proxies to block network when testing with poe

### DIFF
--- a/.github/http_env_block.conf
+++ b/.github/http_env_block.conf
@@ -1,0 +1,12 @@
+# The purpose is to break connectivity to make sure
+# network dependencies are not accidentally introduced, see for
+# instance 9b6a6d2d05a0.
+#
+# Connections attempts to localhost are much less likely to be
+# firewalled with a very long time-out and much more likely to "fail
+# fast" instead.  Even if something is listening on these ports, the
+# chances of it being a functional HTTP proxy are close do zero.
+#
+# Tweak capitals and numbers to make these easy to "git grep"
+http_proxy=http://LocalHosT:6666
+https_proxy=http://LocalHosT:6667

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
         run: echo "import sys; print(sys.version); print(sys.platform)" | uv run -
 
       - name: Run ${{ matrix.task }} on ${{ matrix.os }} - ${{ matrix.python-version }}
-        run: uv run --frozen --directory "./check out/" poe ${{ matrix.task }}
+        run: uv run --frozen --directory "./check out/" --env-file=.github/http_env_block.conf poe ${{ matrix.task }}
 
       - name: Upload coverage reports
         if: ${{ matrix.task == 'test' }}


### PR DESCRIPTION
Break `poe` connectivity to make sure network dependencies are not
accidentally introduced, see for instance 9b6a6d2d05a0523f8cfa4694a494a4fa1bfa1109.

Note `uv` is still free to download anything it wants.

Proxies increasing productivity for once in their life!

Signed-off-by: Marc Herbert <marc.herbert@intel.com>