### PR TITLE
manifest.py: stop catching TypeError in validate() and obfuscating

### DIFF
--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -1612,8 +1612,6 @@ class Manifest:
             raise ManifestVersionError(mv.version, file=self._ctx.current_abspath) from mv
         except MalformedManifest as mm:
             self._malformed(mm.args[0], parent=mm)
-        except TypeError as te:
-            self._malformed(te.args[0], parent=te)
 
         # Finish loading the validated data.
 


### PR DESCRIPTION
This is partial revert of 23b8525181a4 ("manifest: improve validate() handling"). There is no reason for validate() to expect anything else than a string or a dict unless there is some massive internal issue or some cpython issue like the one I found in #908. In the latter cases, we _do_ want a stack trace printed. Seeing the ruamel stack trace shared in #908 would have saved me hours of debugging. This commit prints that stack trace.