### PR TITLE
manifest: model west-commands as per-entry records

### DIFF
--- a/src/west/commands.py
+++ b/src/west/commands.py
@@ -662,7 +662,7 @@ def extension_commands(config: Configuration, manifest: Manifest | None = None):
 
     specs = OrderedDict()
     for project in manifest.projects:
-        if project.west_commands:
+        if project.west_commands_entries:
             specs[project.path] = _ext_specs(project)
     return specs
 
@@ -673,10 +673,11 @@ def _ext_specs(project):
 
     ret = []
 
-    for cmd in project.west_commands:
+    for entry in project.west_commands_entries:
+        cmd = entry.path
         spec_file = os.path.join(project.abspath, cmd)
 
-        # Verify project.west_commands isn't trying a directory traversal
+        # Verify the entry's path isn't trying a directory traversal
         # outside of the project.
         if escapes_directory(spec_file, project.abspath):
             raise ExtensionCommandError(
@@ -702,10 +703,9 @@ def _ext_specs(project):
         except pykwalify.errors.SchemaError as e:
             raise ExtensionCommandError from e
 
-        # Resolve west command extensions relative to the manifest root for
-        # import-derived west-commands entries, otherwise project root.
-        mfst_dir = project._west_commands_manifest_dirs.get(cmd)
-        base_dir = os.path.join(project.abspath, mfst_dir) if mfst_dir else project.abspath
+        # We must resolve the paths to west commands relative to the
+        # west manifest's path from the project root.
+        base_dir = os.path.join(project.abspath, entry.base_dir)
 
         for commands_desc in commands_spec['west-commands']:
             ret.extend(_ext_specs_from_desc(project, commands_desc, base_dir))

--- a/src/west/manifest-schema.yml
+++ b/src/west/manifest-schema.yml
@@ -13,7 +13,7 @@
 #
 #  DO NOT CHANGE THIS FILE WITHOUT:
 #
-#  - updating west.manifest.SCHEMA_VERSION and 
+#  - updating west.manifest.SCHEMA_VERSION and
 #    west.manifest._VALID_SCHEMA_VERS
 #  - reviewing and updating sphinx documentation
 #
@@ -120,10 +120,14 @@ mapping:
           clone-depth:
             required: false
             type: int
-          # Path to a west-commands.yml inside the project.
+          # West commands declared by this project. May be a string
+          # (path to a west-commands.yml inside the project), a list of
+          # such strings, or a list of {file, base-dir} maps where
+          # base-dir is the project-relative root the spec's `file:`
+          # entries are resolved against. Validated in Python.
           west-commands:
             required: false
-            type: str
+            type: any
           # Additional manifest data to import from the project.
           import:
             required: false
@@ -155,7 +159,7 @@ mapping:
       # commands. See the above comment for details.
       west-commands:
         required: false
-        type: str
+        type: any
       # Additional manifest data to import from the manifest
       # repository.
       import:

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -59,7 +59,7 @@ QUAL_REFS_WEST = 'refs/west/'
 #: v1.0.x, so that users can say "I want schema version 1" instead of
 #: having to keep using '0.13', which was the previous version this
 #: changed.)
-SCHEMA_VERSION = '1.2'
+SCHEMA_VERSION = '1.6'
 # MAINTAINERS:
 #
 # - Make sure to update _VALID_SCHEMA_VERS if you change this.
@@ -216,6 +216,7 @@ _VALID_SCHEMA_VERS = [
     '0.12',
     '0.13',
     '1.0',
+    '1.2',
     SCHEMA_VERSION,
 ]
 

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -15,8 +15,10 @@ import re
 import shlex
 import subprocess
 import sys
+import warnings
 from collections import deque
 from collections.abc import Callable, Iterable
+from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, Any, NamedTuple, NoReturn
 
@@ -73,11 +75,25 @@ SCHEMA_VERSION = '1.6'
 # Internal helpers
 #
 
-# The value of a west-commands as passed around during manifest
-# resolution. It can become a list due to resolving imports, even
-# though it's just a str in each individual file right now.
-# TODO: WestCommands should be promoted to a Python class, see issue #959
-WestCommandsType = str | list[str]
+
+@dataclass(frozen=True)
+class WestCommandsEntry:
+    '''A single west-commands spec declared in a West project.
+
+    ``path`` is the spec YAML location, relative to the project root.
+
+    ``base_dir`` is the directory that the spec's ``file:`` entries
+    (paths to the Python files implementing the commands) are resolved
+    against, also relative to the project root. The common case is an
+    empty ``base_dir``, meaning the project root; a non-empty
+    ``base_dir`` is set when the entry was promoted from a submanifest
+    imported from a project subdirectory (so the Python files inside
+    the spec are relative to that subdirectory, not the project root).
+    '''
+
+    path: str
+    base_dir: str = ''
+
 
 # Type for the importer callback passed to the manifest constructor.
 # (ImportedContentType is just an alias for what it gives back.)
@@ -232,36 +248,93 @@ def _load(data: str) -> Any:
         raise MalformedManifest(data) from e
 
 
-def _west_commands_list(west_commands: WestCommandsType | None) -> list[str]:
-    # Convert the raw data from a manifest file to a list of
-    # west_commands locations. (If it's already a list, make a
-    # defensive copy.)
+def _parse_west_commands(raw: Any) -> list[WestCommandsEntry]:
+    # Normalize raw west-commands YAML data into a list of
+    # WestCommandsEntry. Accepts:
+    #
+    #   - None or empty                    -> []
+    #   - str                              -> [WestCommandsEntry(str)]
+    #   - list of (str | dict | Entry)     -> mixed list, dicts must
+    #                                         have a 'file' key and may
+    #                                         have a 'base-dir' key
+    #   - already-parsed list[Entry]       -> defensive copy
+    #
+    # Raises MalformedManifest on any other shape.
 
-    if west_commands is None:
+    if not raw:
         return []
-    elif isinstance(west_commands, str):
-        return [west_commands]
-    else:
-        return list(west_commands)
+    if isinstance(raw, str):
+        return [WestCommandsEntry(path=raw)]
+    if not isinstance(raw, list):
+        raise MalformedManifest(
+            f'invalid west-commands value {raw!r}: '
+            'expected a string, a list of strings, or a list of '
+            "{file, base-dir} maps"
+        )
+
+    ret: list[WestCommandsEntry] = []
+    for item in raw:
+        match item:
+            case WestCommandsEntry():
+                ret.append(item)
+            case str():
+                ret.append(WestCommandsEntry(path=item))
+            case dict():
+                file = item.get('file')
+                if not isinstance(file, str) or not file:
+                    raise MalformedManifest(
+                        f'invalid west-commands entry {item!r}: missing or non-string \'file\' key'
+                    )
+                base_dir = item.get('base-dir', '')
+                if not isinstance(base_dir, str):
+                    raise MalformedManifest(
+                        f'invalid west-commands entry {item!r}: \'base-dir\' must be a string'
+                    )
+                extras = set(item) - {'file', 'base-dir'}
+                if extras:
+                    raise MalformedManifest(
+                        f'invalid west-commands entry {item!r}: unexpected keys {sorted(extras)}'
+                    )
+                ret.append(WestCommandsEntry(path=file, base_dir=base_dir))
+            case _:
+                raise MalformedManifest(
+                    f'invalid west-commands element {item!r}: '
+                    'expected a string or a {file, base-dir} map'
+                )
+    return ret
 
 
-def _west_commands_maybe_delist(west_commands: list[str]) -> WestCommandsType:
-    # Convert a west_commands list to a string if there's
-    # just one element, otherwise return the list itself.
+def _emit_west_commands(entries: list[WestCommandsEntry]) -> str | list:
+    # Serialize a list of WestCommandsEntry into the simplest YAML form
+    # that preserves info:
+    #   - all base_dir == ''  ->  single str (1 entry) or list[str]
+    #   - any non-empty       ->  list of (str | {file, base-dir})
 
-    if len(west_commands) == 1:
-        return west_commands[0]
-    else:
-        return west_commands
+    if all(not e.base_dir for e in entries):
+        if len(entries) == 1:
+            return entries[0].path
+        return [e.path for e in entries]
+    return [e.path if not e.base_dir else {'file': e.path, 'base-dir': e.base_dir} for e in entries]
 
 
-def _west_commands_merge(wc1: list[str], wc2: list[str]) -> list[str]:
-    # Merge two west_commands lists, filtering out duplicates.
+def _merge_west_commands(
+    wc1: list[WestCommandsEntry], wc2: list[WestCommandsEntry]
+) -> list[WestCommandsEntry]:
+    # Merge two west_commands lists, dropping any entry from wc2
+    # whose path is already in wc1 (first wins).
 
-    if wc1 and wc2:
-        return wc1 + [wc for wc in wc2 if wc not in wc1]
-    else:
-        return wc1 or wc2
+    if not wc1:
+        return list(wc2)
+    if not wc2:
+        return list(wc1)
+    paths = {e.path for e in wc1}
+    kept = []
+    for e in wc2:
+        if e.path in paths:
+            _logger.debug('west-commands: keeping first %s, dropping duplicate', e.path)
+        else:
+            kept.append(e)
+    return list(wc1) + kept
 
 
 # Manifest import handling
@@ -411,11 +484,11 @@ class _import_ctx(NamedTuple):
     # the import tree in precedence order.
     group_filter_q: deque
 
-    # The list of west command names provided by the manifest
+    # The list of west command entries provided by the manifest
     # repository itself. This is mutable state in the same way
     # 'projects' is. Manifests which are imported earlier get
     # higher precedence here as usual.
-    manifest_west_commands: list[str]
+    manifest_west_commands_entries: list[WestCommandsEntry]
 
     # The current restrictions on which projects the importing
     # manifest is interested in.
@@ -824,8 +897,13 @@ class Project:
     - ``clone_depth``: clone depth to fetch when first cloning the
       project, or ``None`` (the revision should not be a SHA
       if this is used)
-    - ``west_commands``: list of YAML files where extension commands in
-      the project are declared
+    - ``west_commands_entries``: list of `WestCommandsEntry` records
+      describing the YAML files where extension commands in the project
+      are declared, and the base directory each spec's ``file:`` entries
+      are resolved against
+    - ``west_commands`` (**deprecated**): list of the YAML file paths
+      from ``west_commands_entries``. Loses per-entry ``base_dir`` info;
+      emits ``DeprecationWarning`` on read.
     - ``topdir``: the top level directory of the west workspace
       the project is part of, or ``None``
     - ``remote_name``: the name of the remote which should be set up
@@ -846,7 +924,7 @@ class Project:
             f'Project("{self.name}", "{self.url}", '
             f'revision="{self.revision}", path={self.path!r}, '
             f'clone_depth={self.clone_depth}, '
-            f'west_commands={self.west_commands}, '
+            f'west_commands_entries={self.west_commands_entries}, '
             f'topdir={self.topdir!r}, '
             f'groups={self.groups!r}, '
             f'userdata={self.userdata!r})'
@@ -865,7 +943,7 @@ class Project:
         path: PathType | None = None,
         submodules: SubmodulesType = False,
         clone_depth: int | None = None,
-        west_commands: WestCommandsType | None = None,
+        west_commands: Any = None,
         topdir: PathType | None = None,
         remote_name: str | None = None,
         groups: GroupsType | None = None,
@@ -883,9 +961,9 @@ class Project:
         :param path: path (relative to topdir), or None for *name*
         :param submodules: submodules to pull within the project
         :param clone_depth: depth to use for initial clone
-        :param west_commands: path to a west commands specification YAML
-            file in the project, relative to its base directory,
-            or list of these
+        :param west_commands: raw west-commands value from the manifest
+            (a string, a list of strings, or a list of {file, base-dir}
+            maps), or an already-parsed list of `WestCommandsEntry`
         :param topdir: the west workspace's top level directory
         :param remote_name: the name of the remote which should be
             set up if the project is being cloned (default: 'origin')
@@ -900,14 +978,28 @@ class Project:
         self.revision = revision or _DEFAULT_REV
         self.clone_depth = clone_depth
         self.path = os.fspath(path or name)
-        self.west_commands = _west_commands_list(west_commands)
+        self.west_commands_entries: list[WestCommandsEntry] = _parse_west_commands(west_commands)
         self.topdir = os.fspath(topdir) if topdir else None
         self.remote_name = remote_name or 'origin'
         self.groups: GroupsType = groups or []
         self.userdata: Any = userdata
 
-        # Internal helpers
-        self._west_commands_manifest_dirs: dict[str, str] = {}
+    @property
+    def west_commands(self) -> list[str]:
+        '''Deprecated: paths from `west_commands_entries`.
+
+        Use `west_commands_entries` instead — that exposes the per-entry
+        ``base_dir`` needed to resolve Python files inside the spec when
+        the entry was promoted from a subdirectory submanifest.
+        '''
+        warnings.warn(
+            'Project.west_commands is deprecated; use '
+            'west_commands_entries (list[WestCommandsEntry] with .path '
+            'and .base_dir).',
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return [e.path for e in self.west_commands_entries]
 
     @property
     def path(self) -> str:
@@ -952,8 +1044,8 @@ class Project:
             ret['path'] = self.path
         if self.clone_depth:
             ret['clone-depth'] = self.clone_depth
-        if self.west_commands:
-            ret['west-commands'] = _west_commands_maybe_delist(self.west_commands)
+        if self.west_commands_entries:
+            ret['west-commands'] = _emit_west_commands(self.west_commands_entries)
         if self.groups:
             ret['groups'] = self.groups
         if isinstance(self.submodules, bool) and self.submodules:
@@ -1202,9 +1294,12 @@ class ManifestProject(Project):
       native path name format (or ``None`` if ``topdir`` is)
     - ``posixpath``: like ``abspath``, but with slashes (``/``) as
       path separators
-    - ``west_commands``:``west_commands:`` key in the manifest's
-      ``self:`` map. This may be a list of such if the self
-      section imports multiple additional files with west commands.
+    - ``west_commands_entries``: list of `WestCommandsEntry` records
+      derived from the ``west-commands:`` key in the manifest's ``self:``
+      map (plus any extra west commands files contributed by self
+      imports).
+    - ``west_commands`` (**deprecated**): paths from
+      ``west_commands_entries``. Emits ``DeprecationWarning`` on read.
     - ``userdata``: the parsed 'userdata' field under self in the manifest file
 
     Other readable attributes included for Project compatibility:
@@ -1220,7 +1315,7 @@ class ManifestProject(Project):
     def __repr__(self):
         return (
             f'ManifestProject(path={self.path!r}, '
-            f'west_commands={self.west_commands}, '
+            f'west_commands_entries={self.west_commands_entries}, '
             f'topdir={self.topdir!r}, '
             f'userdata={self.userdata!r})'
         )
@@ -1228,16 +1323,16 @@ class ManifestProject(Project):
     def __init__(
         self,
         path: PathType | None = None,
-        west_commands: WestCommandsType | None = None,
+        west_commands: Any = None,
         topdir: PathType | None = None,
         userdata: Any | None = None,
     ):
         '''
         :param path: Relative path to the manifest repository in the
             west workspace, if known.
-        :param west_commands: path to a west commands specification YAML
-            file in the project, relative to its base directory,
-            or list of these
+        :param west_commands: raw west-commands value from the manifest
+            (a string, a list of strings, or a list of {file, base-dir}
+            maps), or an already-parsed list of `WestCommandsEntry`
         :param topdir: Root of the west workspace the manifest
             project is inside. If not given, all absolute path
             attributes (abspath and posixpath) will be None.
@@ -1267,8 +1362,7 @@ class ManifestProject(Project):
         self._posixpath: str | None = None
 
         # Extension commands.
-        self.west_commands = _west_commands_list(west_commands)
-        self._west_commands_manifest_dirs: dict[str, str] = {}
+        self.west_commands_entries: list[WestCommandsEntry] = _parse_west_commands(west_commands)
 
     @property
     def abspath(self) -> str | None:
@@ -1282,8 +1376,8 @@ class ManifestProject(Project):
         ret: dict = {}
         if self.path:
             ret['path'] = self.path
-        if self.west_commands:
-            ret['west-commands'] = _west_commands_maybe_delist(self.west_commands)
+        if self.west_commands_entries:
+            ret['west-commands'] = _emit_west_commands(self.west_commands_entries)
         if self.userdata:
             ret['userdata'] = self.userdata
         return ret
@@ -2062,7 +2156,7 @@ class Manifest:
             projects={},
             project_filter=project_filter,
             group_filter_q=deque(),
-            manifest_west_commands=[],
+            manifest_west_commands_entries=[],
             imap_filter=None,
             path_prefix=Path('.'),
             current_abspath=current_abspath,
@@ -2125,7 +2219,7 @@ class Manifest:
             # Create the ManifestProject instance.
             mp = ManifestProject(
                 path=self._config_path if self.topdir else self.yaml_path,
-                west_commands=self._ctx.manifest_west_commands,
+                west_commands=self._ctx.manifest_west_commands_entries,
                 topdir=self.topdir,
                 userdata=self.userdata,
             )
@@ -2238,14 +2332,9 @@ class Manifest:
         # we treat imports from self as if they are defined "before"
         # the contents in the higher level manifest, so any west
         # commands imported from self have higher precedence.
-        west_commands = slf.get('west-commands')
-        if west_commands:
-            assert isinstance(west_commands, str)
-            west_commands = [west_commands]
-        else:
-            west_commands = []
-        self._ctx.manifest_west_commands[:] = _west_commands_merge(
-            self._ctx.manifest_west_commands, west_commands
+        west_commands = _parse_west_commands(slf.get('west-commands'))
+        self._ctx.manifest_west_commands_entries[:] = _merge_west_commands(
+            self._ctx.manifest_west_commands_entries, west_commands
         )
 
     def _assert_imports_ok(self) -> None:
@@ -2724,32 +2813,34 @@ class Manifest:
             # west commands, they logically belong to 'project'.
             # We therefore use a separate list for tracking them
             # from our current list.
-            manifest_west_commands=[],
+            manifest_west_commands_entries=[],
         )
         try:
             submanifest = Manifest(topdir=self.topdir, internal_import_ctx=child_ctx)
         except RecursionError as e:
             raise _ManifestImportDepth(None, mfst_path) from e
 
-        # Patch up any extension commands in the imported data
-        # by allocating them to the project.
-
-        # If the manifest was imported from a project subdirectory
-        # (manifest_path is a relative path within the project),
-        # we need to adjust the west_commands paths to be relative
-        # to the project root, not to the manifest subdirectory.
+        # Patch up any extension commands in the imported data by
+        # allocating them to the project. If the manifest was imported
+        # from a project subdirectory, each entry's path and base_dir
+        # are prefixed with the subdirectory so they stay relative to
+        # the project root and the spec's `file:` entries still resolve
+        # correctly. An entry that already carries a base_dir (e.g.
+        # from a resolved manifest) composes with the subdirectory
+        # rather than being overwritten by it.
         mfst_dir = Path(mfst_path) if directory_import else Path(mfst_path).parent
-        west_commands_to_merge = [
-            (mfst_dir / cmd).as_posix() for cmd in submanifest._ctx.manifest_west_commands
-        ]
-
-        # Keep track of which imported manifest directory each adjusted
-        # west-commands entry came from, so command Python files can be
-        # resolved relative to that manifest root later in commands.py.
-        for adjusted_cmd in west_commands_to_merge:
-            project._west_commands_manifest_dirs.setdefault(adjusted_cmd, str(mfst_dir))
-
-        project.west_commands = _west_commands_merge(project.west_commands, west_commands_to_merge)
+        adjusted = []
+        for entry in submanifest._ctx.manifest_west_commands_entries:
+            base_dir = mfst_dir / entry.base_dir
+            adjusted.append(
+                WestCommandsEntry(
+                    path=(mfst_dir / entry.path).as_posix(),
+                    base_dir='' if base_dir == Path('.') else base_dir.as_posix(),
+                )
+            )
+        project.west_commands_entries = _merge_west_commands(
+            project.west_commands_entries, adjusted
+        )
 
     def _import_content_from_project(self, project: Project, path: str) -> ImportedContentType:
         if not (self._ctx.import_flags & ImportFlag.FORCE_PROJECTS) and project.is_cloned():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -666,7 +666,7 @@ def check_proj_consistency(actual, expected):
     )
     assert actual.clone_depth == expected.clone_depth
     assert actual.revision == expected.revision
-    assert actual.west_commands == expected.west_commands
+    assert actual.west_commands_entries == expected.west_commands_entries
 
 
 def tree(path: Path, prefix="") -> str:

--- a/tests/manifests/invalid_west_commands_4.yml
+++ b/tests/manifests/invalid_west_commands_4.yml
@@ -7,6 +7,4 @@ manifest:
     - name: testproject
       remote: testremote
       west-commands:
-        - file: cmd.yml
-          base-dir: sub
-          bogus: oops
+        - this-key-is-not-file: nope

--- a/tests/manifests/invalid_west_commands_5.yml
+++ b/tests/manifests/invalid_west_commands_5.yml
@@ -7,6 +7,4 @@ manifest:
     - name: testproject
       remote: testremote
       west-commands:
-        - file: cmd.yml
-          base-dir: sub
-          bogus: oops
+        - 42

--- a/tests/manifests/invalid_west_commands_6.yml
+++ b/tests/manifests/invalid_west_commands_6.yml
@@ -8,5 +8,4 @@ manifest:
       remote: testremote
       west-commands:
         - file: cmd.yml
-          base-dir: sub
-          bogus: oops
+          base-dir: 42

--- a/tests/test_extension_commands.py
+++ b/tests/test_extension_commands.py
@@ -279,6 +279,11 @@ def test_call_imported_project_submanifest_commands_from_project_subdirectory(re
     # west-commands YAML are resolved relative to the imported manifest root.
     # The same paths must work whether a project is imported or initialized directly;
     # importing must never break anything.
+    #
+    # The submanifest also declares an entry that already carries a
+    # base-dir: the entry's base_dir must compose with the submanifest
+    # subdirectory (mf_subdir/nested), so the spec's `file:` paths
+    # resolve against that composed directory when the command runs.
     manifest_path = repos_tmpdir / 'repos' / 'zephyr'
     net_tools_path = repos_tmpdir / 'repos' / 'net-tools'
 
@@ -286,7 +291,10 @@ def test_call_imported_project_submanifest_commands_from_project_subdirectory(re
         '''\
         manifest:
           self:
-            west-commands: scripts/west-commands-from-subdir.yml
+            west-commands:
+            - scripts/west-commands-from-subdir.yml
+            - file: nested/west-commands-nested.yml
+              base-dir: nested
         '''
     )
     MF_SUB_COMMANDS_YML = textwrap.dedent(
@@ -318,6 +326,35 @@ def test_call_imported_project_submanifest_commands_from_project_subdirectory(re
                 print('imported command from subdir works')
         '''
     )
+    MF_NESTED_COMMANDS_YML = textwrap.dedent(
+        '''\
+        west-commands:
+          - file: cmds/nested_command.py
+            commands:
+              - name: imported-command-from-nested-base-dir
+                class: ImportedCommandFromNestedBaseDir
+                help: nested base-dir extension help
+        '''
+    )
+    MF_NESTED_WEST_PY = textwrap.dedent(
+        '''\
+        from west.commands import WestCommand
+
+        class ImportedCommandFromNestedBaseDir(WestCommand):
+            def __init__(self):
+                super().__init__(
+                    'imported-command-from-nested-base-dir',
+                    'nested base-dir command help',
+                    'nested base-dir command description',
+                )
+
+            def do_add_parser(self, parser_adder):
+                return parser_adder.add_parser(self.name)
+
+            def do_run(self, args, unknown):
+                print('imported command from nested base-dir works')
+        '''
+    )
 
     add_commit(
         net_tools_path,
@@ -326,6 +363,8 @@ def test_call_imported_project_submanifest_commands_from_project_subdirectory(re
             'mf_subdir/west.yml': MF_SUB_WEST_YML,
             'mf_subdir/scripts/west-commands-from-subdir.yml': MF_SUB_COMMANDS_YML,
             'mf_subdir/test/west-commands/subdir_command.py': MF_SUB_WEST_PY,
+            'mf_subdir/nested/west-commands-nested.yml': MF_NESTED_COMMANDS_YML,
+            'mf_subdir/nested/cmds/nested_command.py': MF_NESTED_WEST_PY,
         },
     )
 
@@ -350,6 +389,9 @@ def test_call_imported_project_submanifest_commands_from_project_subdirectory(re
 
     ext_output = cmd('imported-command-from-subdir', cwd=workspace)
     assert 'imported command from subdir works' in ext_output
+
+    ext_output = cmd('imported-command-from-nested-base-dir', cwd=workspace)
+    assert 'imported command from nested base-dir works' in ext_output
 
 
 def test_call_imported_project_submanifest_commands_from_project_subdirectory_special_chars(
@@ -445,7 +487,7 @@ def test_call_imported_project_submanifest_commands_from_project_subdirectory_sp
         # Untouched on Un*x
         expected = r'mf_subdir/' + _WEIRD_CMDS_PATH
     print()
-    assert net_tools["west-commands"][1] == expected
+    assert net_tools["west-commands"][1]["file"] == expected
 
 
 def test_extension_special_chars(west_update_tmpdir):

--- a/tests/test_extension_commands.py
+++ b/tests/test_extension_commands.py
@@ -7,7 +7,7 @@ import textwrap
 from pathlib import Path
 
 import yaml
-from conftest import GIT, WINDOWS, add_commit, cmd, cmd_raises, yaml_editor
+from conftest import GIT, WINDOWS, add_commit, cmd, cmd_raises, create_repo, yaml_editor
 
 
 def _yaml_get_proj(mf: dict, projname: str):
@@ -488,6 +488,139 @@ def test_call_imported_project_submanifest_commands_from_project_subdirectory_sp
         expected = r'mf_subdir/' + _WEIRD_CMDS_PATH
     print()
     assert net_tools["west-commands"][1]["file"] == expected
+
+
+def test_call_resolved_manifest_commands_from_project_subdirectory(repos_tmpdir):
+    # 'west manifest --resolve' records west-commands promoted from a
+    # project subdirectory submanifest as {file, base-dir} maps on that
+    # project. Committing the resolved manifest into a *subdirectory*
+    # of another project and importing it from there must leave those
+    # entries alone: they resolve against the checkout of the project
+    # declaring them (net-tools), so the importing subdirectory ('subA')
+    # must not be composed into their base-dir. The extension command
+    # must keep working, and re-resolving must reproduce the same
+    # {file, base-dir} entry: the round trip is idempotent.
+    repos = repos_tmpdir / 'repos'
+    manifest_path = repos / 'zephyr'
+    net_tools_path = repos / 'net-tools'
+
+    MF_SUB_WEST_YML = textwrap.dedent(
+        '''\
+        manifest:
+          self:
+            west-commands: scripts/cmds.yml
+        '''
+    )
+    MF_SUB_COMMANDS_YML = textwrap.dedent(
+        '''\
+        west-commands:
+          - file: py/resolved_command.py
+            commands:
+              - name: resolved-command
+                class: ResolvedCommand
+                help: resolved manifest extension help
+        '''
+    )
+    MF_SUB_WEST_PY = textwrap.dedent(
+        '''\
+        from west.commands import WestCommand
+
+        class ResolvedCommand(WestCommand):
+            def __init__(self):
+                super().__init__(
+                    'resolved-command',
+                    'resolved manifest command help',
+                    'resolved manifest command description',
+                )
+
+            def do_add_parser(self, parser_adder):
+                return parser_adder.add_parser(self.name)
+
+            def do_run(self, args, unknown):
+                print('resolved command from subB works')
+        '''
+    )
+
+    add_commit(
+        net_tools_path,
+        'add subB submanifest with extension command',
+        files={
+            'subB/west.yml': MF_SUB_WEST_YML,
+            'subB/scripts/cmds.yml': MF_SUB_COMMANDS_YML,
+            'subB/py/resolved_command.py': MF_SUB_WEST_PY,
+        },
+    )
+
+    with yaml_editor(manifest_path / 'west.yml') as mf:
+        net_tools_project = _yaml_get_proj(mf, 'net-tools')
+        net_tools_project['import'] = 'subB/west.yml'
+    subprocess.check_call(
+        [
+            GIT,
+            '-C',
+            str(manifest_path),
+            'commit',
+            '-m',
+            'import subB/west.yml',
+            'west.yml',
+        ]
+    )
+
+    ws1 = repos_tmpdir / 'ws1'
+    cmd(['init', '-m', str(manifest_path), str(ws1)])
+    cmd('update', cwd=ws1)
+    assert 'resolved command from subB works' in cmd('resolved-command', cwd=ws1)
+
+    # The resolved manifest records the promoted entry as a
+    # {file, base-dir} map on the net-tools project.
+    expected_entry = {'file': 'subB/scripts/cmds.yml', 'base-dir': 'subB'}
+    resolved = cmd(['manifest', '--resolve'], cwd=ws1)
+    net_tools = _yaml_get_proj(yaml.safe_load(resolved), 'net-tools')
+    assert expected_entry in net_tools['west-commands']
+
+    # Commit the resolved manifest into a subdirectory of a new
+    # 'container' project, and import it from there.
+    container_path = repos / 'container'
+    create_repo(container_path)
+    add_commit(
+        container_path,
+        'add resolved manifest in a subdirectory',
+        files={'subA/west.yml': resolved},
+    )
+
+    with open(manifest_path / 'west.yml', 'w') as f:
+        f.write(
+            textwrap.dedent(
+                f'''\
+                manifest:
+                  projects:
+                  - name: container
+                    url: file://{container_path}
+                    import: subA/west.yml
+                '''
+            )
+        )
+    subprocess.check_call(
+        [
+            GIT,
+            '-C',
+            str(manifest_path),
+            'commit',
+            '-m',
+            'import resolved manifest from container subdirectory',
+            'west.yml',
+        ]
+    )
+
+    ws2 = repos_tmpdir / 'ws2'
+    cmd(['init', '-m', str(manifest_path), str(ws2)])
+    cmd('update', cwd=ws2)
+    assert 'resolved command from subB works' in cmd('resolved-command', cwd=ws2)
+
+    # net-tools' entry passed through the import unchanged: its
+    # base-dir is still 'subB', not 'subA/subB'.
+    net_tools = _yaml_get_proj(yaml.safe_load(cmd(['manifest', '--resolve'], cwd=ws2)), 'net-tools')
+    assert expected_entry in net_tools['west-commands']
 
 
 def test_extension_special_chars(west_update_tmpdir):

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -50,6 +50,7 @@ from west.manifest import (
     ManifestProject,
     ManifestVersionError,
     Project,
+    WestCommandsEntry,
     _ManifestImportDepth,
     is_group,
     manifest_path,
@@ -135,12 +136,12 @@ def test_project_init():
     assert p.abspath is None
     assert p.posixpath is None
     assert p.clone_depth is None
-    assert p.west_commands == []
+    assert p.west_commands_entries == []
     assert p.topdir is None
 
     p = Project('p', 'some-url', clone_depth=4, west_commands='foo', topdir=TOPDIR)
     assert p.clone_depth == 4
-    assert p.west_commands == ['foo']
+    assert p.west_commands_entries == [WestCommandsEntry(path='foo')]
     assert p.topdir == TOPDIR
     assert p.abspath == os.path.join(TOPDIR, 'p')
     assert p.posixpath == TOPDIR_POSIX + '/p'
@@ -535,7 +536,75 @@ def test_project_west_commands():
       url: https://foo.com
       west-commands: some-path/west-commands.yml
     ''')
-    assert m.projects[1].west_commands == ['some-path/west-commands.yml']
+    assert m.projects[1].west_commands_entries == [
+        WestCommandsEntry(path='some-path/west-commands.yml'),
+    ]
+
+
+def test_project_west_commands_deprecated_property():
+    p = Project('p', 'some-url', west_commands='foo.yml', topdir=TOPDIR)
+    with pytest.warns(DeprecationWarning, match='west_commands_entries'):
+        assert p.west_commands == ['foo.yml']
+
+
+def test_project_west_commands_list_and_dict_forms():
+    # The schema accepts a list whose elements are strings and/or
+    # {file, base-dir} maps. Each form maps to a WestCommandsEntry.
+
+    m = M('''\
+    projects:
+    - name: zephyr
+      url: https://foo.com
+      west-commands:
+        - plain-string.yml
+        - file: with-base.yml
+          base-dir: sub
+        - file: no-base.yml
+    ''')
+    assert m.projects[1].west_commands_entries == [
+        WestCommandsEntry(path='plain-string.yml'),
+        WestCommandsEntry(path='with-base.yml', base_dir='sub'),
+        WestCommandsEntry(path='no-base.yml'),
+    ]
+
+
+def test_project_west_commands_plain_list_roundtrip():
+    # A project with several plain-string west-commands entries (no
+    # base_dir) should serialize as a list of strings in as_yaml(),
+    # rather than collapsing to a single string or emitting maps.
+
+    m = M('''\
+    projects:
+    - name: zephyr
+      url: https://foo.com
+      west-commands:
+        - a.yml
+        - b.yml
+    ''')
+    expected = [WestCommandsEntry(path='a.yml'), WestCommandsEntry(path='b.yml')]
+    assert m.projects[1].west_commands_entries == expected
+
+    roundtripped = Manifest.from_data(m.as_yaml())
+    assert roundtripped.projects[1].west_commands_entries == expected
+
+
+def test_project_west_commands_dict_form_roundtrip():
+    # A manifest declaring a {file, base-dir} entry directly should
+    # roundtrip through as_yaml() preserving the dict form.
+
+    m = M('''\
+    projects:
+    - name: zephyr
+      url: https://foo.com
+      west-commands:
+        - file: cmd.yml
+          base-dir: sub
+    ''')
+    expected = [WestCommandsEntry(path='cmd.yml', base_dir='sub')]
+    assert m.projects[1].west_commands_entries == expected
+
+    roundtripped = Manifest.from_data(m.as_yaml())
+    assert roundtripped.projects[1].west_commands_entries == expected
 
 
 def test_project_git_methods(tmpdir):
@@ -611,7 +680,9 @@ def test_project_repr():
     assert (
         repr(m.projects[1])
         == 'Project("zephyr", "https://foo.com", revision="r", path=\'zephyr\', '
-        'clone_depth=None, west_commands=[\'some-path/west-commands.yml\'], '
+        "clone_depth=None, "
+        "west_commands_entries="
+        "[WestCommandsEntry(path='some-path/west-commands.yml', base_dir='')], "
         'topdir=None, groups=[], userdata=None)'
     )
 
@@ -777,7 +848,7 @@ def test_manifest_project():
     assert mp.name == 'manifest'
     assert mp.path == 'my-path'
     assert m.yaml_path == 'my-path'
-    assert mp.west_commands == ['cmds.yml']
+    assert mp.west_commands_entries == [WestCommandsEntry(path='cmds.yml')]
     assert mp.topdir is None
     assert mp.abspath is None
     assert mp.posixpath is None
@@ -2109,8 +2180,11 @@ def test_import_project_submanifest_commands(manifest_repo):
     assert (p1 / 'm2.yml').check(file=0, dir=0)
 
     p1 = MF().get_projects(['p1'])[0]
-    expected = ['m1-commands.yml', 'm2-commands.yml']
-    assert p1.west_commands == expected
+    expected = [
+        WestCommandsEntry(path='m1-commands.yml'),
+        WestCommandsEntry(path='m2-commands.yml'),
+    ]
+    assert p1.west_commands_entries == expected
 
 
 def test_import_project_submanifest_commands_both(manifest_repo):
@@ -2161,8 +2235,12 @@ def test_import_project_submanifest_commands_both(manifest_repo):
     assert (p1 / 'm2.yml').check(file=0, dir=0)
 
     p1 = MF().get_projects(['p1'])[0]
-    expected = ['p1-commands.yml', 'm1-commands.yml', 'm2-commands.yml']
-    assert p1.west_commands == expected
+    expected = [
+        WestCommandsEntry(path='p1-commands.yml'),
+        WestCommandsEntry(path='m1-commands.yml'),
+        WestCommandsEntry(path='m2-commands.yml'),
+    ]
+    assert p1.west_commands_entries == expected
 
 
 def test_import_project_submanifest_commands_from_project_subdirectory(manifest_repo):
@@ -2186,7 +2264,10 @@ def test_import_project_submanifest_commands_from_project_subdirectory(manifest_
                                   - name: p2
                                     url: url-placeholder2
                                   self:
-                                    west-commands: p2subdir/west-commands.yml
+                                    west-commands:
+                                    - p2subdir/west-commands.yml
+                                    - file: nested/west-commands.yml
+                                      base-dir: nested
                                 ''',
         },
     )
@@ -2205,12 +2286,24 @@ def test_import_project_submanifest_commands_from_project_subdirectory(manifest_
             import: mf_subdir/west.yml
         ''')
 
-    # The west_commands path should be 'mf_subdir/p2subdir/west-commands.yml',
-    # not 'west-commands.yml', to be resolved correctly
-    # relative to the project root. See issue #725.
+    # The entry's path should be 'mf_subdir/p2subdir/west-commands.yml',
+    # not 'west-commands.yml', to be resolved correctly relative to the
+    # project root, and base_dir should be 'mf_subdir' so the spec's
+    # `file:` paths still resolve against the submanifest directory.
+    # See issue #725. An entry that already carries a base_dir composes
+    # with the subdirectory instead of having it overwritten.
+    expected = [
+        WestCommandsEntry(
+            path='mf_subdir/p2subdir/west-commands.yml',
+            base_dir='mf_subdir',
+        ),
+        WestCommandsEntry(
+            path='mf_subdir/nested/west-commands.yml',
+            base_dir='mf_subdir/nested',
+        ),
+    ]
     p1_proj = MF().get_projects(['p1'])[0]
-    expected = ['mf_subdir/p2subdir/west-commands.yml']
-    assert p1_proj.west_commands == expected
+    assert p1_proj.west_commands_entries == expected
 
     # Case B: import using an import-map whose 'file' is a file path.
     with open(manifest_repo / 'west.yml', 'w') as f:
@@ -2223,10 +2316,8 @@ def test_import_project_submanifest_commands_from_project_subdirectory(manifest_
             file: mf_subdir/west.yml
       ''')
 
-    # Reload and check the west_commands were resolved the same way.
     p1_proj = MF().get_projects(['p1'])[0]
-    expected = ['mf_subdir/p2subdir/west-commands.yml']
-    assert p1_proj.west_commands == expected
+    assert p1_proj.west_commands_entries == expected
 
     # Case C: import as a string path to the submanifest directory.
     with open(manifest_repo / 'west.yml', 'w') as f:
@@ -2238,10 +2329,8 @@ def test_import_project_submanifest_commands_from_project_subdirectory(manifest_
           import: mf_subdir
       ''')
 
-    # Reload and check the west_commands were resolved the same way.
     p1_proj = MF().get_projects(['p1'])[0]
-    expected = ['mf_subdir/p2subdir/west-commands.yml']
-    assert p1_proj.west_commands == expected
+    assert p1_proj.west_commands_entries == expected
 
     # Case D: import using an import-map whose 'file' is a directory.
     with open(manifest_repo / 'west.yml', 'w') as f:
@@ -2254,10 +2343,78 @@ def test_import_project_submanifest_commands_from_project_subdirectory(manifest_
             file: mf_subdir
       ''')
 
-    # Reload and check the west_commands were resolved the same way.
     p1_proj = MF().get_projects(['p1'])[0]
-    expected = ['mf_subdir/p2subdir/west-commands.yml']
-    assert p1_proj.west_commands == expected
+    assert p1_proj.west_commands_entries == expected
+
+
+def test_import_project_submanifest_commands_resolved_yaml_roundtrip(manifest_repo):
+    # A parent manifest imports a submanifest from a project
+    # subdirectory (`mf_subdir/west.yml`) which declares
+    # `self: west-commands:`. After resolution the parent project
+    # carries a WestCommandsEntry whose path is project-relative
+    # ('mf_subdir/p2subdir/west-commands.yml') and whose base_dir is
+    # the submanifest directory ('mf_subdir'), so the spec's `file:`
+    # paths still resolve against the subdirectory.
+    #
+    # That base_dir information must survive a Manifest.as_yaml()
+    # roundtrip: serializing the resolved manifest and parsing it back
+    # should produce a project with the same WestCommandsEntry list.
+
+    p1 = manifest_repo / '..' / 'p1'
+    create_repo(p1)
+    create_branch(p1, 'manifest-rev', checkout=True)
+    add_commit(
+        p1,
+        'add mf_subdir/west.yml with west-commands',
+        files={
+            'mf_subdir/west.yml': '''\
+                                manifest:
+                                  projects:
+                                  - name: p2
+                                    url: url-placeholder2
+                                  self:
+                                    west-commands:
+                                    - p2subdir/west-commands.yml
+                                    - file: nested/west-commands.yml
+                                      base-dir: nested
+                                ''',
+        },
+    )
+    checkout_branch(p1, 'master')
+
+    with open(manifest_repo / 'west.yml', 'w') as f:
+        f.write('''\
+        manifest:
+          projects:
+          - name: p1
+            url: url-placeholder
+            import: mf_subdir/west.yml
+        ''')
+
+    expected = [
+        WestCommandsEntry(
+            path='mf_subdir/p2subdir/west-commands.yml',
+            base_dir='mf_subdir',
+        ),
+        WestCommandsEntry(
+            path='mf_subdir/nested/west-commands.yml',
+            base_dir='mf_subdir/nested',
+        ),
+    ]
+
+    original = MF()
+    p1_orig = original.get_projects(['p1'])[0]
+    assert p1_orig.west_commands_entries == expected
+
+    # Serialize the resolved manifest and parse it back: the
+    # resolved YAML should be equivalent to the original, including
+    # the per-entry base_dir.
+    with open(manifest_repo / 'west.yml', 'w') as f:
+        f.write(original.as_yaml())
+
+    roundtripped = MF()
+    p1_round = roundtripped.get_projects(['p1'])[0]
+    assert p1_round.west_commands_entries == expected
 
 
 def test_import_map_error_handling():
@@ -2549,7 +2706,7 @@ def test_import_self_submanifest_commands(manifest_repo):
         ''')
 
     mp = MF().projects[MANIFEST_PROJECT_INDEX]
-    assert mp.west_commands == ['sub-commands.yml']
+    assert mp.west_commands_entries == [WestCommandsEntry(path='sub-commands.yml')]
 
 
 def test_import_self_submanifest_commands_both(manifest_repo):
@@ -2581,7 +2738,10 @@ def test_import_self_submanifest_commands_both(manifest_repo):
         f.write(sub)
 
     mp = MF().projects[MANIFEST_PROJECT_INDEX]
-    assert mp.west_commands == ['sub-commands.yml', 'top-commands.yml']
+    assert mp.west_commands_entries == [
+        WestCommandsEntry(path='sub-commands.yml'),
+        WestCommandsEntry(path='top-commands.yml'),
+    ]
 
 
 def test_import_flags_ignore(tmpdir):


### PR DESCRIPTION
Replace the `WestCommandsType` alias and the parallel `_west_commands_manifest_dirs` dict with a frozen `WestCommandsEntry` dataclass carrying (`path`, `base_dir`). `Project.west_commands_entries` is the new canonical attribute; the old `west_commands` becomes a deprecated read-only property. Schema accepts `str` / `list[str]` / `list[{file, base-dir}]` so resolved manifests roundtrip through `as_yaml()` without losing the `base_dir` needed to resolve `file:` paths inside specs imported from a project subdirectory.

Fixes https://github.com/zephyrproject-rtos/west/issues/959
Supersedes https://github.com/zephyrproject-rtos/west/pull/965