### PR TITLE
project: stop defaulting `west init` to upstream Zephyr

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,10 +29,12 @@ By default the manifest file is named ``west.yml``.
 You use ``west init`` to set up this directory, then ``west update`` to fetch
 and/or update the repositories named in the manifest.
 
-By default, west uses `upstream Zephyr's manifest file
-<https://github.com/zephyrproject-rtos/zephyr/blob/main/west.yml>`_, but west
-doesn't care if the manifest repository is zephyr or not. You can and are
-encouraged to make your own manifest repositories to meet your needs.
+West used to default to `upstream Zephyr's manifest file
+<https://github.com/zephyrproject-rtos/zephyr/blob/main/west.yml>`_.
+You are still able and will always be able to use this manifest but you
+are now required to pass it explicitly and, you are more encouraged than
+before to design your own manifest(s) instead and minimized security SBOMs
+based on your specific needs.
 
 For more details, see the `West (Zephyr's meta-tool)
 <https://docs.zephyrproject.org/latest/develop/west/index.html>`_ in the Zephyr
@@ -41,12 +43,12 @@ documentation.
 Example usage using the upstream manifest file::
 
   mkdir zephyrproject && cd zephyrproject
-  west init
+  west init -m https://github.com/zephyrproject-rtos/zephyr/
   west update
 
 What just happened:
 
-- ``west init`` clones the upstream *west manifest* repository, which in this
+- ``west init -m ...`` clones the upstream *west manifest* repository, which in this
   case is the zephyr repository. The manifest repository contains ``west.yml``,
   a YAML description of the Zephyr installation, including Git repositories and
   other metadata.

--- a/src/west/app/project.py
+++ b/src/west/app/project.py
@@ -274,11 +274,8 @@ Each component can have subdirectories, even the last one despite its name
 
 1. Using a Manifest Repository (default)
 ----------------------------------------
-West clones the given repository (provided via `-m / --manifest-url`).
+West clones the repository provided via `-m / --manifest-url`.
 Note, that the repository must contain a west manifest.
-
-If no `-m / --manifest-url` is provided, west uses the Zephyr URL by default:
-  {MANIFEST_URL_DEFAULT}.
 
 The topdir (where `.west` is created) is determined as follows:
 - argument `-t / --topdir` if provided
@@ -347,8 +344,9 @@ below.
         )
 
         # Remember to update the usage if you modify any arguments.
+        clone_or_local = parser.add_mutually_exclusive_group(required=True)
 
-        parser.add_argument(
+        clone_or_local.add_argument(
             '-m',
             '--manifest-url',
             metavar='URL',
@@ -373,7 +371,7 @@ below.
             help='''manifest repository branch or tag name
                     to check out first; cannot be combined with -l''',
         )
-        parser.add_argument(
+        clone_or_local.add_argument(
             '-l',
             '--local',
             action='store_true',
@@ -568,7 +566,7 @@ below.
 
         self.banner(f'Initializing in {topdir}')
 
-        manifest_url = args.manifest_url or MANIFEST_URL_DEFAULT
+        manifest_url = args.manifest_url
         if args.manifest_rev:
             # This works with tags, too.
             branch_opt = ['--branch', args.manifest_rev]
@@ -2819,9 +2817,6 @@ def projects_unknown(manifest, projects):
 
 # Top-level west directory, containing west itself and the manifest.
 WEST_DIR = util.WEST_DIR
-
-# Default manifest repository URL.
-MANIFEST_URL_DEFAULT = 'https://github.com/zephyrproject-rtos/zephyr'
 
 #
 # Other shared globals.

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1923,8 +1923,8 @@ def test_init_again(west_init_tmpdir):
 
     expected_msg = f'FATAL ERROR: already initialized in {west_init_tmpdir}'
 
-    # A bare `init` defaults to cloning -m http://zephyrproject/zephyr
-    exc, stderr = cmd_raises('init', SystemExit, cwd=west_init_tmpdir)
+    # The local disk state should be checked before the remote bogus_url
+    exc, stderr = cmd_raises(['init', '-m', 'bogus_url'], SystemExit, cwd=west_init_tmpdir)
     assert exc.value.code == 1
     assert expected_msg in stderr
 


### PR DESCRIPTION
Stop defaulting `west init` to `west init -m
https://github.com/zephyrproject-rtos/zephyr/`. The argument must be passed explicitly.

Thanks to argparse, a bare `west init` now errors like this:

```
usage:

  west init [-m URL] [--mr REVISION] [--mf FILE] [-o=GIT_CLONE_OPTION] [directory]
  west init -l [--mf FILE] directory

west init: error: one of the arguments -m/--manifest-url -l/--local is required
```

This is part of the wider effort to make west independent from Zephyr: https://github.com/zephyrproject-rtos/west/issues/246

This should also help nudge people towards creating their own manifests, which will mitigate Zephyr's "tragedy of the commons" where many people want their stuff to be present the default upstream manifest, while also complaining that the default is way too big and slow (currently around 10 Gigabytes)

- https://github.com/zephyrproject-rtos/zephyr/issues/91061
- https://github.com/zephyrproject-rtos/zephyr/issues/108783#issuecomment-4526275800