### PR TITLE
Support remapping of west projects urls

### DIFF
--- a/src/west/manifest-schema.yml
+++ b/src/west/manifest-schema.yml
@@ -66,6 +66,25 @@ mapping:
             required: true
             type: str
 
+  # allow some remapping of values by downstream projects
+  remapping:
+    required: false
+    type: map
+    mapping:
+      # search-replace within URLs (e.g. to use mirror URLs)
+      url:
+        required: false
+        type: seq
+        sequence:
+          - type: map
+            mapping:
+              old:
+                required: true
+                type: str
+              new:
+                required: true
+                type: str
+
   # The "projects" key specifies a sequence of "projects", each of which has a
   # remote, and may specify additional configuration.
   #

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -7,6 +7,7 @@
 Parser and abstract data types for west manifests.
 '''
 
+import copy
 import enum
 import errno
 import logging
@@ -180,6 +181,34 @@ ManifestDataType = str | dict
 # Logging
 
 _logger = logging.getLogger(__name__)
+
+
+# Representation of remapping
+
+
+class ImportRemapping:
+    """Represents `remapping` within a manifest."""
+
+    def __init__(self, manifest_data: dict | None = None):
+        """Initialize a new ImportRemapping instance."""
+        self.url_replaces: list[tuple[str, str]] = []
+        self.append(manifest_data or {})
+
+    def append(self, manifest_data: dict):
+        """Append values from a manifest data (dictionary) to this instance."""
+        for kind, values in manifest_data.get('remapping', {}).items():
+            if kind == 'url':
+                self.url_replaces += [(v['old'], v['new']) for v in values]
+
+    def merge(self, other):
+        """Merge another ImportRemapping instance into this one."""
+        if not isinstance(other, ImportRemapping):
+            raise TypeError(f"Unsupported type'{type(other).__name__}'")
+        self.url_replaces += other.url_replaces
+
+    def copy(self):
+        """Return a deep copy of this instance."""
+        return copy.deepcopy(self)
 
 
 # Type for the submodule value passed through the manifest file.
@@ -455,6 +484,9 @@ class _import_ctx(NamedTuple):
 
     # Bit vector of flags that modify import behavior.
     import_flags: 'ImportFlag'
+
+    # remapping
+    remapping: ImportRemapping
 
 
 def _imap_filter_allows(imap_filter: ImapFilterFnType, project: 'Project') -> bool:
@@ -2052,6 +2084,7 @@ class Manifest:
             current_repo_abspath=current_repo_abspath,
             project_importer=project_importer,
             import_flags=import_flags,
+            remapping=ImportRemapping(),
         )
 
     def _recursive_init(self, ctx: _import_ctx):
@@ -2073,6 +2106,10 @@ class Manifest:
         _logger.debug('loading %s', loading_what)
 
         manifest_data = self._ctx.current_data['manifest']
+
+        # append values from resolved manifest_data to current context
+        new_remapping = ImportRemapping(manifest_data)
+        self._ctx.remapping.merge(new_remapping)
 
         schema_version = str(manifest_data.get('version', SCHEMA_VERSION))
 
@@ -2322,6 +2359,7 @@ class Manifest:
             current_abspath=pathobj_abs,
             current_relpath=pathobj,
             current_data=pathobj_abs.read_text(encoding=Manifest.encoding),
+            remapping=self._ctx.remapping.copy(),
         )
         try:
             Manifest(topdir=self.topdir, internal_import_ctx=child_ctx)
@@ -2451,6 +2489,13 @@ class Manifest:
             url = url_bases[remote] + '/' + (repo_path or name)
         else:
             self._malformed(f'project {name} has no remote or url and no default remote is set')
+
+        # modify the url
+        if url:
+            url_replaces = self._ctx.remapping.url_replaces
+            for url_replace in reversed(url_replaces):
+                old, new = url_replace
+                url = url.replace(old, new)
 
         # The project's path needs to respect any import: path-prefix,
         # regardless of self._ctx.import_flags. The 'ignore' type flags
@@ -2672,6 +2717,7 @@ class Manifest:
             # We therefore use a separate list for tracking them
             # from our current list.
             manifest_west_commands=[],
+            remapping=self._ctx.remapping.copy(),
         )
         try:
             submanifest = Manifest(topdir=self.topdir, internal_import_ctx=child_ctx)

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -121,6 +121,183 @@ def test_workspace(west_update_tmpdir):
     assert wct.join('zephyr', 'subsys', 'bluetooth', 'code.c').check(file=1)
 
 
+def test_workspace_remap_url(tmpdir, repos_tmpdir):
+    remotes_dir = repos_tmpdir / 'repos'
+    workspace_dir = tmpdir / 'workspace'
+    workspace_dir.mkdir()
+
+    # use remote zephyr
+    remote_zephyr = tmpdir / 'repos' / 'zephyr'
+
+    # create a local base project with a west.yml
+    project_base = remotes_dir / 'base'
+    create_repo(project_base)
+    add_commit(
+        project_base,
+        'manifest commit',
+        # zephyr revision is implicitly master:
+        files={
+            'west.yml': textwrap.dedent('''
+            manifest:
+              remapping:
+                url:
+                - old: xxx
+                  new: yyy
+              remotes:
+                - name: upstream
+                  url-base: xxx
+              projects:
+              - name: zephyr
+                remote: upstream
+                path: zephyr-rtos
+                import: True
+              ''')
+        },
+    )
+
+    # create another project with another west.yml (stacked on base)
+    project_middle = remotes_dir / 'middle'
+    create_repo(project_middle)
+    add_commit(
+        project_middle,
+        'manifest commit',
+        # zephyr revision is implicitly master:
+        files={
+            'west.yml': f'''
+                      manifest:
+                        remapping:
+                          url:
+                          - old: yyy
+                            new: zzz
+                        projects:
+                        - name: base
+                          url: {project_base}
+                          import: True
+                      '''
+        },
+    )
+
+    # create an app that uses middle project
+    project_app = workspace_dir / 'app'
+    project_app.mkdir()
+    with open(project_app / 'west.yml', 'w') as f:
+        f.write(
+            textwrap.dedent(f'''\
+            manifest:
+              remapping:
+                url:
+                  - old: zzz
+                    new: {os.path.dirname(remote_zephyr)}
+              projects:
+                - name: middle
+                  url: {project_middle}
+                  import: True
+        ''')
+        )
+
+    # init workspace in projects_dir (project_app's parent)
+    cmd(['init', '-l', project_app])
+
+    # update workspace in projects_dir
+    cmd('update', cwd=workspace_dir)
+
+    # zephyr projects from base are cloned
+    for project_subdir in [
+        Path('subdir') / 'Kconfiglib',
+        'tagged_repo',
+        'net-tools',
+        'zephyr-rtos',
+    ]:
+        assert (workspace_dir / project_subdir).check(dir=1)
+        assert (workspace_dir / project_subdir / '.git').check(dir=1)
+
+
+def test_workspace_remap_url_from_self_import(repos_tmpdir):
+    remote_zephyr = repos_tmpdir / 'repos' / 'zephyr'
+    projects_dir = repos_tmpdir / 'projects'
+    projects_dir.mkdir()
+
+    # create a local base project with a west.yml
+    project_base = projects_dir / 'base'
+    project_base.mkdir()
+    with open(project_base / 'west.yml', 'w') as f:
+        f.write(
+            textwrap.dedent('''\
+            manifest:
+              remotes:
+                - name: upstream
+                  url-base: nonexistent
+              projects:
+              - name: zephyr
+                remote: upstream
+                path: zephyr-rtos
+                import: True
+        ''')
+        )
+
+    # create another project with another west.yml (stacked on base)
+    project_middle = projects_dir / 'middle'
+    project_middle.mkdir()
+    with open(project_middle / 'west.yml', 'w') as f:
+        f.write(
+            textwrap.dedent('''\
+            manifest:
+              self:
+                import: ../base
+        ''')
+        )
+
+    # create another project with another west.yml (stacked on base)
+    project_another = projects_dir / 'another'
+    project_another.mkdir()
+    with open(project_another / 'west.yml', 'w') as f:
+        f.write(
+            textwrap.dedent('''\
+            manifest:
+              # this should not have any effect since there are no imports
+              remapping:
+                url:
+                  - old: nonexistent
+                    new: from-another
+        ''')
+        )
+
+    # create another project with another west.yml (stacked on base)
+    project_app = projects_dir / 'app'
+    project_app.mkdir()
+    with open(project_app / 'west.yml', 'w') as f:
+        f.write(
+            textwrap.dedent(f'''\
+            manifest:
+              remapping:
+                url:
+                  - old: nonexistent
+                    new: {os.path.dirname(remote_zephyr)}
+              self:
+                import:
+                - ../another
+                - ../middle
+        ''')
+        )
+
+    # init workspace in projects_dir (project_app's parent)
+    cmd(['init', '-l', project_app])
+
+    # update workspace in projects_dir
+    cmd('update', cwd=projects_dir)
+
+    ws = projects_dir
+    # zephyr projects from base are cloned
+    for project_subdir in [
+        Path('subdir') / 'Kconfiglib',
+        'tagged_repo',
+        'net-tools',
+        'zephyr-rtos',
+    ]:
+        assert (ws / project_subdir).check(dir=1)
+        assert (ws / project_subdir / '.git').check(dir=1)
+
+
 def test_list(west_update_tmpdir):
     # Projects shall be listed in the order they appear in the manifest.
     # Check the behavior for some format arguments of interest as well.


### PR DESCRIPTION
Proposal for #615

Support is added for a new `remapping` section in the west manifest.

Under the `url` key, users can define search-and-replace patterns (whereby `old` will be replaced with `new`).
Those patterns are applied to all project URLs during project import (recursively).
This allows downstream projects to modify remote URLs while keeping all other metadata (e.g. original `revision`).
This is extremely helpful when downstream projects just want to use mirrored repositories.

## Usage
In general you can specify search-replace patterns for `url` (or substrings from `url`) via `west.yml`.
It is a simple search-replace (no regex).
This means, for example you can add following remapping-block to your `west.yml` in case you have mirrored all zephyr repositories into your own "mirrors" organization in your company Github instance:

```
manifest:
  remapping:
    url:
      - old: github.com/zephyr-rtos
        new: github.company.com/mirrors
```

If the repositories are mirrored to different Github organizations or instances, you can apply multiple (more fine-granular) remapping-patterns.

```
manifest:
  remapping:
    url:
      - old: github.com/foo/libfoo
        new: github.company.com/foo/mirrored-libfoo
      - old: github.com/foo/libbar
        new: github.othercompany.com/forked/libbar
```