### PR TITLE
Support multiple west config files per config level

### DIFF
--- a/src/west/app/config.py
+++ b/src/west/app/config.py
@@ -49,6 +49,11 @@ All `west config` commands can be applied for a specific configuration level by
 providing one of the following arguments:
     --local | --system | --global
 
+For each configuration level (local, global, and system) multiple config
+file locations can be specified. To do so, set according environment variable
+to contain all paths (separated by 'os.pathsep', which is ';' on Windows or
+':' otherwise): Latter configuration files have precedence in such lists.
+
 The following command prints a list of all configuration files currently
 considered and existing (listed in the order as they are loaded):
     west config --list-paths
@@ -189,7 +194,7 @@ class Config(WestCommand):
             self.write(args)
 
     def list_paths(self, args):
-        config_paths = self.config.get_paths(args.configfile or ALL)
+        config_paths = self.config.get_existing_paths(args.configfile or ALL)
         for config_path in config_paths:
             self.inf(config_path)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,6 +69,22 @@ WINDOWS = platform.system() == 'Windows'
 
 
 @contextlib.contextmanager
+def tmp_west_topdir(path: str | Path):
+    """
+    Temporarily create a west topdir for the duration of the `with` block by
+    creating a .west directory at given path. The directory is removed again
+    when the `with` block exits.
+    """
+    west_dir = Path(path) / '.west'
+    west_dir.mkdir(parents=True)
+    try:
+        yield
+    finally:
+        # remove the directory (must be empty)
+        west_dir.rmdir()
+
+
+@contextlib.contextmanager
 def update_env(env: dict[str, str | None]):
     """
     Temporarily update the process environment variables.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -19,6 +19,18 @@ GLOBAL = config.ConfigFile.GLOBAL
 LOCAL = config.ConfigFile.LOCAL
 ALL = config.ConfigFile.ALL
 
+west_env = {
+    SYSTEM: 'WEST_CONFIG_SYSTEM',
+    GLOBAL: 'WEST_CONFIG_GLOBAL',
+    LOCAL: 'WEST_CONFIG_LOCAL',
+}
+
+west_flag = {
+    SYSTEM: '--system',
+    GLOBAL: '--global',
+    LOCAL: '--local',
+}
+
 
 @pytest.fixture(autouse=True)
 def autouse_config_tmpdir(config_tmpdir):
@@ -93,18 +105,11 @@ def test_config_global():
     assert 'pytest' not in lcl
 
 
-TEST_CASES_CONFIG_LIST_PATHS = [
-    # (flag, env_var)
-    ('--local', 'WEST_CONFIG_LOCAL'),
-    ('--system', 'WEST_CONFIG_SYSTEM'),
-    ('--global', 'WEST_CONFIG_GLOBAL'),
-]
-
-
-@pytest.mark.parametrize("test_case", TEST_CASES_CONFIG_LIST_PATHS)
-def test_config_list_paths_env(test_case):
+@pytest.mark.parametrize("location", [LOCAL, GLOBAL, SYSTEM])
+def test_config_list_paths_env(location):
     '''Test that --list-paths considers the env variables'''
-    flag, env_var = test_case
+    flag = west_flag[location]
+    env_var = west_env[location]
 
     # create the config
     cmd(f'config {flag} pytest.key val')

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -256,15 +256,15 @@ def test_system_creation():
     # Test that the system file -- and just that file -- is created on
     # demand.
 
-    assert not os.path.isfile(config._location(SYSTEM))
-    assert not os.path.isfile(config._location(GLOBAL))
-    assert not os.path.isfile(config._location(LOCAL))
+    assert not os.path.isfile(config._location(SYSTEM)[0])
+    assert not os.path.isfile(config._location(GLOBAL)[0])
+    assert not os.path.isfile(config._location(LOCAL)[0])
 
     update_testcfg('pytest', 'key', 'val', configfile=SYSTEM)
 
-    assert os.path.isfile(config._location(SYSTEM))
-    assert not os.path.isfile(config._location(GLOBAL))
-    assert not os.path.isfile(config._location(LOCAL))
+    assert os.path.isfile(config._location(SYSTEM)[0])
+    assert not os.path.isfile(config._location(GLOBAL)[0])
+    assert not os.path.isfile(config._location(LOCAL)[0])
     assert cfg(f=ALL)['pytest']['key'] == 'val'
     assert cfg(f=SYSTEM)['pytest']['key'] == 'val'
     assert 'pytest' not in cfg(f=GLOBAL)
@@ -274,15 +274,15 @@ def test_system_creation():
 def test_global_creation():
     # Like test_system_creation, for global config options.
 
-    assert not os.path.isfile(config._location(SYSTEM))
-    assert not os.path.isfile(config._location(GLOBAL))
-    assert not os.path.isfile(config._location(LOCAL))
+    assert not os.path.isfile(config._location(SYSTEM)[0])
+    assert not os.path.isfile(config._location(GLOBAL)[0])
+    assert not os.path.isfile(config._location(LOCAL)[0])
 
     update_testcfg('pytest', 'key', 'val', configfile=GLOBAL)
 
-    assert not os.path.isfile(config._location(SYSTEM))
-    assert os.path.isfile(config._location(GLOBAL))
-    assert not os.path.isfile(config._location(LOCAL))
+    assert not os.path.isfile(config._location(SYSTEM)[0])
+    assert os.path.isfile(config._location(GLOBAL)[0])
+    assert not os.path.isfile(config._location(LOCAL)[0])
     assert cfg(f=ALL)['pytest']['key'] == 'val'
     assert 'pytest' not in cfg(f=SYSTEM)
     assert cfg(f=GLOBAL)['pytest']['key'] == 'val'
@@ -292,15 +292,15 @@ def test_global_creation():
 def test_local_creation():
     # Like test_system_creation, for local config options.
 
-    assert not os.path.isfile(config._location(SYSTEM))
-    assert not os.path.isfile(config._location(GLOBAL))
-    assert not os.path.isfile(config._location(LOCAL))
+    assert not os.path.isfile(config._location(SYSTEM)[0])
+    assert not os.path.isfile(config._location(GLOBAL)[0])
+    assert not os.path.isfile(config._location(LOCAL)[0])
 
     update_testcfg('pytest', 'key', 'val', configfile=LOCAL)
 
-    assert not os.path.isfile(config._location(SYSTEM))
-    assert not os.path.isfile(config._location(GLOBAL))
-    assert os.path.isfile(config._location(LOCAL))
+    assert not os.path.isfile(config._location(SYSTEM)[0])
+    assert not os.path.isfile(config._location(GLOBAL)[0])
+    assert os.path.isfile(config._location(LOCAL)[0])
     assert cfg(f=ALL)['pytest']['key'] == 'val'
     assert 'pytest' not in cfg(f=SYSTEM)
     assert 'pytest' not in cfg(f=GLOBAL)
@@ -310,9 +310,9 @@ def test_local_creation():
 def test_local_creation_with_topdir():
     # Like test_local_creation, with a specified topdir.
 
-    system = pathlib.Path(config._location(SYSTEM))
-    glbl = pathlib.Path(config._location(GLOBAL))
-    local = pathlib.Path(config._location(LOCAL))
+    system = pathlib.Path(config._location(SYSTEM)[0])
+    glbl = pathlib.Path(config._location(GLOBAL)[0])
+    local = pathlib.Path(config._location(LOCAL)[0])
 
     topdir = pathlib.Path(os.getcwd()) / 'test-topdir'
     topdir_west = topdir / '.west'

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -127,6 +127,9 @@ def test_config_list_paths_env(location):
 
 
 def test_config_list_paths():
+    _, err_msg = cmd_raises('config --list-paths pytest.foo', SystemExit)
+    assert '--list-paths cannot be combined with name argument' in err_msg
+
     WEST_CONFIG_LOCAL = os.environ['WEST_CONFIG_LOCAL']
     WEST_CONFIG_GLOBAL = os.environ['WEST_CONFIG_GLOBAL']
     WEST_CONFIG_SYSTEM = os.environ['WEST_CONFIG_SYSTEM']


### PR DESCRIPTION
This is (another) alternative to PR #849. It is easier to discuss this solution while there is already some implementation existing.

# Why?
In a big company there are often shared configs for build system and tooling (e.g., west and its configs).
Those generic configs must be applied first and contain some default or fallback values, if the user does not specify any value in any user config.
Depending on the company and team size, multiple different configs need to be stacked.
Remember, that users must always be able to overwrite values from those generic config files within their config.

# Proposed Solution
Multiple config files can be specified in the according environment variable (`WEST_CONFIG_SYSTEM`, `WEST_CONFIG_GLOBAL`, `WEST_CONFIG_LOCAL`) for each config level (separated by `os.pathsep`).
The config files are applied in the same order as they are specified, whereby values from later files override earlier ones.

I personally like configuration through env variables, but I fear you don't.
Nevertheless I have prepared this proposal. Maybe it convinces you.

In a next step, this mechanism could also be combined with the approach from #849, so that multiple configs per config level are supported with a dropin config directory each. This would be the ultimative solution.