### PR TITLE
project: compare: add -f/--format for machine-readable output

### DIFF
--- a/src/west/app/project.py
+++ b/src/west/app/project.py
@@ -863,13 +863,38 @@ class Compare(_ProjectCommand):
             The command also prints output for the manifest repository if it
             has nonempty status.
 
-            The output is meant to be human-readable, and may change. It is
-            not a stable interface to write scripts against. This command
-            requires git 2.22 or later.'''),
+            The default output is meant to be human-readable, and may change.
+            It is not a stable interface to write scripts against. If you need
+            machine-readable output (e.g. to feed back into "west update" or
+            "west forall"), pass --format; see FORMAT STRINGS below.
+
+            This command requires git 2.22 or later.'''),
         )
 
     def do_add_parser(self, parser_adder):
-        parser = self._parser(parser_adder, epilog=ACTIVE_CLONED_PROJECTS_HELP)
+        parser = self._parser(
+            parser_adder,
+            epilog=f'''\
+{ACTIVE_CLONED_PROJECTS_HELP}
+
+FORMAT STRINGS
+--------------
+
+When --format is given, "west compare" prints one line per project
+with changes, rendered using the given Python format string. The
+supported keys are the same ones documented in "west list --help".
+Unlike the default output, --format output is a stable interface
+suitable for scripting, for example:
+
+POSIX:
+
+    west compare --format '{{name}}' | while read -r name; do west update "$name"; done
+
+PowerShell:
+
+    west compare --format '{{name}}' | ForEach-Object {{ west update $_ }}
+''',
+        )
         parser.add_argument(
             'projects',
             metavar='PROJECT',
@@ -900,6 +925,13 @@ class Compare(_ProjectCommand):
                     or any compare.ignore-branches configuration
                     option''',
         )
+        parser.add_argument(
+            '-f',
+            '--format',
+            help='''if given, print one line per project with changes
+                    using this format string (stable, machine-readable
+                    output); see FORMAT STRINGS below''',
+        )
         return parser
 
     def do_run(self, args, ignored):
@@ -915,6 +947,13 @@ class Compare(_ProjectCommand):
 
         failed = []
         printed_output = False
+
+        def compare_project(project, fmt):
+            if fmt is None:
+                self.compare(project)
+            else:
+                self._format_project(project, fmt)
+
         for project in self._cloned_projects(args, only_active=not args.all):
             if isinstance(project, ManifestProject):
                 # West doesn't track the relationship between the manifest
@@ -922,7 +961,7 @@ class Compare(_ProjectCommand):
                 # in printing output for comparisons that makes sense.
                 if self._has_nonempty_status(project):
                     try:
-                        self.compare(project)
+                        compare_project(project, args.format)
                         printed_output = True
                     except subprocess.CalledProcessError:
                         failed.append(project)
@@ -960,7 +999,7 @@ class Compare(_ProjectCommand):
                 ):
                     continue
 
-                self.compare(project)
+                compare_project(project, args.format)
                 printed_output = True
             except subprocess.CalledProcessError:
                 failed.append(project)

--- a/src/west/app/project.py
+++ b/src/west/app/project.py
@@ -149,6 +149,86 @@ class _ProjectCommand(WestCommand):
 
         return has_output()
 
+    def _format_project(self, project, fmt, *, manifest_path_from_yaml=False):
+        # Shared between 'west list --format' and 'west compare --format'.
+        # Does not catch subprocess.CalledProcessError; callers decide
+        # whether such failures are fatal.
+        def sha_thunk(project):
+            self.die_if_no_git()
+
+            if not project.is_cloned():
+                self.die(
+                    f'cannot get sha for uncloned project {project.name}; '
+                    f'run "west update {project.name}" and retry'
+                )
+            elif isinstance(project, ManifestProject):
+                return f'{"N/A":40}'
+            else:
+                return project.sha(MANIFEST_REV)
+
+        def cloned_thunk(project):
+            self.die_if_no_git()
+
+            return "cloned" if project.is_cloned() else "not-cloned"
+
+        def active_thunk(project):
+            self.die_if_no_git()
+
+            return "active" if self.manifest.is_active(project) else "inactive"
+
+        def delay(func, project):
+            return DelayFormat(partial(func, project))
+
+        # Spelling out the format keys explicitly here gives us
+        # future-proofing if the internal Project representation
+        # ever changes.
+        #
+        # Using DelayFormat delays computing derived values, such
+        # as SHAs, unless they are specifically requested, and then
+        # ensures they are only computed once.
+        try:
+            if isinstance(project, ManifestProject):
+                # Special-case the manifest repository while it's
+                # still showing up in the 'projects' list. Yet
+                # more evidence we should tackle #327.
+                if manifest_path_from_yaml:
+                    path = self.manifest.yaml_path
+                    apath = abspath(os.path.join(self.topdir, path)) if path else None
+                    ppath = Path(apath).as_posix() if apath else None
+                else:
+                    path = self.manifest.repo_path
+                    apath = self.manifest.repo_abspath
+                    ppath = self.manifest.repo_posixpath
+            else:
+                path = project.path
+                apath = project.abspath
+                ppath = project.posixpath
+
+            result = fmt.format(
+                name=project.name,
+                description=project.description or "None",
+                url=project.url or 'N/A',
+                path=path,
+                abspath=apath,
+                posixpath=ppath,
+                revision=project.revision or 'N/A',
+                clone_depth=project.clone_depth or "None",
+                cloned=delay(cloned_thunk, project),
+                active=delay(active_thunk, project),
+                sha=delay(sha_thunk, project),
+                groups=','.join(project.groups),
+            )
+        except KeyError as e:
+            # The raised KeyError seems to just put the first
+            # invalid argument in the args tuple, regardless of
+            # how many unrecognizable keys there were.
+            self.die(f'unknown key "{e.args[0]}" in format string {shlex.quote(fmt)}')
+        except IndexError:
+            self.parser.print_usage()
+            self.die(f'invalid format string {shlex.quote(fmt)}')
+
+        self.inf(result, colorize=False)
+
 
 class Init(_ProjectCommand):
     def __init__(self):
@@ -548,32 +628,6 @@ The following arguments are available:
         return parser
 
     def do_run(self, args, user_args):
-        def sha_thunk(project):
-            self.die_if_no_git()
-
-            if not project.is_cloned():
-                self.die(
-                    f'cannot get sha for uncloned project {project.name}; '
-                    f'run "west update {project.name}" and retry'
-                )
-            elif isinstance(project, ManifestProject):
-                return f'{"N/A":40}'
-            else:
-                return project.sha(MANIFEST_REV)
-
-        def cloned_thunk(project):
-            self.die_if_no_git()
-
-            return "cloned" if project.is_cloned() else "not-cloned"
-
-        def active_thunk(project):
-            self.die_if_no_git()
-
-            return "active" if self.manifest.is_active(project) else "inactive"
-
-        def delay(func, project):
-            return DelayFormat(partial(func, project))
-
         if args.inactive and args.projects:
             self.parser.error('-i cannot be combined with an explicit project list')
 
@@ -588,57 +642,14 @@ The following arguments are available:
                 self.dbg(f'{project.name}: skipping project')
                 continue
 
-            # Spelling out the format keys explicitly here gives us
-            # future-proofing if the internal Project representation
-            # ever changes.
-            #
-            # Using DelayFormat delays computing derived values, such
-            # as SHAs, unless they are specifically requested, and then
-            # ensures they are only computed once.
             try:
-                if isinstance(project, ManifestProject):
-                    # Special-case the manifest repository while it's
-                    # still showing up in the 'projects' list. Yet
-                    # more evidence we should tackle #327.
-                    if args.manifest_path_from_yaml:
-                        path = self.manifest.yaml_path
-                        apath = abspath(os.path.join(self.topdir, path)) if path else None
-                        ppath = Path(apath).as_posix() if apath else None
-                    else:
-                        path = self.manifest.repo_path
-                        apath = self.manifest.repo_abspath
-                        ppath = self.manifest.repo_posixpath
-                else:
-                    path = project.path
-                    apath = project.abspath
-                    ppath = project.posixpath
-
-                result = args.format.format(
-                    name=project.name,
-                    description=project.description or "None",
-                    url=project.url or 'N/A',
-                    path=path,
-                    abspath=apath,
-                    posixpath=ppath,
-                    revision=project.revision or 'N/A',
-                    clone_depth=project.clone_depth or "None",
-                    cloned=delay(cloned_thunk, project),
-                    active=delay(active_thunk, project),
-                    sha=delay(sha_thunk, project),
-                    groups=','.join(project.groups),
+                self._format_project(
+                    project,
+                    args.format,
+                    manifest_path_from_yaml=args.manifest_path_from_yaml,
                 )
-            except KeyError as e:
-                # The raised KeyError seems to just put the first
-                # invalid argument in the args tuple, regardless of
-                # how many unrecognizable keys there were.
-                self.die(f'unknown key "{e.args[0]}" in format string {shlex.quote(args.format)}')
-            except IndexError:
-                self.parser.print_usage()
-                self.die(f'invalid format string {shlex.quote(args.format)}')
             except subprocess.CalledProcessError:
                 self.die(f'subprocess failed while listing {project.name}')
-
-            self.inf(result, colorize=False)
 
 
 class ManifestCommand(_ProjectCommand):

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -628,6 +628,122 @@ def test_compare(config_tmpdir, west_init_tmpdir):
     assert 'mybranch' in cmd('compare --no-ignore-branches')
 
 
+def test_compare_format_manifest(config_tmpdir, west_init_tmpdir):
+    # ManifestProject special-casing: empty output, single-line
+    # machine-readable output without any banner, and the path/sha/url
+    # keys that are distinct from regular projects -- same conventions
+    # as 'west list'.
+
+    # No dirty projects -> no output at all.
+    assert cmd('compare --format {name}') == ''
+
+    # Dirty the manifest repo.
+    foo = west_init_tmpdir / 'zephyr' / 'foo'
+    with open(foo, 'w'):
+        pass
+
+    # The whole point of --format is stable machine-readable output:
+    # no banner ('=== ...'), exactly one line per dirty project, and
+    # the ManifestProject is named 'manifest' just like 'west list'.
+    out = cmd('compare --format {name}')
+    assert '===' not in out
+    assert out.splitlines() == ['manifest']
+
+    # Path-style keys for the ManifestProject come from manifest.repo_*,
+    # not project.*. {sha}/{url} are 'N/A' and {revision} is 'HEAD'.
+    # {groups} is empty. These all match 'west list' behavior.
+    assert cmd('compare -f {path}').strip() == 'zephyr'
+    assert cmd('compare -f {abspath}').strip() == str(west_init_tmpdir / 'zephyr')
+    assert cmd('compare -f {posixpath}').strip() == (Path(west_init_tmpdir / 'zephyr').as_posix())
+    assert cmd('compare -f {sha}').strip() == 'N/A'
+    assert cmd('compare -f {url}').strip() == 'N/A'
+    assert cmd('compare -f {revision}').strip() == 'HEAD'
+    assert cmd(['compare', '-f', '[{groups}]']).strip() == '[]'
+
+    # --exit-code still fires when --format produced any output.
+    with pytest.raises(SystemExit):
+        cmd('compare --exit-code --format {name}')
+
+    # Cleanup -> empty output again.
+    os.unlink(foo)
+    assert cmd('compare --format {name}') == ''
+
+
+def test_compare_format_projects(config_tmpdir, west_init_tmpdir):
+    # Regular (non-manifest) projects: every format key, multi-project
+    # ordering, and interactions with --all / named projects / the
+    # manifest.group-filter configuration option.
+
+    cmd('update')
+    kconfiglib = west_init_tmpdir / 'subdir' / 'Kconfiglib'
+    bar = kconfiglib / 'bar'
+    with open(bar, 'w'):
+        pass
+
+    # {sha} must resolve to a real 40-char hex SHA for a cloned project
+    # (not 'N/A'): this verifies DelayFormat actually gets invoked when
+    # the format string references {sha}.
+    line = cmd(['compare', '-f', '{name}|{sha}']).strip()
+    name, sha = line.split('|')
+    assert name == 'Kconfiglib'
+    assert re.match(r'^[0-9a-f]{40}$', sha)
+
+    # All remaining keys.
+    out = cmd([
+        'compare',
+        '-f',
+        '{name}|{url}|{path}|{abspath}|{posixpath}|{revision}|{groups}',
+    ]).strip()
+    fields = out.split('|')
+    assert fields[0] == 'Kconfiglib'
+    assert fields[1].endswith('/Kconfiglib')  # url from test fixture's url-base
+    # {path} preserves the manifest YAML value verbatim (always forward
+    # slashes), regardless of OS -- same behavior as 'west list -f {path}'.
+    assert fields[2] == 'subdir/Kconfiglib'
+    assert fields[3] == str(kconfiglib)
+    assert fields[4] == Path(kconfiglib).as_posix()
+    assert fields[5] == 'zephyr'
+    assert fields[6] == 'Kconfiglib-group'  # set in test fixture's manifest
+
+    # Multiple dirty projects produce one line per project, in manifest
+    # order (Kconfiglib before tagged_repo in this fixture's manifest).
+    tagged = west_init_tmpdir / 'tagged_repo' / 'baz'
+    with open(tagged, 'w'):
+        pass
+    assert cmd('compare -f {name}').splitlines() == ['Kconfiglib', 'tagged_repo']
+    os.unlink(tagged)
+
+    # An inactive project is skipped by default but appears with --all
+    # or when named explicitly (same active-project semantics as plain
+    # 'west compare').
+    cmd('config manifest.group-filter -- -Kconfiglib-group')
+    assert cmd('compare -f {name}') == ''
+    assert cmd('compare --all -f {name}').strip() == 'Kconfiglib'
+    assert cmd('compare -f {name} Kconfiglib').strip() == 'Kconfiglib'
+    cmd('config -d manifest.group-filter')
+
+    os.unlink(bar)
+
+
+def test_compare_format_errors(config_tmpdir, west_init_tmpdir):
+    # Malformed format strings must fail cleanly via self.die() ->
+    # SystemExit, not with an uncaught KeyError/IndexError traceback.
+    # Dirty the manifest repo so the format path is actually reached.
+    foo = west_init_tmpdir / 'zephyr' / 'foo'
+    with open(foo, 'w'):
+        pass
+
+    # Unknown named key.
+    with pytest.raises(SystemExit):
+        cmd('compare -f {bogus}')
+
+    # Positional argument (fmt.format() has no positional args).
+    with pytest.raises(SystemExit):
+        cmd('compare -f {0}')
+
+    os.unlink(foo)
+
+
 def test_diff(west_init_tmpdir):
     # FIXME: Check output
 


### PR DESCRIPTION
Mirror "west list --format" on "west compare": when --format is given, print one line per dirty project using the format string and skip the banner/status output. Supports the same keys as "west list" ({name}, {url}, {path}, {abspath}, {posixpath}, {revision}, {sha}, {groups}), including ManifestProject special-casing.

Unlike default compare output (documented as unstable), --format output is a stable interface suitable for scripting, e.g.:

    west update $(west compare --format '{name}')

https://github.com/zephyrproject-rtos/west/issues/941