### PR TITLE
init: make sure git remote treats 'remote: name:' positionally

### DIFF
--- a/src/west/app/project.py
+++ b/src/west/app/project.py
@@ -1840,7 +1840,7 @@ class Update(_ProjectCommand):
                 cwd=self.topdir,
             )
             # Reset the remote's URL to the project's fetch URL.
-            project.git(['remote', 'set-url', project.remote_name, project.url])
+            project.git(['remote', 'set-url', '--', project.remote_name, project.url])
             # Make sure we have a detached HEAD so we can delete the
             # local branch created by git clone.
             project.git('checkout --quiet --detach HEAD')


### PR DESCRIPTION
No functional changes expected for "normal" remote names like "zephyr" or "github". If the remote name is something like "--foo", this should ensure the command succeeds by forcing git to treat that as a positional argument. Note that we already do the same thing higher up in the 'git remote add' step; this is just for consistency.