### PR TITLE
commands: extensions: warn about unused .help field and make it optional

### DIFF
--- a/src/west/app/main.py
+++ b/src/west/app/main.py
@@ -225,6 +225,8 @@ class WestApp:
 
         for group, classes in BUILTIN_COMMAND_GROUPS.items():
             lst = [cls() for cls in classes]
+            for cmd in lst:
+                assert cmd.help, f".help field missing in built-in command '{cmd.name}'"
             self.builtins.update({command.name: command for command in lst})
             self.builtin_groups[group] = lst
 

--- a/src/west/commands.py
+++ b/src/west/commands.py
@@ -131,8 +131,12 @@ class WestCommand(ABC):
     def __init__(
         self,
         name: str,
-        help: str,
-        description: str,
+        # Required for built-ins but unused by extensions, see
+        # https://github.com/zephyrproject-rtos/west/issues/927
+        help: str | None = None,
+        # We want a description. But this parameter comes after .help which has a
+        # default value, so it must have a default too. We check below instead.
+        description: str | None = None,
         accepts_unknown_args: bool = False,
         requires_workspace: bool = True,
         verbosity: Verbosity = Verbosity.INF,
@@ -158,8 +162,10 @@ class WestCommand(ABC):
         :param verbosity: command output verbosity level; can be changed later
         '''
         self.name: str = name
-        self.help: str = help
-        self.description: str = description
+        self.help: str | None = help
+        assert description is not None, f"west command '{name}' misses a description field"
+        # We have unfortunately allowed blank description strings in the past
+        self.description: str = description if description else "MISSING description"
         self.accepts_unknown_args: bool = accepts_unknown_args
         self.requires_workspace = requires_workspace
         self.verbosity = verbosity
@@ -592,9 +598,23 @@ class _ExtFactory:
 
         # Create the command instance and return it.
         try:
-            return cls()
+            cmd = cls()
         except Exception as e:
             raise ExtensionCommandError(hint='command constructor threw an exception') from e
+
+        if cmd.help:
+            # Very "soft" warning that does not pollute expected output
+            cmd.description += f'''
+WARNING: in file {self.py_file},
+  the WestCommand constructor of the west extension '{cmd.name}' sets
+  the ignored 'help' field to "{cmd.help}"
+  but only the help from the west-commands.yml file has ever been used.
+  See west bug https://github.com/zephyrproject-rtos/west/issues/927.
+  Change that help field to "" to silence this warning while preserving
+  compatibility with older west versions that unfortunately required
+  that help parameter.'''
+
+        return cmd
 
 
 @dataclass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -264,8 +264,7 @@ def _session_repos(tmp_path_factory):
                 class TestExtension(WestCommand):
                     def __init__(self):
                         super().__init__('test-extension',
-                                         'test-extension-help',
-                                         '')
+                                         description='description of test extension')
                     def do_add_parser(self, parser_adder):
                         parser = parser_adder.add_parser(self.name)
                         return parser

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -2160,14 +2160,20 @@ def test_extension_command_multiproject(repos_tmpdir):
                       '''),
             'scripts/test.py': textwrap.dedent('''\
                       from west.commands import WestCommand
+                      import argparse
                       class Test(WestCommand):
                           def __init__(self):
                               super(Test, self).__init__(
                                   'kconfigtest',
-                                  'Kconfig test application',
-                                  '')
+                                  'ignored help string that must warn',
+                                  'description of Kconfiglib kconfigtest extension',
+                              )
                           def do_add_parser(self, parser_adder):
-                              parser = parser_adder.add_parser(self.name)
+                              parser = parser_adder.add_parser(self.name,
+                                description=self.description,
+                                # we don't want newlines "randomly" inserted
+                                formatter_class=argparse.RawDescriptionHelpFormatter,
+                              )
                               return parser
                           def do_run(self, args, ignored):
                               print('Testing kconfig test')
@@ -2196,6 +2202,10 @@ def test_extension_command_multiproject(repos_tmpdir):
 
     actual = cmd('kconfigtest')
     assert actual.rstrip() == 'Testing kconfig test'
+
+    actual = cmd('kconfigtest -h')
+    assert 'description of Kconfiglib kconfigtest' in actual
+    assert re.search(r'WARNING.*Kconfiglib.*scripts.*test.py.*927', actual, re.DOTALL)
 
 
 def test_extension_command_duplicate(repos_tmpdir):
@@ -2252,17 +2262,17 @@ def test_extension_command_duplicate(repos_tmpdir):
                               class: Test
                       '''),
             'scripts/test.py': textwrap.dedent('''\
-                      from argparse import REMAINDER
+                      import argparse
                       from west.commands import WestCommand
                       class List(WestCommand):
                           def __init__(self):
                               super(List, self).__init__(
                                   'list',
-                                  'test list',
-                                  '')
+                                  description='description of rejected list extension',
+                               )
                           def do_add_parser(self, parser_adder):
                               parser = parser_adder.add_parser(self.name)
-                              parser.add_argument('any', nargs=REMAINDER)
+                              parser.add_argument('any', nargs=argparse.REMAINDER)
                               return parser
                           def do_run(self, args, ignored):
                               print('This must never be printed')
@@ -2270,10 +2280,15 @@ def test_extension_command_duplicate(repos_tmpdir):
                           def __init__(self):
                               super(Test, self).__init__(
                                   'test-extension',
-                                  'test application',
-                                  '')
+                                  '', # help
+                                  '', # description
+                               )
                           def do_add_parser(self, parser_adder):
-                              parser = parser_adder.add_parser(self.name)
+                              parser = parser_adder.add_parser(self.name,
+                                  description=self.description,
+                                  # we don't want newlines "randomly" inserted
+                                  formatter_class=argparse.RawDescriptionHelpFormatter,
+                              )
                               return parser
                           def do_run(self, args, ignored):
                               print('Testing kconfig test command')
@@ -2299,6 +2314,11 @@ def test_extension_command_duplicate(repos_tmpdir):
     # Expect output from the Kconfiglib command, not its net-tools duplicate.
     actual = cmd('test-extension').splitlines()
     assert actual == expected_warns + ['Testing kconfig test command']
+
+    actual = cmd('test-extension -h')
+    assert "MISSING description" in actual
+    # https://github.com/zephyrproject-rtos/west/issues/927 is silenced by: help=''
+    assert "927" not in actual
 
 
 def test_topdir_none(tmpdir):


### PR DESCRIPTION
Since the beginning of west extensions in 2019 Zephyr commit d3bb3cfd7a4a and others, west has
requested to extension authors to:

- provide a string .help field in each extension constructor
- "keep it in sync" with the duplicate help in `west-commands.yml`,
  see https://github.com/zephyrproject-rtos/zephyr/commit/808028b46fc95ba5

As detailed testing and analysis in https://github.com/zephyrproject-rtos/west/issues/927
have shown, the contructor parameter has never been used. Only the help in west-commands.yml
is used. This is confirmed by the "TODO" added by commit 0d39b6b77a5ff059f69019d2d9167423e8cf258d.

- Stop forcing extension authors to provide an unused field
- "Gently" warn when they do in `west my_extension -h`
- Use `help=''` as a special west transition value
- Ajust test coverage accordingly

Signed-off-by: Marc Herbert <Marc.Herbert@gmail.com>