### PR TITLE
conftest.py: test the local west, not the installed one

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,9 @@ from pathlib import Path, PurePath
 
 import pytest
 
+# https://chrisyeh96.github.io/2017/08/08/definitive-guide-python-imports.html#case-3-importing-from-parent-directory
+# Test the local west and not some other, installed version.
+sys.path.insert(1, os.path.join(sys.path[0], '../src'))
 from west.app import main
 
 GIT = shutil.which('git')


### PR DESCRIPTION
Discovered by chance after uninstall west and trying to run pytest directly. This was hopefully not a problem when running test with "uv"?

This issue was probably introduced by #859. Commit 879bb019276b91 seems relevant too.