### PR TITLE
project: forall: clarify that WEST_PROJECT_* are manifest-based

### DIFF
--- a/src/west/app/project.py
+++ b/src/west/app/project.py
@@ -2122,6 +2122,11 @@ class ForAll(_ProjectCommand):
 
                 west forall -c "echo \\$WEST_PROJECT_NAME"
 
+            The WEST_PROJECT_* values are purely based on the manifest
+            file(s). In case of changes unknown to west, these values
+            may or may not still match what your system has become when
+            you run the command.
+
             If the command has multiple words, you must quote the -c
             option to prevent the shell from splitting it up. Since
             the command is run through the shell, you can use


### PR DESCRIPTION
As noted in
https://github.com/zephyrproject-rtos/west/issues/942#issuecomment-4226897309, it's very easy to change the git remote name and make WEST_PROJECT_REMOTE out of sync.