### PR TITLE
A couple fixes to use more inclusive language

### DIFF
--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -174,7 +174,7 @@ def _update_project_filter(project_filter: ProjectFilterType, option_value: str 
 
 
 # The parsed contents of a manifest YAML file as returned by _load(),
-# after sanitychecking with validate().
+# after schema validation with validate().
 ManifestDataType = str | dict
 
 # Logging
@@ -783,7 +783,7 @@ class ImportFlag(enum.IntFlag):
 
 
 def _flags_ok(flags: ImportFlag) -> bool:
-    # Sanity-check the combination of flags.
+    # Validate the combination of flags.
     F_I = ImportFlag.IGNORE
     F_FP = ImportFlag.FORCE_PROJECTS
     F_IP = ImportFlag.IGNORE_PROJECTS
@@ -2230,7 +2230,7 @@ class Manifest:
         )
 
     def _assert_imports_ok(self) -> None:
-        # Sanity check that we aren't calling code that does importing
+        # Check that we aren't calling code that does importing
         # if the flags tell us not to.
         #
         # Could be deleted if this feature stabilizes and we never hit

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -92,7 +92,7 @@ def test_config_global():
     assert cmd('config pytest.global').rstrip() == 'bar'
     assert cmd('config --global pytest.global').rstrip() == 'bar'
 
-    # Sanity check that we can create multiple variables per section.
+    # Check that we can create multiple variables per section.
     # Just use the API here; there's coverage already that the command line
     # and API match.
     cmd('config --global pytest.global2 foo2')

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -413,7 +413,7 @@ def test_manifest_freeze(west_update_tmpdir):
     #   manifest
     # - attributes are listed in NURPCW order (name, url, ...)
     # - all revisions are full 40-character SHAs
-    # - there isn't any random YAML tag crap
+    # - there isn't any random YAML tag
     expected_res = [
         '^manifest:$',
         '^  projects:$',


### PR DESCRIPTION
Replace "sanity" / "sanity check" with better alternatives
Drop an occurrence of a swear word