### PR TITLE
test_manifest.py: re-enable RecursionError test for python 3.13.13

### DIFF
--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -2957,10 +2957,11 @@ _def_rec_limit = sys.getrecursionlimit()
 # more coverage. We used to test only the default value and to pass this test by chance, missing
 # the regression in cpython 3.13.8 caused by this backport to 3.13:
 # https://github.com/python/cpython/commit/ebccd1de88d
-# Long story in west issue #908.
+# Long story in https://github.com/python/cpython/issues/145008 and west issue #908
 @pytest.mark.parametrize("py_rec_limit", range(_def_rec_limit, _def_rec_limit + 10))
 @pytest.mark.skipif(
-    (3, 13, 8) <= sys.version_info and sys.version_info < (3, 14), reason="See west issue #908"
+    (3, 13, 8) <= sys.version_info[0:3] and sys.version_info[0:3] <= (3, 13, 12),
+    reason="cpython issue #145008",
 )
 def test_import_loop_detection_self(manifest_repo, py_rec_limit):
     # Verify that a self-import which causes an import loop is an error.


### PR DESCRIPTION
https://github.com/python/cpython/issues/145008 has been marked with the "release blocker" label, so let's make sure we will test the next 3.13.x version whenever it is released. In the worst case we can always bump the maximum version number again.

Also add a direct link to 145008: better than navigating the initial and confusing west issue #908