### PR TITLE
support 'west config --list-paths'

### DIFF
--- a/src/west/configuration.py
+++ b/src/west/configuration.py
@@ -181,6 +181,16 @@ class Configuration:
         self._global = _InternalCF.from_path(self._global_path)
         self._local = _InternalCF.from_path(self._local_path)
 
+    def get_paths(self, location: ConfigFile = ConfigFile.ALL):
+        ret = []
+        if self._global and location in [ConfigFile.GLOBAL, ConfigFile.ALL]:
+            ret.append(self._global.path)
+        if self._system and location in [ConfigFile.SYSTEM, ConfigFile.ALL]:
+            ret.append(self._system.path)
+        if self._local and location in [ConfigFile.LOCAL, ConfigFile.ALL]:
+            ret.append(self._local.path)
+        return ret
+
     def get(
         self, option: str, default: str | None = None, configfile: ConfigFile = ConfigFile.ALL
     ) -> str | None:


### PR DESCRIPTION
Extracted from #867

# Why?

It is helpful for users to see which configuration files are currently being used by `west`, and in which order they are applied.  
This makes it easier to debug configuration issues and understand where specific settings originate from.

# Proposal

Introduce a new command-line option `--list-paths`, which prints all configuration files that are currently considered and exist. 
The files are listed in the order they are loaded, as later files override values from earlier ones.

This option can be combined with `--local`, `--global`, or `--system` to list only the path for a specific configuration level.
