### PR TITLE
Fix python-xdist failure and run tests 6 times faster

### DIFF
--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -2675,6 +2675,12 @@ def test_import_project_release_dir(tmpdir):
     # Tests for a workspace that imports a directory from a project
     # at a fixed release.
 
+    # Don't run in a random cwd, this could be an existing west
+    # workspace and would fail the `west init -l ...` below.  We don't
+    # want this test to depend on any special cwd either so the root is
+    # a reasonable choice.
+    os.chdir(tmpdir.parts()[0])
+
     remotes = tmpdir / 'remotes'
     empty_project = remotes / 'empty_project'
     create_repo(empty_project)


### PR DESCRIPTION
Generally speaking, tests sensitive to the current directory should not
run from a random directory.

The current directory of test_import_project_release_dir() was either
the current directory or wherever the previous test left it, which could
be inside a random west workspace. This crashed the `west init -l
/tmp/pytest/...` command used by the test.

Found thanks to pytest-xdist and pytest -n 20, but there is more
"reliable" way to reproduce: move west.git instead a west workspace and
run:

   pytest -k test_import_project_release_dir

This fails with the "already initialized" error.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>