### PR TITLE
app: cache: Expand tilde to user home in cache paths

### DIFF
--- a/src/west/app/project.py
+++ b/src/west/app/project.py
@@ -2352,7 +2352,7 @@ class Grep(_ProjectCommand):
 
         config_option = self.config.get(f'grep.{tool}-path')
         if config_option:
-            return config_option
+            return str(expand_path(config_option))
 
         if tool == 'git-grep':
             self.die_if_no_git()

--- a/src/west/app/project.py
+++ b/src/west/app/project.py
@@ -36,6 +36,7 @@ from west.manifest import (
     _manifest_content_at,
 )
 from west.manifest import is_group as is_project_group
+from west.util import expand_path
 
 #
 # Project-related or multi-repo commands, like "init", "update",
@@ -1833,14 +1834,14 @@ class Update(_ProjectCommand):
         # Note: The url is hashed and used as a subfolder to accomodate
         # changes in the manifest.
         subdir_hash = hashlib.md5(project.url.encode('utf-8')).hexdigest()
-        return os.fspath(Path(self.auto_cache) / basename(project.url) / subdir_hash)
+        return os.fspath(expand_path(self.auto_cache) / basename(project.url) / subdir_hash)
 
     def project_cache(self, project):
         # Find the absolute path to a pre-existing local clone of a project
         # and return it. If the search fails, return None.
 
         if self.name_cache is not None:
-            maybe = Path(self.name_cache) / project.name
+            maybe = expand_path(self.name_cache) / project.name
             if maybe.is_dir():
                 self.dbg(
                     f'found {project.name} in --name-cache {self.name_cache}',
@@ -1853,7 +1854,7 @@ class Update(_ProjectCommand):
                     level=Verbosity.DBG_MORE,
                 )
         if self.path_cache is not None:
-            maybe = Path(self.path_cache) / project.path
+            maybe = expand_path(self.path_cache) / project.path
             if maybe.is_dir():
                 self.dbg(
                     f'found {project.path} in --path-cache {self.path_cache}',

--- a/src/west/util.py
+++ b/src/west/util.py
@@ -86,3 +86,8 @@ def west_topdir(start: PathType | None = None, fall_back: bool = True) -> str:
                     'Could not find a west workspace in this or any parent directory'
                 )
         cur_dir = parent_dir
+
+
+def expand_path(path: PathType) -> Path:
+    '''Returns an expanded path for the provided path-like argument.'''
+    return Path(path).expanduser()

--- a/src/west/util.py
+++ b/src/west/util.py
@@ -5,9 +5,9 @@
 '''Miscellaneous utilities.'''
 
 import os
-import pathlib
 import shlex
 import textwrap
+from pathlib import Path
 
 # What west's APIs accept for paths.
 #
@@ -29,8 +29,8 @@ def escapes_directory(path: PathType, directory: PathType) -> bool:
 
     Verifies `path` is inside of `directory`, after resolving
     both.'''
-    path_resolved = pathlib.Path(path).resolve()
-    dir_resolved = pathlib.Path(directory).resolve()
+    path_resolved = Path(path).resolve()
+    dir_resolved = Path(directory).resolve()
     try:
         path_resolved.relative_to(dir_resolved)
         ret = False
@@ -70,7 +70,7 @@ def west_topdir(start: PathType | None = None, fall_back: bool = True) -> str:
     Like west_dir(), but returns the path to the parent directory of the .west/
     directory instead, where project repositories are stored
     '''
-    cur_dir = pathlib.Path(start or os.getcwd())
+    cur_dir = Path(start or os.getcwd())
 
     while True:
         if (cur_dir / WEST_DIR).is_dir():


### PR DESCRIPTION
Allow passing a cache path starting with a '~' and expand to the user's home directory.