### PR TITLE
pyproject.toml: simplify coverage filter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,19 +66,13 @@ include-package-data = true
 where = ["src"]
 namespaces = false
 
+# Note this section is only for interactive `coverage run ...` use and ignored by "gh-test"
+# below.  pytest's --cov-config= option is for passing .coveragerc file syntax and it seems to
+# silently ignore pyproject.toml files.
 [tool.coverage.run]
 patch = ["subprocess"]
 relative_files = true
-omit = [
-  "*/tmp/*",
-]
-
-[tool.coverage.report]
-omit = [
-  "*/tmp/*",
-  "*/net-tools/scripts/*",
-  "*/subdir/Kconfiglib/scripts/test.py",
-]
+source = ["src/"]
 
 [tool.coverage.paths]
 source = [
@@ -134,5 +128,6 @@ gh-lint = "ruff check --output-format=github ."
 gh-format = "ruff format --check --output-format=github"
 
 [tool.poe.tasks.gh-test]
-cmd = "python -m pytest -W error -v -o pythonpath= -o junit_family=xunit1 --junitxml=junit.xml --cov-report=html --cov-config=pyproject.toml --cov=west"
+# Keep the --cov= option in sync with [tool.coverage.run] above.
+cmd = "python -m pytest -W error -v -o pythonpath= -o junit_family=xunit1 --junitxml=junit.xml --cov-report=html --cov=src/"
 env = {PYTHONIOENCODING = "utf-8"}


### PR DESCRIPTION
Drop the "omit" rules and use a simpler "source = src/" to declare
what we are interested in. This is the first recommendation at
https://coverage.readthedocs.io/en/latest/source.html#source-execution

Stop using the `pytest --cov-config=pyproject.toml` option as this
file format seems silently ignored there.