### PR TITLE
feat: add --topdir commandline option

### DIFF
--- a/src/west/app/main.py
+++ b/src/west/app/main.py
@@ -560,6 +560,13 @@ class WestApp:
         )
 
         parser.add_argument(
+            '-t',
+            '--topdir',
+            default=None,
+            help='''Override west topdir.''',
+        )
+
+        parser.add_argument(
             '-q',
             '--quiet',
             default=0,

--- a/src/west/app/project.py
+++ b/src/west/app/project.py
@@ -308,8 +308,12 @@ below.
         manifest_dir = Path(args.directory or os.getcwd()).resolve()
         manifest_filename = args.manifest_file or 'west.yml'
         manifest_file = manifest_dir / manifest_filename
-        topdir = manifest_dir.parent
         rel_manifest = manifest_dir.name
+        # If user overrides topdir, use that.
+        if args.topdir is not None:
+            topdir = Path(args.topdir).resolve()
+        else:
+            topdir = manifest_dir.parent
         west_dir = topdir / WEST_DIR
 
         if not manifest_file.is_file():
@@ -320,7 +324,7 @@ below.
         self.create(west_dir)
         os.chdir(topdir)
         self.config = Configuration(topdir=topdir)
-        self.config.set('manifest.path', os.fspath(rel_manifest))
+        self.config.set('manifest.path', str(manifest_dir))
         self.config.set('manifest.file', manifest_filename)
 
         return topdir


### PR DESCRIPTION
## Description

This removes the enforcement of "supported topologies" (https://docs.zephyrproject.org/latest/develop/west/workspaces.html#topologies-supported) and enables users to have whatever kind of topology they want.

This also enables the following workflow:
```bash
# Clone the project using regular git, just like every other project
# in the world.
git clone git@github.com:foo/my-project

# Build the project using west.
west --topdir=./build init --local .
cd build
west build <target> <etc>
```

This solution also sidesteps the odd restriction that the topdir should be located in `..`, which can result in polluting random locations and makes some CI workflows difficult.

## Known Issues

For some reason, having `manifest.path` set as an absolute path produces a warning. If any maintainers can explain why this is the case, that would be much appreciated.
Due to this, the unit test suite is failing.