### PR TITLE
.github: check commit sign-off in CI

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -1,0 +1,29 @@
+---
+# yamllint disable rule:truthy
+name: Commit Checks
+
+on: [pull_request]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  commit-check:
+    name: Check commits
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Full history and the PR head so the action can resolve the base
+          # branch and merge-base (see actions/checkout#552).
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+
+      - name: Check commit sign-off
+        uses: zephyrproject-rtos/action-dco@e3485a11e085fdc05fa4320e9cc3a86ccd665d89 # v1.0.0


### PR DESCRIPTION
Add a workflow that runs the [action-dco](https://github.com/pdgendt/action-dco) composite action over a pull request's commits, verifying each carries a `Signed-off-by` line matching the author (`First Last <email>`), as required by the DCO.