### PR TITLE
Fix: Clone from auto-cache fails when the repository’s remote default branch changes

### DIFF
--- a/src/west/app/project.py
+++ b/src/west/app/project.py
@@ -1821,29 +1821,6 @@ class Update(_ProjectCommand):
             )
             # Reset the remote's URL to the project's fetch URL.
             project.git(['remote', 'set-url', project.remote_name, project.url])
-            # Make sure we have a detached HEAD so we can delete the
-            # local branch created by git clone.
-            project.git('checkout --quiet --detach HEAD')
-            # Find the name of any local branch created by git clone.
-            # West commits to only touching 'manifest-rev' in the
-            # local branch name space.
-            local_branches = (
-                project.git(
-                    ['for-each-ref', '--format', '%(refname)', 'refs/heads/*'], capture_stdout=True
-                )
-                .stdout.decode('utf-8')
-                .splitlines()
-            )
-            # This should contain at most one branch in current
-            # versions of git, but we might as well get them all just
-            # in case that changes.
-            for branch in local_branches:
-                if not branch:
-                    continue
-                # This is safe: it can't be garbage collected by git before we
-                # have a chance to use it, because we have another ref, namely
-                # f'refs/remotes/{project.remote_name}/{branch}'.
-                project.git(['update-ref', '-d', branch])
 
     def project_auto_cache(self, project):
         if self.auto_cache is None:

--- a/src/west/app/project.py
+++ b/src/west/app/project.py
@@ -2010,38 +2010,15 @@ class Update(_ProjectCommand):
             project.git(['remote', 'add', '--', project.remote_name, project.url])
         else:
             self.small_banner(f'{project.name}: cloning from {cache_dir}')
-            # Clone the project from a local cache repository. Set the
-            # remote name to the value that would be used without a
-            # cache.
+            # Clone the project into the workspace from a local cache
+            # repository. Set the remote name to the value that would be
+            # used without a cache.
             project.git(
                 ['clone', '--origin', project.remote_name, cache_dir, project.abspath],
                 cwd=self.topdir,
             )
             # Reset the remote's URL to the project's fetch URL.
             project.git(['remote', 'set-url', '--', project.remote_name, project.url])
-            # Make sure we have a detached HEAD so we can delete the
-            # local branch created by git clone.
-            project.git('checkout --quiet --detach HEAD')
-            # Find the name of any local branch created by git clone.
-            # West commits to only touching 'manifest-rev' in the
-            # local branch name space.
-            local_branches = (
-                project.git(
-                    ['for-each-ref', '--format', '%(refname)', 'refs/heads/*'], capture_stdout=True
-                )
-                .stdout.decode('utf-8')
-                .splitlines()
-            )
-            # This should contain at most one branch in current
-            # versions of git, but we might as well get them all just
-            # in case that changes.
-            for branch in local_branches:
-                if not branch:
-                    continue
-                # This is safe: it can't be garbage collected by git before we
-                # have a chance to use it, because we have another ref, namely
-                # f'refs/remotes/{project.remote_name}/{branch}'.
-                project.git(['update-ref', '-d', branch])
 
     def project_auto_cache(self, project):
         if self.auto_cache is None:

--- a/tests/test_project_caching.py
+++ b/tests/test_project_caching.py
@@ -408,6 +408,19 @@ def test_update_auto_cache_skipped_remote_update(tmpdir):
     for msg in msgs:
         assert msg in stdout
 
+    # Rename remote default branches and update remote (results in dangling remote HEAD).
+    subprocess.check_call([GIT, 'branch', '-m', 'master', 'renamed-master'], cwd=foo_remote)
+    subprocess.check_call([GIT, 'branch', '-m', 'master', 'changed/main'], cwd=bar_remote)
+    subprocess.check_call([GIT, 'remote', 'update', '--prune'], cwd=auto_cache_dir_foo)
+    subprocess.check_call([GIT, 'remote', 'update', '--prune'], cwd=auto_cache_dir_bar)
+
+    # west update must succeed
+    setup_workspace_and_west_update(
+        tmpdir / 'workspace5',
+        foo_head='renamed-master',
+        bar_head='changed/main',
+    )
+
 
 def test_update_caches_priorities(tmpdir):
     # Test that the correct cache is used if multiple caches are specified


### PR DESCRIPTION
### Issue: Auto-cache fails when cached repository’s default branch changes

We’re encountering failures when using **auto-cache** in scenarios where the **default branch name of a cached repository has changed**. @pdgendt has been able to reproduce this issue locally as well.

During analysis, we observed that `git remote update --prune` completes successfully. However, attempting to clone a repository from the auto-cache into the workspace subsequently results in a valid clone, but with no HEAD existing.

This behavior is resolved with git (2.48.0). Without the fix from this PR, the added test fails with older git (before 2.48.0, e.g. 2.34.1 from Ubuntu 22), but it passes when newer git (>=2.48.0) is used.
Reference to git Release Notes: https://github.com/git/git/blob/master/Documentation/RelNotes/2.48.0.adoc
```
When "git fetch $remote" notices that refs/remotes/$remote/HEAD is missing and discovers what branch the other side points with its HEAD, refs/remotes/$remote/HEAD is updated to point to it.
```

A typical `west update` error looks like this:
```
--- trusted-firmware-m: cloning from /var/tmp/west/auto-cache/trusted-firmware-m/23a33554f8237323fc95b384be1b9463
Cloning into '/home/klt1re/work/GIT/uc-platform-ws/modules/tee/tf-m/trusted-firmware-m'...
done.
warning: remote HEAD refers to nonexistent ref, unable to checkout
fatal: git checkout: --detach does not take a path argument 'HEAD'
```

### Root Cause

When a remote default branch is renamed and the auto-cache is updated with remote, the auto-cache becomes corrupt as HEAD points to an invalid remote HEAD

Git clone from such a corrupt auto-cache succeeds, but with a warning `warning: remote HEAD refers to nonexistent ref, unable to checkout.`. Subsequent git commands using HEAD may fail. For example, the next git command in `west update` is `git checkout --detach HEAD`, which now fails because HEAD does not exist.

### First Approach: Ensure HEAD exists

After cloning, run `git checkout {project.revision}` to make sure that HEAD exists. Subsequent `git checkout --detach HEAD` will succeed. But in this case, the auto-cache still remains corrupt. So I personally prefer a solution that fixes the auto-cache, instead of just fixing the workspace.  


### Second Approach: Fixing the auto-cache

After running `git remote update --prune`, we need to set HEAD to remote HEAD within the auto-cache.
This is addressed by:

1. Reading the current remote HEAD using:
   `git ls-remote --symref origin HEAD`
2. Updating the local HEAD to match the remote using:
   `git symbolic-ref HEAD <remote-HEAD>`

This ensures the cache stays in sync with the upstream repository’s default branch and prevents the checkout errors described above. This solution helps to ensure that HEAD will always exist after cloning from the cache.

### Third Approach: Avoid running into the issue by not using HEAD at all

Avoid using `HEAD` at all during `west update` after cloning a repository from a cache into the workspace.

**This is the approach implemented in this PR.** It doesn't depend on any particular git version's `HEAD`-repair behavior (unlike the git 2.48.0 mitigation noted above), and it doesn't require any extra logic to keep the auto-cache's own `HEAD` in sync (the second approach), since nothing else in `west` reads `HEAD` from either the auto-cache or the freshly cloned workspace repository — the subsequent checkout of the actual revision is already resolved from `manifest-rev`, independent of `HEAD`.
