### PR TITLE
support `west init --topdir`

### DIFF
--- a/src/west/app/project.py
+++ b/src/west/app/project.py
@@ -24,10 +24,8 @@ from urllib.parse import urlparse
 from west import util
 from west.commands import CommandError, Verbosity, WestCommand
 from west.configuration import Configuration
-from west.manifest import MANIFEST_REV_BRANCH as MANIFEST_REV
-from west.manifest import QUAL_MANIFEST_REV_BRANCH as QUAL_MANIFEST_REV
-from west.manifest import QUAL_REFS_WEST as QUAL_REFS
 from west.manifest import (
+    _WEST_YML,
     ImportFlag,
     Manifest,
     ManifestImportFailed,
@@ -35,6 +33,9 @@ from west.manifest import (
     Submodule,
     _manifest_content_at,
 )
+from west.manifest import MANIFEST_REV_BRANCH as MANIFEST_REV
+from west.manifest import QUAL_MANIFEST_REV_BRANCH as QUAL_MANIFEST_REV
+from west.manifest import QUAL_REFS_WEST as QUAL_REFS
 from west.manifest import is_group as is_project_group
 from west.util import expand_path
 
@@ -236,19 +237,82 @@ class Init(_ProjectCommand):
             'init',
             'create a west workspace',
             f'''\
-Creates a west workspace.
+Initialize a west workspace (topdir) from a west manifest (`west.yml`) by
+creating a `.west` directory in the topdir and a local configuration file
+`.west/config`.
+The West manifest can come from either a git repository (that will be cloned
+during workspace initialization) or from an already existing local directory.
 
-With -l, creates a workspace around an existing local repository;
-without -l, creates a workspace by cloning a manifest repository
-by URL.
+West only reads the manifest data from the manifest tree.
+In detail, this is the manifest file and any files it imports. Everything else
+in that tree is not used by west at all (including git history or branches).
 
-With -m, clones the repository at that URL and uses it as the
-manifest repository. If --mr is not given, the remote's default
-branch will be used, if it exists.
+Common arguments
+----------------
+In a nutshell:
 
-With neither, -m {MANIFEST_URL_DEFAULT} is assumed.
+    topdir/manifest.path/manifest.file
 
-Warning: 'west init' renames and/or deletes temporary files inside the
+Each component can have subdirectories, even the last one despite its name
+`manifest.file`.
+
+-t / --topdir WORKSPACE_DIR
+    The workspace directory; `.west` is created inside it. Defaults are
+    described per mode below.
+
+--mp / --manifest-path SUBPATH
+    Path, relative to the workspace, where the manifest tree
+    lives within the workspace (sets the `manifest.path` config option).
+    In remote mode: where the manifest repository is cloned.
+    In local mode: a newer and clearer alternative to the positional argument.
+
+--mf / --manifest-file FILE
+    Path of the manifest file inside the manifest directory (sets the
+    `manifest.file` config option); relative to `manifest.path` and may
+    include subdirectories. Defaults to '{_WEST_YML}'.
+
+
+1. Using a Manifest Repository (default)
+----------------------------------------
+West clones the given repository (provided via `-m / --manifest-url`).
+Note, that the repository must contain a west manifest.
+
+If no `-m / --manifest-url` is provided, west uses the Zephyr URL by default:
+  {MANIFEST_URL_DEFAULT}.
+
+The topdir (where `.west` is created) is determined as follows:
+- argument `-t / --topdir` if provided
+- otherwise: the positional argument `directory` if provided (deprecated;
+  prefer `-t/--topdir`)
+- otherwise: the current working directory
+
+The positional argument `directory` and `-t / --topdir` cannot be combined
+in cloning mode; use `--manifest-path SUBPATH` instead to control where
+within the workspace the manifest repository is cloned (defaults to the
+manifest's `self: path:` if declared, otherwise the manifest URL's basename,
+e.g. <topdir>/zephyr).
+
+With `--mr`, the revision (branch, tag, or sha) of the repository can be
+specified that will be used. It defaults to the repository's default branch.
+
+2. Using a Local Manifest
+-------------------------
+If `-l / --local` is given, west initializes a workspace from an already
+present manifest tree.
+
+The topdir (where `.west` is created) is determined as follows:
+- argument `-t / --topdir` if provided
+- otherwise (legacy form): `manifest_directory`'s parent, or the current
+  working directory if neither the positional nor `--manifest-path` is given
+
+The manifest tree location can be specified either as the positional
+argument `manifest_directory` (a path to the manifest directory) or via the
+newer `--manifest-path` (a subdirectory of the workspace). The two forms
+cannot be combined.
+
+Known Issues
+------------
+'west init' renames and/or deletes temporary files inside the
 workspace being created. This fails on some filesystems when some
 development tool or any other program is trying to read/index these
 temporary files at the same time. For instance, it is required to stop
@@ -273,9 +337,12 @@ below.
         parser = self._parser(
             parser_adder,
             usage='''
+  init with a repository:
+  %(prog)s [-m URL] [--mr MF_REVISION] [--mf FILE] [--mp SUBPATH]
+                [-o=GIT_CLONE_OPTION] [-t WORKSPACE_DIR] [directory]
 
-  %(prog)s [-m URL] [--mr REVISION] [--mf FILE] [-o=GIT_CLONE_OPTION] [directory]
-  %(prog)s -l [--mf FILE] directory
+  init with an existing local manifest:
+  %(prog)s -l [-t WORKSPACE_DIR] [--mf FILE] [--mp SUBPATH] [manifest_directory]
 ''',
         )
 
@@ -284,6 +351,7 @@ below.
         parser.add_argument(
             '-m',
             '--manifest-url',
+            metavar='URL',
             help='''manifest repository URL to clone;
                     cannot be combined with -l''',
         )
@@ -292,6 +360,7 @@ below.
             '--clone-opt',
             action='append',
             default=[],
+            metavar='GIT_CLONE_OPTION',
             help='''additional option to pass to 'git clone'
                     (e.g. '-o=--depth=1'); may be given more than once;
                     cannot be combined with -l''',
@@ -300,21 +369,53 @@ below.
             '--mr',
             '--manifest-rev',
             dest='manifest_rev',
+            metavar='MF_REVISION',
             help='''manifest repository branch or tag name
                     to check out first; cannot be combined with -l''',
-        )
-        parser.add_argument(
-            '--mf', '--manifest-file', dest='manifest_file', help='manifest file name to use'
         )
         parser.add_argument(
             '-l',
             '--local',
             action='store_true',
-            help='''use "directory" as an existing local
-                    manifest repository instead of cloning one from
-                    MANIFEST_URL; .west is created next to "directory"
-                    in this case, and manifest.path points at
-                    "directory"''',
+            help='''initialize workspace from an already existing local
+                    manifest instead of cloning a git repository;
+                    cannot be combined with -m''',
+        )
+        parser.add_argument(
+            '--mf',
+            '--manifest-file',
+            dest='manifest_file',
+            metavar='FILE',
+            help=f'''manifest file name (sets the manifest.file config
+                     option); the relative path of the manifest file
+                     within the manifest directory.
+                     Defaults to {_WEST_YML}.''',
+        )
+        parser.add_argument(
+            '--mp',
+            '--manifest-path',
+            dest='manifest_path',
+            metavar='SUBPATH',
+            help='''path of the manifest repository within the workspace
+                    (sets the manifest.path config option); SUBPATH must be
+                    relative and is interpreted relative to the workspace
+                    root (-t/--topdir, the positional directory in remote
+                    mode, or cwd, in that order); in remote mode this is
+                    where the manifest repository is cloned and defaults to
+                    the manifest's "self: path:" if declared, otherwise the
+                    manifest URL's basename (e.g. "zephyr"); in local mode
+                    this is an alternative to the positional argument and
+                    cannot be combined with it''',
+        )
+        parser.add_argument(
+            '-t',
+            '--topdir',
+            dest='topdir',
+            metavar='WORKSPACE_DIR',
+            help='''the workspace directory where .west directory
+                    will be created (WORKSPACE_DIR/.west);
+                    the workspace directory may already exist
+                    and WORKSPACE_DIR/.west must not exist''',
         )
         parser.add_argument(
             '--rename-delay',
@@ -330,9 +431,13 @@ below.
             'directory',
             nargs='?',
             default=None,
-            help='''with -l, the path to the local manifest repository;
-            without it, the directory to create the workspace in (defaulting
-            to the current working directory in this case)''',
+            metavar='directory',
+            help='''With --local: the path to a local directory which contains
+                    a west manifest (west.yml); cannot be combined with
+                    --manifest-path.
+                    Without --local (remote mode): the workspace directory
+                    where .west will be created. This form is deprecated;
+                    prefer -t/--topdir. It cannot be combined with -t.''',
         )
 
         return parser
@@ -364,6 +469,9 @@ below.
         if args.manifest_file is not None and Path(args.manifest_file).is_absolute():
             self.die(f'--mf {args.manifest_file} argument is not relative')
 
+        if args.manifest_path is not None and Path(args.manifest_path).is_absolute():
+            self.die(f'--mp {args.manifest_path} argument is not relative')
+
         self.die_if_no_git()
 
         if args.local:
@@ -380,41 +488,85 @@ below.
         if args.manifest_rev is not None:
             self.die('--mr cannot be used with -l')
 
-        # We need to resolve this to handle the case that args.directory
-        # is '.'. In that case, Path('.').parent is just Path('.') instead of
-        # Path('..').
-        #
-        # https://docs.python.org/3/library/pathlib.html#pathlib.PurePath.parent
-        manifest_dir = Path(args.directory or os.getcwd()).resolve()
+        if args.directory is not None and args.manifest_path is not None:
+            self.die(
+                'in local mode, the positional <directory> cannot be combined '
+                'with --manifest-path; pass one or the other'
+            )
 
-        try:
-            already = util.west_topdir(manifest_dir, fall_back=False)
-            self.die_already(already)
-        except util.WestNotFound:
-            pass
+        # Resolve the manifest directory. With --manifest-path, the manifest
+        # location is a subpath of the workspace; without it, the positional
+        # argument (or cwd) is the manifest directory directly. Note we call
+        # resolve() so that 'west init -l .' works as expected -- without it,
+        # Path('.').parent is Path('.') rather than Path('..').
+        if args.manifest_path is not None:
+            topdir = Path(args.topdir or os.getcwd()).resolve()
+            abs_manifest_path = (topdir / args.manifest_path).resolve()
+        else:
+            abs_manifest_path = Path(args.directory or os.getcwd()).resolve()
+            topdir = Path(args.topdir or abs_manifest_path.parent).resolve()
 
-        manifest_filename = args.manifest_file or 'west.yml'
-        manifest_file = manifest_dir / manifest_filename
-        topdir = manifest_dir.parent
-        rel_manifest = manifest_dir.name
+        manifest_file = args.manifest_file or _WEST_YML
+        abs_manifest_file = abs_manifest_path / manifest_file
+
+        # Re-initialization is always an error: check the workspace
+        # itself first so the error refers to topdir rather than to the
+        # manifest path.
+        for check in (topdir, abs_manifest_path):
+            try:
+                already = util.west_topdir(check, fall_back=False)
+                self.die_already(already)
+            except util.WestNotFound:
+                pass
+
+        if not abs_manifest_file.is_file():
+            self.die(f'can\'t init: no {manifest_file} found in {abs_manifest_path}')
+
+        if not abs_manifest_file.is_relative_to(topdir):
+            self.die(f'{abs_manifest_file} must be relative to west topdir {topdir}')
+
+        rel_manifest = abs_manifest_path.relative_to(topdir)
         west_dir = topdir / WEST_DIR
 
-        if not manifest_file.is_file():
-            self.die(f'can\'t init: no {manifest_filename} found in {manifest_dir}')
-
-        self.banner('Initializing from existing manifest repository', rel_manifest)
+        self.banner('Initializing with existing manifest', rel_manifest)
         self.small_banner(f'Creating {west_dir} and local configuration file')
         self.create(west_dir, exist_ok=False)
         os.chdir(topdir)
         self.config = Configuration(topdir=topdir)
         self.config.set('manifest.path', os.fspath(rel_manifest))
-        self.config.set('manifest.file', manifest_filename)
+        self.config.set('manifest.file', manifest_file)
 
         return topdir
 
     def bootstrap(self, args) -> Path:
-        topdir = Path(abspath(args.directory or os.getcwd()))
-        self.banner('Initializing in', topdir)
+        # Determine the workspace/topdir. The positional <directory> in
+        # remote mode is the legacy way to set topdir; --topdir is the
+        # canonical knob. The two cannot be combined: with -t given,
+        # --manifest-path is the way to control where within the workspace
+        # the manifest repository is cloned.
+        if args.topdir and args.directory:
+            self.die(
+                f"positional <directory> '{args.directory}' cannot be combined "
+                f"with -t/--topdir; use --manifest-path SUBPATH to control "
+                f"where the manifest repository is cloned within the workspace"
+            )
+
+        if args.topdir:
+            topdir = Path(args.topdir)
+        elif args.directory:
+            self.wrn(
+                "the positional <directory> argument in remote mode is "
+                "deprecated; use -t/--topdir instead"
+            )
+            topdir = Path(args.directory)
+        else:
+            topdir = Path('.')
+        topdir = topdir.resolve()
+
+        if args.manifest_path and util.escapes_directory(topdir / args.manifest_path, topdir):
+            self.die(f'--mp {args.manifest_path} argument escapes the workspace {topdir}')
+
+        self.banner(f'Initializing in {topdir}')
 
         manifest_url = args.manifest_url or MANIFEST_URL_DEFAULT
         if args.manifest_rev:
@@ -469,7 +621,7 @@ below.
             raise
 
         # Verify the manifest file exists.
-        temp_manifest_filename = args.manifest_file or 'west.yml'
+        temp_manifest_filename = args.manifest_file or _WEST_YML
         temp_manifest = tempdir / temp_manifest_filename
         if not temp_manifest.is_file():
             self.die(
@@ -486,14 +638,26 @@ below.
         manifest = Manifest.from_data(
             temp_manifest.read_text(encoding=Manifest.encoding), import_flags=ImportFlag.IGNORE
         )
-        if manifest.yaml_path:
-            manifest_path = manifest.yaml_path
+
+        if args.manifest_path:
+            # User-supplied --manifest-path fully overrides the default
+            # (the manifest's "self: path:" or the URL basename).
+            manifest_path = Path(args.manifest_path)
+            if manifest.yaml_path and Path(manifest.yaml_path) != manifest_path:
+                self.wrn(
+                    f'--manifest-path {manifest_path} overrides the manifest\'s '
+                    f'declared "self: path: {manifest.yaml_path}"'
+                )
         else:
-            # We use PurePath() here in case manifest_url is a
-            # windows-style path. That does the right thing in that
-            # case, without affecting POSIX platforms, where PurePath
-            # is PurePosixPath.
-            manifest_path = PurePath(urlparse(manifest_url).path).name
+            if manifest.yaml_path:
+                yaml_path = manifest.yaml_path
+            else:
+                # We use PurePath() here in case manifest_url is a
+                # windows-style path. That does the right thing in that
+                # case, without affecting POSIX platforms, where PurePath
+                # is PurePosixPath.
+                yaml_path = PurePath(urlparse(manifest_url).path).name
+            manifest_path = Path(yaml_path)
 
         manifest_abspath = topdir / manifest_path
 
@@ -531,7 +695,7 @@ below.
             self.die(e)
         self.small_banner('setting manifest.path to', manifest_path)
         self.config = Configuration(topdir=topdir)
-        self.config.set('manifest.path', manifest_path)
+        self.config.set('manifest.path', str(manifest_path))
         self.config.set('manifest.file', temp_manifest_filename)
 
         return topdir

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -665,3 +665,15 @@ def check_proj_consistency(actual, expected):
     assert actual.clone_depth == expected.clone_depth
     assert actual.revision == expected.revision
     assert actual.west_commands == expected.west_commands
+
+
+def tree(path: Path, prefix="") -> str:
+    lines = []
+    entries = sorted(path.iterdir(), key=lambda p: (p.is_file(), p.name))
+    for i, entry in enumerate(entries):
+        connector = "└── " if i == len(entries) - 1 else "├── "
+        lines.append(prefix + connector + entry.name)
+        if entry.is_dir():
+            indent = "    " if i == len(entries) - 1 else "│   "
+            lines.extend(tree(entry, prefix + indent).splitlines())
+    return "\n".join(lines)

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2020, Nordic Semiconductor ASA
 
 import collections
+import io
 import os
 import re
 import shutil
@@ -25,6 +26,7 @@ from conftest import (
     create_repo,
     create_workspace,
     rev_parse,
+    tree,
     yaml_editor,
 )
 
@@ -2037,6 +2039,388 @@ def test_init_local_with_manifest_filename(repos_tmpdir):
     cmd(['init', '--mf', 'project.yml', '-l', zephyr_install_dir])
     workspace.chdir()
     cmd('update')
+
+
+def _setup_test_init(manifest_repo, local_dir, topdir, directory, manifest_file, manifest_path):
+    flags = []
+    if local_dir:
+        # make sure that manifest_repo is present under local_dir
+        clone(str(manifest_repo), str(local_dir))
+        flags += ['-l']
+    else:
+        # clone from remote manifest
+        flags += ["-m", manifest_repo]
+
+    # extend west init flags according to specified test case
+    if topdir:
+        flags += ['-t', topdir]
+    if manifest_file:
+        flags += ['--mf', manifest_file]
+    if manifest_path:
+        flags += ['--mp', manifest_path]
+    if directory:
+        flags += [directory]
+    return flags
+
+
+TEST_CASES_INIT = [
+    # (local_dir, topdir, directory, manifest_file, manifest_path)
+    ######################################
+    # REMOTE MANIFEST
+    ######################################
+    # init from remote repository (without any parameters)
+    (None, None, None, None, None),
+    # specify topdir in current directory
+    (None, Path('.'), None, None, None),
+    # specify topdir in a subfolder
+    (None, Path('subdir'), None, None, None),
+    # use deprecated [directory] to specify topdir
+    (None, None, Path('subdir'), None, None),
+    # specify topdir and clone manifest into a subpath via --manifest-path
+    (None, Path('subdir'), None, None, Path('extra') / 'level' / 'zephyr'),
+    # specify topdir and clone manifest into a subpath via --manifest-path
+    (None, Path('.'), None, None, Path('extra') / 'level' / 'zephyr'),
+    ######################################
+    # LOCAL MANIFEST
+    ######################################
+    # init workspace in current working directory (without --topdir)
+    (Path('workspace') / 'zephyr', None, Path('workspace') / 'zephyr', None, None),
+    # init workspace in current working directory
+    (Path('workspace') / 'zephyr', Path('.'), Path('workspace') / 'zephyr', None, None),
+    # init workspace in a subfolder of current working directory
+    (Path('workspace') / 'zephyr', Path('workspace'), Path('workspace') / 'zephyr', None, None),
+    # init workspace via --manifest-path instead of the positional argument
+    (Path('workspace') / 'zephyr', Path('workspace'), None, None, Path('zephyr')),
+    # init workspace in current working directory by providing a manifest file
+    (
+        Path('workspace') / 'zephyr',
+        Path('.'),
+        Path('workspace'),
+        Path('zephyr') / 'west.yml',
+        None,
+    ),
+    # init workspace in itself by providing manifest file
+    (
+        Path('workspace') / 'zephyr',
+        Path('.'),
+        Path('.'),
+        Path('workspace') / 'zephyr' / 'west.yml',
+        None,
+    ),
+    # init workspace in a subfolder by providing manifest file
+    (
+        Path('workspace') / 'subdir' / 'zephyr',
+        Path('workspace'),
+        Path('workspace') / 'subdir',
+        Path('zephyr') / 'west.yml',
+        None,
+    ),
+    # init workspace in a subfolder by providing manifest file
+    (
+        Path('workspace') / 'subdir' / 'zephyr',
+        Path('workspace'),
+        Path('workspace'),
+        Path('subdir') / 'zephyr' / 'west.yml',
+        None,
+    ),
+    # init workspace in a subfolder via --manifest-path
+    (
+        Path('workspace') / 'subdir' / 'zephyr',
+        Path('workspace'),
+        None,
+        None,
+        Path('subdir') / 'zephyr',
+    ),
+]
+
+
+@pytest.mark.parametrize("test_case", TEST_CASES_INIT)
+def test_init(repos_tmpdir, test_case):
+    local_dir, topdir, directory, manifest_file, manifest_path = test_case
+
+    repos_tmpdir.chdir()
+    manifest_repo = repos_tmpdir / 'repos' / 'zephyr'
+    flags = _setup_test_init(
+        manifest_repo, local_dir, topdir, directory, manifest_file, manifest_path
+    )
+
+    # initialize west workspace
+    cmd(['init'] + flags)
+
+    # cd into the workspace
+    if local_dir:
+        # topdir is either specified or default (directory.parent)
+        workspace = topdir or directory.parent
+    else:
+        # topdir is either specified, directory or default (cwd)
+        workspace = topdir or directory or Path.cwd()
+    workspace_abs = workspace.absolute()
+    os.chdir(workspace)
+
+    # check if config option 'manifest.path' is correctly set
+    actual = cmd('config manifest.path')
+    if local_dir:
+        if manifest_path:
+            expected_mp = Path(manifest_path)
+        else:
+            expected_mp = directory.relative_to(workspace)
+        assert Path(actual.rstrip()) == expected_mp
+    else:
+        if manifest_path:
+            # manifest cloned into the requested subpath
+            assert Path(actual.rstrip()) == Path(manifest_path)
+        else:
+            # zephyr is cloned directly to workspace
+            assert Path(actual.rstrip()) == Path('zephyr')
+
+    # check if config option 'manifest.file' is correctly set
+    actual = cmd('config manifest.file')
+    expected = manifest_file or Path('west.yml')
+    assert Path(actual.rstrip()) == Path(expected)
+
+    # re-initialization of a workspace must always fail
+    _, stderr = cmd_raises(['init'] + flags, SystemExit)
+    assert "FATAL ERROR: already initialized" in stderr
+    os.chdir(workspace.parent)
+    _, stderr = cmd_raises(['init', '-l', '--topdir', workspace_abs, manifest_repo], SystemExit)
+    assert "FATAL ERROR: already initialized" in stderr
+    _, stderr = cmd_raises(['init', '--topdir', workspace_abs, '-m', manifest_repo], SystemExit)
+    assert "FATAL ERROR: already initialized" in stderr
+
+
+TEST_CASES_INIT_FAILS = [
+    # (local_dir, topdir, directory, manifest_file, manifest_path,
+    #  expected_error, expected_stderr)
+    ######################################
+    # REMOTE MANIFEST
+    ######################################
+    # specify a non-existent manifest file
+    (
+        None,
+        Path('.'),
+        None,
+        Path('non-existent.yml'),
+        None,
+        SystemExit,
+        "FATAL ERROR: can't init: no non-existent.yml found",
+    ),
+    # combining -t and positional [directory] in remote mode is now an error
+    (
+        None,
+        Path('subdir'),
+        Path('sibling'),
+        None,
+        None,
+        SystemExit,
+        "cannot be combined with -t/--topdir",
+    ),
+    # combining -t and positional [directory] in remote mode is now an error
+    # (even when the positional would have nominally been a valid subpath)
+    (
+        None,
+        Path('subdir'),
+        Path('subdir') / 'extra' / 'level',
+        None,
+        None,
+        SystemExit,
+        "cannot be combined with -t/--topdir",
+    ),
+    # --manifest-path must be relative. Construct an absolute path that
+    # is recognised as absolute on both POSIX and Windows: a bare
+    # "/abs/path" is drive-relative on Windows and Path.is_absolute()
+    # returns False there, which would skip the validation we want to
+    # exercise.
+    (
+        None,
+        Path('subdir'),
+        None,
+        None,
+        Path(os.path.abspath('/abs/path')),
+        SystemExit,
+        "argument is not relative",
+    ),
+    # --manifest-path must stay within the workspace; a relative path that
+    # uses ".." to climb out of the topdir is rejected.
+    (
+        None,
+        Path('subdir'),
+        None,
+        None,
+        Path('..') / 'outside',
+        SystemExit,
+        "escapes the workspace",
+    ),
+    ######################################
+    # LOCAL MANIFEST
+    ######################################
+    # init workspace without a directory
+    (
+        Path('workspace') / 'zephyr',
+        Path('.'),
+        None,
+        None,
+        None,
+        SystemExit,
+        "FATAL ERROR: can't init: no west.yml found",
+    ),
+    # init workspace in a sibling repository path
+    (
+        Path('workspace') / 'zephyr',
+        Path('sibling'),
+        Path('workspace') / 'zephyr',
+        None,
+        None,
+        SystemExit,
+        "west.yml must be relative to west topdir",
+    ),
+    # init workspace from non-existent manifest
+    (
+        Path('workspace') / 'zephyr',
+        Path('.'),
+        Path('non-existent.yml'),
+        None,
+        None,
+        SystemExit,
+        "FATAL ERROR: can't init: no west.yml found",
+    ),
+    # init workspace from a manifest not inside the workspace
+    (
+        Path('..') / 'zephyr',
+        Path('.'),
+        Path('..') / 'zephyr',
+        None,
+        None,
+        SystemExit,
+        "west.yml must be relative to west topdir",
+    ),
+    # combining positional and --manifest-path in local mode is an error
+    (
+        Path('workspace') / 'zephyr',
+        None,
+        Path('workspace') / 'zephyr',
+        None,
+        Path('zephyr'),
+        SystemExit,
+        "cannot be combined with --manifest-path",
+    ),
+]
+
+
+@pytest.mark.parametrize("test_case", TEST_CASES_INIT_FAILS)
+def test_init_fails(repos_tmpdir, test_case):
+    (
+        local_dir,
+        topdir,
+        directory,
+        manifest_file,
+        manifest_path,
+        expected_error,
+        expected_stderr,
+    ) = test_case
+
+    manifest_repo = repos_tmpdir / 'repos' / 'zephyr'
+    repos_tmpdir.chdir()
+    flags = _setup_test_init(
+        manifest_repo, local_dir, topdir, directory, manifest_file, manifest_path
+    )
+    _, stderr = cmd_raises(['init'] + flags, expected_error)
+    assert expected_stderr in stderr
+
+
+def test_init_remote_positional_deprecation_warning(repos_tmpdir):
+    # The positional <directory> in remote mode still works but emits a
+    # deprecation warning pointing at -t/--topdir.
+    zephyr_remote = repos_tmpdir / 'repos' / 'zephyr'
+    repos_tmpdir.chdir()
+
+    out = io.StringIO()
+    cmd(['init', '-m', str(zephyr_remote), 'workspace'], stderr=out)
+    stderr = out.getvalue()
+    assert 'deprecated' in stderr
+    assert '-t/--topdir' in stderr
+    assert (Path(repos_tmpdir) / 'workspace' / '.west').exists()
+
+
+def test_init_topdir_with_manifest_path(repos_tmpdir):
+    # west init -m URL -t /ws --manifest-path zephyr/repos/manifest
+    # clones the manifest into /ws/zephyr/repos/manifest.
+    zephyr_remote = repos_tmpdir / 'repos' / 'zephyr'
+    repos_tmpdir.chdir()
+
+    workspace = Path(repos_tmpdir) / 'ws'
+    mp = Path('zephyr') / 'repos' / 'manifest'
+    cmd(['init', '-m', str(zephyr_remote), '-t', str(workspace), '--mp', str(mp)])
+
+    assert (workspace / '.west').is_dir()
+    assert (workspace / mp / 'west.yml').is_file()
+    os.chdir(workspace)
+    actual = cmd('config manifest.path').rstrip()
+    assert Path(actual) == mp
+
+
+def test_init_local_with_manifest_path(repos_tmpdir):
+    # west init -l -t /ws --manifest-path zephyr is equivalent to
+    # passing the manifest dir as positional.
+    repos_tmpdir.chdir()
+    workspace = Path(repos_tmpdir) / 'ws'
+    clone(str(repos_tmpdir / 'repos' / 'zephyr'), workspace / 'zephyr')
+
+    cmd(['init', '-l', '-t', str(workspace), '--mp', 'zephyr'])
+
+    assert (workspace / '.west').is_dir()
+    os.chdir(workspace)
+    assert cmd('config manifest.path').rstrip() == 'zephyr'
+
+
+def test_init_result_in_similar_worktree(repos_tmpdir):
+    zephyr_remote = repos_tmpdir / 'repos' / 'zephyr'
+    repos_tmpdir.chdir()
+    zephyr_subdir = Path('extra') / 'level' / 'zephyr'
+
+    # init a workspace from an existing local manifest, clone is at topdir_l/extra/level/zephyr
+    topdir_l = Path(repos_tmpdir) / 'topdir_l'
+    clone(str(repos_tmpdir / 'repos' / 'zephyr'), topdir_l / zephyr_subdir)
+    flags_l = ['-l', f'-t={topdir_l}', '--mp', zephyr_subdir]
+    _ = cmd(['init'] + flags_l)
+
+    # init a workspace from a remote manifest -- use --manifest-path to clone
+    # the manifest into the same subdir as the local case
+    topdir_r = Path(repos_tmpdir) / 'topdir_r'
+    flags_r = [f'-m={zephyr_remote}', f'-t={topdir_r}', '--mp', zephyr_subdir]
+    _ = cmd(['init'] + flags_r)
+
+    # Check that both resulting worktrees look the same
+    tree_l = tree(topdir_l)
+    tree_r = tree(topdir_r)
+    assert tree_l == tree_r
+
+
+def test_init_topdir_again(repos_tmpdir):
+    repos_tmpdir.chdir()
+    workspace = Path(repos_tmpdir) / 'ws'
+    zephyr = repos_tmpdir / 'repos' / 'zephyr'
+
+    # initial clone via the deprecated positional <directory> form
+    cmd(['init', 'ws', '-m', zephyr])
+
+    # initialize west workspace again, via the (deprecated) positional form
+    _, stderr = cmd_raises(['init', 'ws', '-m', zephyr], SystemExit)
+    assert "FATAL ERROR: already initialized" in stderr
+
+    # initialize west workspace again, via -t/--topdir
+    _, stderr = cmd_raises(['init', '--topdir', 'ws', '-m', zephyr], SystemExit)
+    assert "FATAL ERROR: already initialized" in stderr
+
+    # initialize west workspace again from inside the workspace in local mode
+    os.chdir(workspace)
+    _, stderr = cmd_raises(['init', '--local', 'zephyr'], SystemExit)
+    assert "FATAL ERROR: already initialized" in stderr
+
+    # initialize west workspace again, local mode with -t and a positional
+    # path that resolves to inside the workspace
+    os.chdir(workspace.parent)
+    _, stderr = cmd_raises(['init', '-l', '--topdir', 'ws', Path('ws') / 'zephyr'], SystemExit)
+    assert "FATAL ERROR: already initialized" in stderr
 
 
 def test_init_local_with_empty_path(repos_tmpdir):


### PR DESCRIPTION
Fixes https://github.com/zephyrproject-rtos/west/issues/774 (Successor of https://github.com/zephyrproject-rtos/west/pull/775 EDIT: and #854)

This PR introduces a new --topdir option for west init, allowing users to explicitly specify the west workspace directory (topdir) during initialization.

This is particularly useful when using --local, as the current behavior always sets the parent of the given directory as the topdir. In addition, west is currently unable to determine both manifest.path and manifest.file from a single directory argument as the path can be interpreted in multiple ways (e.g. it can be split at various places).

With the new --topdir argument, users can now directly control where the west workspace is created.

Parameterized tests for west init --topdir are added as well.

Moreover, the help texts and descriptions are (hopefully) simplified.