### PR TITLE
manifest: give _ManifestImportDepth exception a __str__()

### DIFF
--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -739,7 +739,8 @@ class ManifestVersionError(Exception):
 
 class _ManifestImportDepth(ManifestImportFailed):
     # A hack to signal to main.py what happened.
-    pass
+    def __str__(self):
+        return f'Import of {self.imp} failed: import level too deep'
 
 
 #

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -2968,7 +2968,7 @@ def test_import_loop_detection_self(manifest_repo):
            import: west.yml
         ''')
 
-    with pytest.raises(_ManifestImportDepth):
+    with pytest.raises(_ManifestImportDepth, match=r'\.yml.*too.*deep'):
         MF()
 
 


### PR DESCRIPTION
Stop inheriting the superclass string which was the very generic and misleading "Could not import foo.yml, is it present in your manifest repository?"

Found while debugging xdist issue #908.