### PR TITLE
manifest: restore "path: ." ability but with a warning

### DIFF
--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -2523,19 +2523,21 @@ class Manifest:
         if ret_norm[0] in '/\\' or os.path.isabs(ret_norm):
             self._malformed(
                 f'project "{ret.name}" has absolute path '
-                f'{ret.path}; this must be relative to the '
+                f'"{ret.path}"; this must be relative to the '
                 f'workspace topdir' + (f' ({self.topdir})' if self.topdir else '')
             )
 
         if ret_norm.startswith('..'):
             self._malformed(
-                f'project "{name}" path {ret.path} '
-                f'normalizes to {ret_norm}, which escapes '
+                f'project "{name}" path "{ret.path}" '
+                f'normalizes to "{ret_norm}", which escapes '
                 f'the workspace topdir'
             )
 
         if Path(ret_norm).parts[0] == util.WEST_DIR:
-            self._malformed(f'project "{name}" path {ret.path} is in the {util.WEST_DIR} directory')
+            self._malformed(
+                f'project "{name}" path "{ret.path}" is in the {util.WEST_DIR} directory'
+            )
 
         return ret
 

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -2534,7 +2534,19 @@ class Manifest:
                 f'the workspace topdir'
             )
 
-        if Path(ret_norm).parts[0] == util.WEST_DIR:
+        _path = Path(ret_norm)
+
+        # Unsupported, see https://github.com/zephyrproject-rtos/zephyr/commit/7d40091fbfedfc
+        if _path == Path('.'):
+            _logger.warning("Making the topdir a git clone is not supported; do not report bugs.")
+            return ret
+
+        # Can any other Path have zero part? Just in case, provide a decent error message
+        # instead of "index out of range" (see #910)
+        if len(_path.parts) < 1:
+            self._malformed(f'project "{name}" path "{ret.path}" has no part?! ({_path})')
+
+        if _path.parts[0] == util.WEST_DIR:
             self._malformed(
                 f'project "{name}" path "{ret.path}" is in the {util.WEST_DIR} directory'
             )

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -27,6 +27,7 @@ from conftest import (
     add_tag,
     check_proj_consistency,
     checkout_branch,
+    cmd,
     create_branch,
     create_repo,
     create_workspace,
@@ -490,6 +491,25 @@ def test_project_paths_with_repo_path():
     expected2 = Project('testproject_v2', 'https://url1.com/testproject', revision='v2.0')
     check_proj_consistency(m.projects[1], expected1)
     check_proj_consistency(m.projects[2], expected2)
+
+
+# Officially _not_ supported! Was actually broken from 1.3 to 1.5
+# See #910 and zephyr commit 7d40091fbfedfc
+# If this gets in the way of some great new feature then feel free to remove this test.
+def test_project_path_is_topdir(repos_tmpdir):
+    mnft_dir = Path('zephyr')
+    mnft_file = mnft_dir / 'west.yml'
+
+    with open(mnft_file, encoding='utf-8') as f:
+        mnft = f.read()
+    assert 'path: subdir/Kconfiglib' in mnft
+    with open(mnft_file, 'w', encoding='utf-8') as f:
+        f.write(mnft.replace('path: subdir/Kconfiglib', 'path: .'))
+
+    cmd(['init', '-l', mnft_dir])
+    for c in ['help', 'list', 'update', 'list']:
+        outputs = cmd(c)
+        assert 'WARNING:' in outputs
 
 
 def test_project_clone_depth():


### PR DESCRIPTION
3 commits. Main commit:

manifest: restore "path: ." ability but with a warning

Restore the ability to have a project at the top level but with an
"unsupported" warning printed every time.

Fixes v1.3 commit https://github.com/zephyrproject-rtos/west/commit/2b2d3f2685e688974690c66dfeb1c8d878c071fd ("manifest: Do not allow projects inside
the west directory") which accidentally broke it with an pretty obscure
backtrace:
```
File "python/site-packages/west/manifest.py", line 2460, in _load_project
    if Path(ret_norm).parts[0] == util.WEST_DIR:
       ~~~~~~~~~~~~~~~~~~~~^^^
IndexError: tuple index out of range
```
Fixes issue number https://github.com/zephyrproject-rtos/west/issues/910

This is STILL not supported!
