### PR TITLE
fix: `--list-paths` should print config files in correct order

### DIFF
--- a/src/west/configuration.py
+++ b/src/west/configuration.py
@@ -185,10 +185,10 @@ class Configuration:
 
     def get_paths(self, location: ConfigFile = ConfigFile.ALL) -> list[Path]:
         ret = []
-        if self._global and location in [ConfigFile.GLOBAL, ConfigFile.ALL]:
-            ret.append(self._global.path)
         if self._system and location in [ConfigFile.SYSTEM, ConfigFile.ALL]:
             ret.append(self._system.path)
+        if self._global and location in [ConfigFile.GLOBAL, ConfigFile.ALL]:
+            ret.append(self._global.path)
         if self._local and location in [ConfigFile.LOCAL, ConfigFile.ALL]:
             ret.append(self._local.path)
         return ret

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -139,16 +139,16 @@ def test_config_list_paths():
     assert (
         stdout.splitlines()
         == textwrap.dedent(f'''\
-        {WEST_CONFIG_GLOBAL}
         {WEST_CONFIG_SYSTEM}
+        {WEST_CONFIG_GLOBAL}
         {WEST_CONFIG_LOCAL}
         ''').splitlines()
     )
 
     # do not list any configs if no config files currently exist
     # (Note: even no local config exists, same as outside any west workspace)
-    pathlib.Path(WEST_CONFIG_GLOBAL).unlink()
     pathlib.Path(WEST_CONFIG_SYSTEM).unlink()
+    pathlib.Path(WEST_CONFIG_GLOBAL).unlink()
     pathlib.Path(WEST_CONFIG_LOCAL).unlink()
     stdout = cmd('config --list-paths')
     assert stdout.splitlines() == []


### PR DESCRIPTION
The order of config files which is currently listed in wrong order.
Local config must have highest precedence, and system config lowest.