### PR TITLE
version.py: add comment with workaround to run pytest from scratch.

### DIFF
--- a/src/west/version.py
+++ b/src/west/version.py
@@ -7,6 +7,14 @@
 
 import importlib.metadata
 
+# The package metadata required can be missing when running pytest directly.  One
+# possible workaround is:
+#
+#   cd west && pipx install -e . && pipx uninstall west
+#
+# This cycle leaves behind a `west/src/west.egg-info/PKG-INFO` file which is enough.
+# `pip install --break-system-packages ...` can achieve the same result but with more
+# disruption than pipx.
 __version__ = importlib.metadata.version("west")
 #
 # MAINTAINERS:


### PR DESCRIPTION
`importlib.metadata.version("west")` requires a west package. After a surprisingly long time, I realized there's none when running pytest from scratch. That's because (un)installations seem to always leave one behind. So this "accidentally" tends to work. As a workaround, recommend the very well tried and tested tactic of... installing - and uninstalling.

cc: @thorsten-klein 