### PR TITLE
fix: Allow west commands to be imported from a project subdirectory if manifest is located in subdirectory

### DIFF
--- a/src/west/commands.py
+++ b/src/west/commands.py
@@ -701,13 +701,18 @@ def _ext_specs(project):
         except pykwalify.errors.SchemaError as e:
             raise ExtensionCommandError from e
 
+        # Resolve west command extensions relative to the manifest root for
+        # import-derived west-commands entries, otherwise project root.
+        mfst_dir = project._west_commands_manifest_dirs.get(cmd)
+        base_dir = os.path.join(project.abspath, mfst_dir) if mfst_dir else project.abspath
+
         for commands_desc in commands_spec['west-commands']:
-            ret.extend(_ext_specs_from_desc(project, commands_desc))
+            ret.extend(_ext_specs_from_desc(project, commands_desc, base_dir))
     return ret
 
 
-def _ext_specs_from_desc(project, commands_desc):
-    py_file = os.path.join(project.abspath, commands_desc['file'])
+def _ext_specs_from_desc(project, commands_desc, base_dir):
+    py_file = os.path.join(base_dir, commands_desc['file'])
 
     # Verify the YAML's python file doesn't escape the project directory.
     if escapes_directory(py_file, project.abspath):

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -76,6 +76,7 @@ SCHEMA_VERSION = '1.2'
 # The value of a west-commands as passed around during manifest
 # resolution. It can become a list due to resolving imports, even
 # though it's just a str in each individual file right now.
+# TODO: WestCommands should be promoted to a Python class, see issue #959
 WestCommandsType = str | list[str]
 
 # Type for the importer callback passed to the manifest constructor.
@@ -907,6 +908,9 @@ class Project:
         self.groups: GroupsType = groups or []
         self.userdata: Any = userdata
 
+        # Internal helpers
+        self._west_commands_manifest_dirs: dict[str, str] = dict()
+
     @property
     def path(self) -> str:
         return self._path
@@ -1266,6 +1270,7 @@ class ManifestProject(Project):
 
         # Extension commands.
         self.west_commands = _west_commands_list(west_commands)
+        self._west_commands_manifest_dirs: dict[str, str] = dict()
 
     @property
     def abspath(self) -> str | None:
@@ -2723,6 +2728,12 @@ class Manifest:
         west_commands_to_merge = [
             (mfst_dir / cmd).as_posix() for cmd in submanifest._ctx.manifest_west_commands
         ]
+
+        # Keep track of which imported manifest directory each adjusted
+        # west-commands entry came from, so command Python files can be
+        # resolved relative to that manifest root later in commands.py.
+        for adjusted_cmd in west_commands_to_merge:
+            project._west_commands_manifest_dirs.setdefault(adjusted_cmd, str(mfst_dir))
 
         project.west_commands = _west_commands_merge(project.west_commands, west_commands_to_merge)
 

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -2637,13 +2637,19 @@ class Manifest:
 
         _logger.debug(f'resolving import {path} for {project}')
         imported = self._import_content_from_project(project, path)
-        if imported is None:
-            # This can happen if self._ctx.project_importer returns None.
-            # It means there's nothing to do.
-            return
 
-        for data in imported:
-            self._import_data_from_project(project, data, None)
+        match imported:
+            case None:
+                # This can happen if self._ctx.project_importer returns None.
+                # It means there's nothing to do.
+                return
+            case str():
+                self._import_data_from_project(project, imported, path, directory_import=False)
+            case list():
+                for data in imported:
+                    self._import_data_from_project(project, data, path, directory_import=True)
+            case _:
+                raise AssertionError(f'imported content has unexpected type {type(imported)}')
 
         _logger.debug(f'done resolving import {path} for {project}')
 
@@ -2653,25 +2659,40 @@ class Manifest:
         _logger.debug(f'resolving import {imap} for {project}')
 
         imported = self._import_content_from_project(project, imap.file)
-        if imported is None:
-            return
-
-        for data in imported:
-            self._import_data_from_project(project, data, imap)
+        match imported:
+            case None:
+                return
+            case str():
+                self._import_data_from_project(project, imported, imap, directory_import=False)
+            case list():
+                for data in imported:
+                    self._import_data_from_project(project, data, imap, directory_import=True)
+            case _:
+                raise AssertionError(f'imported content has unexpected type {type(imported)}')
 
         _logger.debug(f'done resolving import {imap} for {project}')
 
     def _import_data_from_project(
-        self, project: Project, data: Any, imap: _import_map | None
+        self,
+        project: Project,
+        data: Any,
+        imap_or_mfpath: _import_map | str,
+        directory_import: bool,
     ) -> None:
         # Destructively add the imported data into our 'projects' map.
-
-        if imap is not None:
-            imap_filter = _compose_imap_filters(self._ctx.imap_filter, _imap_filter(imap))
-            imap_path_prefix = imap.path_prefix
-        else:
-            imap_filter = self._ctx.imap_filter
-            imap_path_prefix = '.'
+        match imap_or_mfpath:
+            case _import_map():
+                imap_filter = _compose_imap_filters(
+                    self._ctx.imap_filter, _imap_filter(imap_or_mfpath)
+                )
+                imap_path_prefix = imap_or_mfpath.path_prefix
+                mfst_path = imap_or_mfpath.file
+            case str():
+                imap_filter = self._ctx.imap_filter
+                imap_path_prefix = '.'
+                mfst_path = imap_or_mfpath
+            case _:
+                raise AssertionError(f'imap_or_mfpath has unexpected type {type(imap_or_mfpath)}')
 
         child_ctx = self._ctx._replace(
             imap_filter=imap_filter,
@@ -2689,38 +2710,41 @@ class Manifest:
         try:
             submanifest = Manifest(topdir=self.topdir, internal_import_ctx=child_ctx)
         except RecursionError as e:
-            raise _ManifestImportDepth(None, imap.file if imap else None) from e
+            raise _ManifestImportDepth(None, mfst_path) from e
 
         # Patch up any extension commands in the imported data
         # by allocating them to the project.
-        project.west_commands = _west_commands_merge(
-            project.west_commands, submanifest._ctx.manifest_west_commands
-        )
+
+        # If the manifest was imported from a project subdirectory
+        # (manifest_path is a relative path within the project),
+        # we need to adjust the west_commands paths to be relative
+        # to the project root, not to the manifest subdirectory.
+        mfst_dir = Path(mfst_path) if directory_import else Path(mfst_path).parent
+        west_commands_to_merge = [
+            (mfst_dir / cmd).as_posix() for cmd in submanifest._ctx.manifest_west_commands
+        ]
+
+        project.west_commands = _west_commands_merge(project.west_commands, west_commands_to_merge)
 
     def _import_content_from_project(self, project: Project, path: str) -> ImportedContentType:
         if not (self._ctx.import_flags & ImportFlag.FORCE_PROJECTS) and project.is_cloned():
             try:
-                content = _manifest_content_at(project, path, Manifest.encoding)
+                return _manifest_content_at(project, path, Manifest.encoding)
             except MalformedManifest as mm:
                 self._malformed(mm.args[0])
             except FileNotFoundError:
                 # We may need to fetch a new manifest-rev, e.g. if
                 # revision is a branch that didn't used to have a
                 # manifest, but now does.
-                content = self._ctx.project_importer(project, path)
+                return self._ctx.project_importer(project, path)
             except subprocess.CalledProcessError:
                 # We may need a new manifest-rev, e.g. if revision is
                 # a SHA we don't have yet.
-                content = self._ctx.project_importer(project, path)
+                return self._ctx.project_importer(project, path)
         else:
             # We need to clone this project, or we were specifically
             # asked to use the importer.
-            content = self._ctx.project_importer(project, path)
-
-        if isinstance(content, str):
-            content = [content]
-
-        return content
+            return self._ctx.project_importer(project, path)
 
     def _load_imap(self, imp: dict, src: str) -> _import_map:
         # Convert a parsed self or project import value from YAML into

--- a/tests/test_extension_commands.py
+++ b/tests/test_extension_commands.py
@@ -6,6 +6,7 @@ import subprocess
 import textwrap
 from pathlib import Path
 
+import pytest
 import yaml
 from conftest import GIT, WINDOWS, add_commit, cmd, cmd_raises, yaml_editor
 
@@ -341,6 +342,85 @@ def test_call_imported_project_submanifest_commands_from_project_subdirectory(re
 
     ext_output = cmd('imported-command-from-subdir', cwd=workspace)
     assert 'imported command from subdir works' in ext_output
+
+
+@pytest.mark.skipif(
+    not WINDOWS, reason="non-posix path separators don't work reliably on non-Windows"
+)
+def test_call_imported_project_submanifest_commands_from_project_subdirectory_windows_paths(
+    repos_tmpdir,
+):
+    # Same as the forward-slash test above, but use Windows-style
+    # separators in the manifest file paths.
+    manifest_path = repos_tmpdir / 'repos' / 'zephyr'
+    net_tools_path = repos_tmpdir / 'repos' / 'net-tools'
+
+    MF_SUB_WEST_YML = textwrap.dedent(
+        '''\
+        manifest:
+          self:
+            west-commands: scripts\\west-commands-from-subdir-windows.yml
+        '''
+    )
+    MF_SUB_COMMANDS_YML = textwrap.dedent(
+        '''\
+        west-commands:
+          - file: test\\west-commands\\subdir_command_windows.py
+            commands:
+              - name: imported-command-from-subdir-windows
+                class: ImportedCommandFromProjectSubdirWindows
+                help: imported command from subdir with windows paths help
+        '''
+    )
+    MF_SUB_WEST_PY = textwrap.dedent(
+        '''\
+        from west.commands import WestCommand
+
+        class ImportedCommandFromProjectSubdirWindows(WestCommand):
+            def __init__(self):
+                super().__init__(
+                    'imported-command-from-subdir-windows',
+                    'imported command from subdir with windows paths help',
+                    'imported command from subdir with windows paths description',
+                )
+
+            def do_add_parser(self, parser_adder):
+                return parser_adder.add_parser(self.name)
+
+            def do_run(self, args, unknown):
+                print('imported command from subdir with windows paths works')
+        '''
+    )
+
+    add_commit(
+        net_tools_path,
+        'add imported submanifest extension command with windows paths',
+        files={
+            r'mf_subdir/west.yml': MF_SUB_WEST_YML,
+            r'mf_subdir/scripts/west-commands-from-subdir-windows.yml': MF_SUB_COMMANDS_YML,
+            r'mf_subdir/test/west-commands/subdir_command_windows.py': MF_SUB_WEST_PY,
+        },
+    )
+
+    with yaml_editor(manifest_path / 'west.yml') as mf:
+        net_tools_project = [p for p in mf['manifest']['projects'] if p['name'] == 'net-tools'][0]
+        net_tools_project['import'] = r'mf_subdir/west.yml'
+    subprocess.check_call([
+        GIT,
+        '-C',
+        str(manifest_path),
+        'commit',
+        '-m',
+        'import mf_subdir\\west.yml',
+        'west.yml',
+    ])
+
+    workspace = repos_tmpdir / 'workspace'
+    cmd(['init', '-m', str(manifest_path), str(workspace)])
+    cmd('update', cwd=workspace)
+
+    ext_output = cmd('imported-command-from-subdir-windows', cwd=workspace)
+    assert 'imported command from subdir with windows paths works' in ext_output
 
 
 def test_extension_special_chars(west_update_tmpdir):

--- a/tests/test_extension_commands.py
+++ b/tests/test_extension_commands.py
@@ -266,6 +266,83 @@ def test_extension_command_multiple_commands_same_file(west_update_tmpdir):
     assert 'second command' in ext_output
 
 
+def test_call_imported_project_submanifest_commands_from_project_subdirectory(repos_tmpdir):
+    # If net-tools imports mf_subdir/west.yml and that manifest declares
+    # self: west-commands: scripts/west-commands.yml, then file paths in that
+    # west-commands YAML are resolved relative to the imported manifest root.
+    # The same paths must work whether a project is imported or initialized directly;
+    # importing must never break anything.
+    manifest_path = repos_tmpdir / 'repos' / 'zephyr'
+    net_tools_path = repos_tmpdir / 'repos' / 'net-tools'
+
+    MF_SUB_WEST_YML = textwrap.dedent(
+        '''\
+        manifest:
+          self:
+            west-commands: scripts/west-commands-from-subdir.yml
+        '''
+    )
+    MF_SUB_COMMANDS_YML = textwrap.dedent(
+        '''\
+        west-commands:
+          - file: test/west-commands/subdir_command.py
+            commands:
+              - name: imported-command-from-subdir
+                class: ImportedCommandFromProjectSubdir
+                help: imported extension help
+        '''
+    )
+    MF_SUB_WEST_PY = textwrap.dedent(
+        '''\
+        from west.commands import WestCommand
+
+        class ImportedCommandFromProjectSubdir(WestCommand):
+            def __init__(self):
+                super().__init__(
+                    'imported-command-from-subdir',
+                    'imported command from subdir help',
+                    'imported command from subdir description',
+                )
+
+            def do_add_parser(self, parser_adder):
+                return parser_adder.add_parser(self.name)
+
+            def do_run(self, args, unknown):
+                print('imported command from subdir works')
+        '''
+    )
+
+    add_commit(
+        net_tools_path,
+        'add imported submanifest extension command',
+        files={
+            'mf_subdir/west.yml': MF_SUB_WEST_YML,
+            'mf_subdir/scripts/west-commands-from-subdir.yml': MF_SUB_COMMANDS_YML,
+            'mf_subdir/test/west-commands/subdir_command.py': MF_SUB_WEST_PY,
+        },
+    )
+
+    with yaml_editor(manifest_path / 'west.yml') as mf:
+        net_tools_project = [p for p in mf['manifest']['projects'] if p['name'] == 'net-tools'][0]
+        net_tools_project['import'] = 'mf_subdir/west.yml'
+    subprocess.check_call([
+        GIT,
+        '-C',
+        str(manifest_path),
+        'commit',
+        '-m',
+        'import mf_subdir/west.yml',
+        'west.yml',
+    ])
+
+    workspace = repos_tmpdir / 'workspace'
+    cmd(['init', '-m', str(manifest_path), str(workspace)])
+    cmd('update', cwd=workspace)
+
+    ext_output = cmd('imported-command-from-subdir', cwd=workspace)
+    assert 'imported command from subdir works' in ext_output
+
+
 def test_extension_special_chars(west_update_tmpdir):
     # Detect any unexpected changes in the way we've been handling backslashes and other
     # special characters. Changes in how we handle such edge cases may or may not be desired

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -2116,6 +2116,101 @@ def test_import_project_submanifest_commands_both(manifest_repo):
     assert p1.west_commands == expected
 
 
+def test_import_project_submanifest_commands_from_project_subdirectory(manifest_repo):
+    # When a manifest is imported from a project subdirectory (e.g., mf_subdir/west.yml),
+    # and that manifest defines west-commands, the paths should be
+    # resolved relative to the manifest subdirectory.
+    # This test covers both string and import-map forms, for file and directory imports.
+
+    p1 = manifest_repo / '..' / 'p1'
+    create_repo(p1)
+    # West reads the manifest from the 'manifest-rev' branch of the project, so we need to
+    # create it and add the manifest there.
+    create_branch(p1, 'manifest-rev', checkout=True)
+    add_commit(
+        p1,
+        'add mf_subdir/west.yml with west-commands',
+        files={
+            'mf_subdir/west.yml': '''\
+                                manifest:
+                                  projects:
+                                  - name: p2
+                                    url: url-placeholder2
+                                  self:
+                                    west-commands: p2subdir/west-commands.yml
+                                ''',
+        },
+    )
+    # Checkout master (which is empty) to ensure the west.yml file is not present in the
+    # file system, and that the west-commands are resolved from the 'manifest-rev' branch
+    # using git, not the currently checked out version.
+    checkout_branch(p1, 'master')
+
+    # Case A: import as a string path to the submanifest file.
+    with open(manifest_repo / 'west.yml', 'w') as f:
+        f.write('''\
+        manifest:
+          projects:
+          - name: p1
+            url: url-placeholder
+            import: mf_subdir/west.yml
+        ''')
+
+    # The west_commands path should be 'mf_subdir/p2subdir/west-commands.yml',
+    # not 'west-commands.yml', to be resolved correctly
+    # relative to the project root. See issue #725.
+    p1_proj = MF().get_projects(['p1'])[0]
+    expected = ['mf_subdir/p2subdir/west-commands.yml']
+    assert p1_proj.west_commands == expected
+
+    # Case B: import using an import-map whose 'file' is a file path.
+    with open(manifest_repo / 'west.yml', 'w') as f:
+        f.write('''\
+      manifest:
+        projects:
+        - name: p1
+          url: url-placeholder
+          import:
+            file: mf_subdir/west.yml
+      ''')
+
+    # Reload and check the west_commands were resolved the same way.
+    p1_proj = MF().get_projects(['p1'])[0]
+    expected = ['mf_subdir/p2subdir/west-commands.yml']
+    assert p1_proj.west_commands == expected
+
+    # Case C: import as a string path to the submanifest directory.
+    with open(manifest_repo / 'west.yml', 'w') as f:
+        f.write('''\
+      manifest:
+        projects:
+        - name: p1
+          url: url-placeholder
+          import: mf_subdir
+      ''')
+
+    # Reload and check the west_commands were resolved the same way.
+    p1_proj = MF().get_projects(['p1'])[0]
+    expected = ['mf_subdir/p2subdir/west-commands.yml']
+    assert p1_proj.west_commands == expected
+
+    # Case D: import using an import-map whose 'file' is a directory.
+    with open(manifest_repo / 'west.yml', 'w') as f:
+        f.write('''\
+      manifest:
+        projects:
+        - name: p1
+          url: url-placeholder
+          import:
+            file: mf_subdir
+      ''')
+
+    # Reload and check the west_commands were resolved the same way.
+    p1_proj = MF().get_projects(['p1'])[0]
+    expected = ['mf_subdir/p2subdir/west-commands.yml']
+    assert p1_proj.west_commands == expected
+
+
 def test_import_map_error_handling():
     # Make sure we handle expected errors when loading import:
     # values that are maps.


### PR DESCRIPTION
Fixes #725

Note that I relied on the test to tell me if the fix is working, I did not test it with a proper repository setup. Let me know if this is desired/this project is one where manual testing of such kind is necessary. 

I'm unfamiliar with west release cycles - if this is accepted, could someone let me know when I could expect to see a new version of west released, so that we can start recommending setups relying on this to our users?