### PR TITLE
conftest.py: add assert(GIT and Path(GIT).exists())

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,7 @@ import pytest
 from west.app import main
 
 GIT = shutil.which('git')
+assert GIT and Path(GIT).exists()
 
 # Git capabilities are discovered at runtime in
 # _check_git_capabilities().


### PR DESCRIPTION
This makes test failures so much user-friendlier when git is missing.