### PR TITLE
pyproject.toml: add new poe target "types-extra"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,6 +118,9 @@ env = {PYTHONIOENCODING = "utf-8"}
 lint = "ruff check ."
 format = "ruff format"
 types = "mypy --package west"
+# work in progress
+types-extra = "mypy --package west --check-untyped-defs"
+
 all = ["test", "lint", "format", "types"]
 
 # Github specific tasks

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -2854,7 +2854,9 @@ class _PatchedConfiguration(Configuration):
         super().__init__(*args, **kwargs)
         self.__patch_dict = patch_dict
 
-    def get(self, option, **kwargs):
+    def get(
+        self, option: str, default: str | None = None, configfile: ConfigFile = ConfigFile.ALL
+    ) -> str | None:
         if option in self.__patch_dict:
             return self.__patch_dict[option]
-        return super().get(option, **kwargs)
+        return super().get(option, default, configfile)


### PR DESCRIPTION
As kindly suggested by the existing "types" target:
```
$ uv run poe types

Poe => mypy --package west

src/west/app/project.py:1364: note: By default the bodies of untyped
functions are not checked, consider using --check-untyped-defs
[annotation-unchecked]

Do not include in the "all" group because it's not passing.
```