### PR TITLE
check manifest --resolve in _subdir_special_chars() test

### DIFF
--- a/tests/test_extension_commands.py
+++ b/tests/test_extension_commands.py
@@ -428,6 +428,21 @@ def test_call_imported_project_submanifest_commands_from_project_subdirectory_sp
     ext_output = cmd('imported-command-from-subdir-windows', cwd=workspace)
     assert 'imported command from subdir with windows paths works' in ext_output
 
+    # Check how west-commands: gets printed back in `west manifest --resolve`
+    _resolved_mf = cmd(['manifest', '--resolve'], cwd=workspace)
+    resolved_mf = yaml.safe_load(_resolved_mf)
+    net_tools = _yaml_get_proj(resolved_mf, "net-tools")
+    # FIXME #961: this is inconsistent with the other _special_chars() test
+    # below which does NOT normalize as_posix() on Windows!
+    if WINDOWS:
+        # All normalized to forward slashes a/b/c/d on Windows
+        expected = r'mf_subdir/' + Path(_WEIRD_CMDS_PATH).as_posix()
+    else:
+        # Untouched on Un*x
+        expected = r'mf_subdir/' + _WEIRD_CMDS_PATH
+    print()
+    assert net_tools["west-commands"][1] == expected
+
 
 def test_extension_special_chars(west_update_tmpdir):
     # Detect any unexpected changes in the way we've been handling backslashes and other

--- a/tests/test_extension_commands.py
+++ b/tests/test_extension_commands.py
@@ -6,7 +6,6 @@ import subprocess
 import textwrap
 from pathlib import Path
 
-import pytest
 import yaml
 from conftest import GIT, WINDOWS, add_commit, cmd, cmd_raises, yaml_editor
 
@@ -344,28 +343,28 @@ def test_call_imported_project_submanifest_commands_from_project_subdirectory(re
     assert 'imported command from subdir works' in ext_output
 
 
-@pytest.mark.skipif(
-    not WINDOWS, reason="non-posix path separators don't work reliably on non-Windows"
-)
-def test_call_imported_project_submanifest_commands_from_project_subdirectory_windows_paths(
+def test_call_imported_project_submanifest_commands_from_project_subdirectory_special_chars(
     repos_tmpdir,
 ):
-    # Same as the forward-slash test above, but use Windows-style
-    # separators in the manifest file paths.
+    # Same as the forward-slash test above, but use non-portable separators in
+    # the manifest file paths. See test_extension_special_chars() for more
+    # details.
     manifest_path = repos_tmpdir / 'repos' / 'zephyr'
     net_tools_path = repos_tmpdir / 'repos' / 'net-tools'
 
+    _WEIRD_CMDS_PATH = r'scripts/\winsubA\\\west-commands-from-subdir-windows.yml'
     MF_SUB_WEST_YML = textwrap.dedent(
-        '''\
+        f'''\
         manifest:
           self:
-            west-commands: scripts\\west-commands-from-subdir-windows.yml
+            west-commands: {_WEIRD_CMDS_PATH}
         '''
     )
+    _WEIRD_EXT_PATH = r'test\\/winsubB\\\west-commands\subdir_command_windows.py'
     MF_SUB_COMMANDS_YML = textwrap.dedent(
-        '''\
+        f'''\
         west-commands:
-          - file: test\\west-commands\\subdir_command_windows.py
+          - file: {_WEIRD_EXT_PATH}
             commands:
               - name: imported-command-from-subdir-windows
                 class: ImportedCommandFromProjectSubdirWindows
@@ -396,9 +395,9 @@ def test_call_imported_project_submanifest_commands_from_project_subdirectory_wi
         net_tools_path,
         'add imported submanifest extension command with windows paths',
         files={
-            r'mf_subdir/west.yml': MF_SUB_WEST_YML,
-            r'mf_subdir/scripts/west-commands-from-subdir-windows.yml': MF_SUB_COMMANDS_YML,
-            r'mf_subdir/test/west-commands/subdir_command_windows.py': MF_SUB_WEST_PY,
+            Path('mf_subdir') / 'west.yml': MF_SUB_WEST_YML,
+            Path('mf_subdir') / _WEIRD_CMDS_PATH: MF_SUB_COMMANDS_YML,
+            Path('mf_subdir') / _WEIRD_EXT_PATH: MF_SUB_WEST_PY,
         },
     )
 

--- a/tests/test_extension_commands.py
+++ b/tests/test_extension_commands.py
@@ -9,6 +9,13 @@ from pathlib import Path
 import yaml
 from conftest import GIT, WINDOWS, add_commit, cmd, cmd_raises, yaml_editor
 
+
+def _yaml_get_proj(mf: dict, projname: str):
+    _l = [p for p in mf["manifest"]['projects'] if p["name"] == projname]
+    assert len(_l) == 1
+    return _l[0]
+
+
 # The west command "test-extension" comes from the "west_update_tmpdir" fixture in conftest.py
 
 
@@ -449,15 +456,10 @@ def test_extension_special_chars(west_update_tmpdir):
     ext_output = cmd('test-extension')
     assert 'Testing test command 1' in ext_output
 
-    def yaml_get_proj(mf: dict, projname: str):
-        _l = [p for p in mf["manifest"]['projects'] if p["name"] == projname]
-        assert len(_l) == 1
-        return _l[0]
-
     # Now also rename the project's 'scripts/west-commands.yml' to something strange
     weird_cmds = r'scripts///win subdir\\\w-cmds.yml'
     with yaml_editor('zephyr/west.yml') as _mf:
-        _ext_p_yml = yaml_get_proj(_mf, ext_proj)
+        _ext_p_yml = _yaml_get_proj(_mf, ext_proj)
         assert _ext_p_yml["west-commands"] == 'scripts/west-commands.yml'
         _ext_p_yml["west-commands"] = weird_cmds
     (ext_proj_p / 'scripts' / 'west-commands.yml').rename(ext_proj_p / weird_cmds)
@@ -473,7 +475,7 @@ def test_extension_special_chars(west_update_tmpdir):
     # Test how west-commands gets printed back in `west manifest --resolve`
     resolved_mf = cmd('manifest --resolve')
     resolved_mf = yaml.safe_load(resolved_mf)
-    ext_proj_yaml = yaml_get_proj(resolved_mf, ext_proj)
+    ext_proj_yaml = _yaml_get_proj(resolved_mf, ext_proj)
     assert ext_proj_yaml["west-commands"] == weird_cmds
 
     ######  self: west-commands #####


### PR DESCRIPTION
3 commits. Main one:

Extend test that was just added by commit https://github.com/zephyrproject-rtos/west/commit/1152ac24137490b4c8020f73470b9961a87a8e84 ("tests: extension-commands: Add test checking \\ windows-style variants for west-commands")

This exposes new issue https://github.com/zephyrproject-rtos/west/issues/961 where the behavior is not consistent, not even on Windows alone.

Signed-off-by: Marc Herbert <marc.herbert@gmail.com>