### PR TITLE
tests: stop hardcoding a forward slash in 'scripts/west-commands.yml'

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,8 +31,19 @@ GIT = shutil.which('git')
 # name.
 GIT_INIT_HAS_BRANCH = False
 
+WINDOWS = platform.system() == 'Windows'
+
+# We do NOT recommend or even advertise using backslashes on Windows because:
+# - they are a quoting and escape nightmare, and
+# - forward slashes work 99% of the time on Windows.
+# But:
+# - Backslashes should still work on Windows! So let's test them.
+# - This helps catch OS-independent mistakes in both production code and test code
+#   where we hardcode forward slashes directly instead of using Python's Pathlib or os.path.
+_scripts_west_cmds = r'scripts\\west-commands.yml' if WINDOWS else 'scripts///west-commands.yml'
+
 # If you change this, keep the docstring in repos_tmpdir() updated also.
-MANIFEST_TEMPLATE = '''\
+MANIFEST_TEMPLATE = f'''\
 manifest:
   defaults:
     remote: test-local
@@ -56,12 +67,10 @@ manifest:
     - name: net-tools
       description: Networking tools.
       clone-depth: 1
-      west-commands: scripts/west-commands.yml
+      west-commands: '{_scripts_west_cmds}'
   self:
     path: zephyr
 '''
-
-WINDOWS = platform.system() == 'Windows'
 
 #
 # Contextmanager
@@ -649,4 +658,5 @@ def check_proj_consistency(actual, expected):
     )
     assert actual.clone_depth == expected.clone_depth
     assert actual.revision == expected.revision
-    assert actual.west_commands == expected.west_commands
+    for a, e in zip(actual.west_commands, expected.west_commands, strict=True):
+        assert PurePath(a) == PurePath(e)

--- a/tests/test_extension_commands.py
+++ b/tests/test_extension_commands.py
@@ -4,7 +4,7 @@
 
 import textwrap
 
-from conftest import add_commit, cmd, cmd_raises
+from conftest import WINDOWS, add_commit, cmd, cmd_raises
 
 
 def test_extension_commands_basic(west_update_tmpdir):
@@ -218,11 +218,13 @@ def test_extension_command_default_class_name(west_update_tmpdir):
 def test_extension_command_multiple_commands_same_file(west_update_tmpdir):
     # Test multiple commands defined in the same python file
     net_tools_path = west_update_tmpdir / 'net-tools'
+    # Make sure we use either Pathlib or os.path
+    ext_file = r'scripts\\multi.py' if WINDOWS else 'scripts//multi.py'
     add_commit(
         net_tools_path,
         'add multiple commands',
         files={
-            'scripts/multi.py': textwrap.dedent('''\
+            ext_file: textwrap.dedent('''\
                 from west.commands import WestCommand
 
                 class FirstCommand(WestCommand):
@@ -241,9 +243,9 @@ def test_extension_command_multiple_commands_same_file(west_update_tmpdir):
                     def do_run(self, args, unknown):
                         print('second command')
                 '''),
-            'scripts/west-commands.yml': textwrap.dedent('''\
+            'scripts/west-commands.yml': textwrap.dedent(f'''\
                 west-commands:
-                  - file: scripts/multi.py
+                  - file: {ext_file}
                     commands:
                       - name: first
                         class: FirstCommand

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -435,7 +435,7 @@ def test_manifest_freeze(west_update_tmpdir):
         '^    url: .*$',
         '^    revision: [a-f0-9]{40}$',
         '^    clone-depth: 1$',
-        '^    west-commands: scripts/west-commands.yml$',
+        r'^    west-commands: scripts[/\\]+west-commands.yml$',
         '^  self:$',
         '^    path: zephyr$',
     ]
@@ -459,7 +459,7 @@ def test_manifest_freeze_active(west_update_tmpdir):
         '^    url: .*$',
         '^    revision: [a-f0-9]{40}$',
         '^    clone-depth: 1$',
-        '^    west-commands: scripts/west-commands.yml$',
+        r'^    west-commands: scripts[/\\]+west-commands.yml$',
         '^  self:$',
         '^    path: zephyr$',
     ]
@@ -491,7 +491,7 @@ def test_manifest_resolve(west_update_tmpdir):
         '^    url: .*$',
         '^    revision: master$',
         '^    clone-depth: 1$',
-        '^    west-commands: scripts/west-commands.yml$',
+        r'^    west-commands: scripts[/\\]+west-commands.yml$',
         '^  self:$',
         '^    path: zephyr$',
     ]
@@ -515,7 +515,7 @@ def test_manifest_resolve_active(west_update_tmpdir):
         '^    url: .*$',
         '^    revision: master$',
         '^    clone-depth: 1$',
-        '^    west-commands: scripts/west-commands.yml$',
+        r'^    west-commands: scripts[/\\]+west-commands.yml$',
         '^  self:$',
         '^    path: zephyr$',
     ]


### PR DESCRIPTION
Use backwards slashes on Windows to catch any future hardcoding mistake.

Minor oversight found while discussing #920