### PR TITLE
project: die if the --manifest-file argument is not relative

### DIFF
--- a/src/west/app/project.py
+++ b/src/west/app/project.py
@@ -281,6 +281,9 @@ below.
         if args.local and (args.manifest_url or args.manifest_rev or args.clone_opt):
             self.die('-l cannot be combined with -m, -o or --mr')
 
+        if args.manifest_file is not None and Path(args.manifest_file).is_absolute():
+            self.die(f'--mf {args.manifest_file} argument is not relative')
+
         self.die_if_no_git()
 
         if args.local:


### PR DESCRIPTION
This was found while testing the --topdir pull request #854 in progress. It's valid with or without it.