### PR TITLE
enable `--check-untyped-defs` flag for `mypy`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,7 @@ env = {PYTHONIOENCODING = "utf-8"}
 [tool.poe.tasks]
 lint = "ruff check ."
 format = "ruff format"
-types = "mypy --package west"
+types = "mypy --package west --check-untyped-defs"
 all = ["test", "lint", "format", "types"]
 
 # Github specific tasks

--- a/src/west/commands.py
+++ b/src/west/commands.py
@@ -157,6 +157,7 @@ class WestCommand(ABC):
             a fatal error.
         :param verbosity: command output verbosity level; can be changed later
         '''
+        self.app = None
         self.name: str = name
         self.help: str = help
         self.description: str = description
@@ -726,14 +727,14 @@ def _commands_module_from_file(file):
     # - Windows and macOS have case insensitive names
     # - Windows accepts slash or backslash as separator
     # - POSIX operating systems have symlinks
-    pathobj = Path(file).resolve()
+    pathobj = Path(file).resolve().as_posix()
     if pathobj in _EXT_MODULES_CACHE:
         return _EXT_MODULES_CACHE[pathobj]
 
     mod_name = next(_EXT_MODULES_NAME_IT)
     spec = importlib.util.spec_from_file_location(mod_name, os.fspath(pathobj))
-    mod = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(mod)
-    _EXT_MODULES_CACHE[file] = mod
-
-    return mod
+    if spec and spec.loader:
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        _EXT_MODULES_CACHE[file] = mod
+        return mod

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -2854,7 +2854,9 @@ class _PatchedConfiguration(Configuration):
         super().__init__(*args, **kwargs)
         self.__patch_dict = patch_dict
 
-    def get(self, option, **kwargs):
+    def get(
+        self, option: str, default: str | None = None, configfile: ConfigFile = ConfigFile.ALL
+    ) -> str | None:
         if option in self.__patch_dict:
             return self.__patch_dict[option]
-        return super().get(option, **kwargs)
+        return super().get(option, default, configfile)


### PR DESCRIPTION
As kindly suggested by the existing "types" target:
```
$ uv run poe types

Poe => mypy --package west

src/west/app/project.py:1364: note: By default the bodies of untyped
functions are not checked, consider using --check-untyped-defs
[annotation-unchecked]
```

Therefore `--check-untyped-defs` flag is enabled for `uv run poe types` and existing code issues are "fixed".