### PR TITLE
manifest: stamp resolved/frozen manifests with the schema version

### DIFF
--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -1712,6 +1712,16 @@ class Manifest:
         # and Python 3.7+ guarantee.
         r: dict[str, Any] = {}
         r['manifest'] = {}
+        # Stamp the resolved/frozen output with SCHEMA_VERSION, the
+        # highest manifest schema version this west supports. The output
+        # is a synthesis of the input manifest and any imports (which
+        # may each declare their own version), so no single declared
+        # version describes it; the highest schema version we support is
+        # a safe upper bound, since west can't emit anything newer than
+        # the schema it implements. Without this, an older west silently
+        # mis-parses the output instead of failing cleanly with a
+        # ManifestVersionError.
+        r['manifest']['version'] = SCHEMA_VERSION
         if self.group_filter:
             r['manifest']['group-filter'] = self.group_filter
         r['manifest']['projects'] = project_dicts
@@ -1726,6 +1736,10 @@ class Manifest:
         projects had been defined in a single manifest without any
         import attributes.
 
+        The result is stamped with the current `SCHEMA_VERSION` (the
+        highest manifest schema version this west supports), since the
+        output may synthesize inputs that declared differing versions.
+
         :param active_only: Do not resolve inactive projects
         '''
         return self._as_dict_helper(pfilter=self.is_active if active_only else None)
@@ -1735,6 +1749,9 @@ class Manifest:
 
         The value is "frozen" in that all project revisions are the
         full SHAs pointed to by `QUAL_MANIFEST_REV_BRANCH` references.
+
+        Like `as_dict`, the result is stamped with the current
+        `SCHEMA_VERSION`.
 
         Raises ``RuntimeError`` if a project SHA can't be resolved.
 

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1240,6 +1240,8 @@ def test_as_dict_and_yaml(manifest_repo):
     '''
     content_dict = {
         'manifest': {
+            # --resolve/--freeze stamp the output with the current schema version.
+            'version': SCHEMA_VERSION,
             'projects': [
                 {'name': 'p1', 'url': 'https://example.com/p1', 'revision': 'master'},
                 {
@@ -1259,7 +1261,10 @@ def test_as_dict_and_yaml(manifest_repo):
         }
     }
 
-    expected_yaml = '''\
+    # NOTE: bare as_yaml() sorts keys (safe_dump default), so 'version'
+    # sorts last; `west manifest --resolve` passes sort_keys=False and
+    # emits it first. See test_project.py for the CLI ordering.
+    expected_yaml = f'''\
 manifest:
   group-filter:
   - -Bdisabled
@@ -1276,6 +1281,7 @@ manifest:
     west-commands: commands.yml
   self:
     path: mp
+  version: '{SCHEMA_VERSION}'
 '''
 
     with open(manifest_repo / 'west.yml', 'w') as f:
@@ -1432,6 +1438,49 @@ def test_version_check_success(ver):
         url: https://foo.com
     ''')
     assert manifest.projects[-1].name == 'foo'
+
+
+@pytest.mark.parametrize('declared', [None, '0.7', '1.0', SCHEMA_VERSION])
+def test_resolve_freeze_stamp_current_schema_version(declared):
+    # `west manifest --resolve` and `--freeze` output is a synthesis
+    # produced by this west, so it is always stamped with the current
+    # SCHEMA_VERSION -- regardless of what the source manifest declared
+    # (or didn't). This avoids under-claiming when imports declare a
+    # newer version than the top-level manifest.
+
+    lines = ['manifest:']
+    if declared is not None:
+        lines.append(f'  version: "{declared}"')
+    lines.append('  projects: []')  # empty, so as_frozen_dict() needs no clones
+    manifest = Manifest.from_data('\n'.join(lines) + '\n')
+
+    assert manifest.as_dict()['manifest']['version'] == SCHEMA_VERSION
+    assert manifest.as_frozen_dict()['manifest']['version'] == SCHEMA_VERSION
+
+
+def test_resolve_stamps_max_when_import_declares_newer():
+    # A submanifest imported from a lower-versioned top-level manifest
+    # must not cause the resolved output to under-claim: the stamp is
+    # SCHEMA_VERSION, which covers any import's (validated) version.
+
+    top = '''\
+    manifest:
+      version: "1.0"
+      projects:
+      - name: upstream
+        url: https://example.com/upstream
+        import: west.yml
+    '''
+    sub = f'''\
+    manifest:
+      version: "{SCHEMA_VERSION}"
+      projects:
+      - name: hal
+        url: https://example.com/hal
+    '''
+    importer = make_importer({('upstream', 'west.yml'): sub})
+    manifest = Manifest.from_data(top, importer=importer, import_flags=FPI)
+    assert manifest.as_dict()['manifest']['version'] == SCHEMA_VERSION
 
 
 def test_project_filter_validation(config_tmpdir):

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -459,6 +459,7 @@ def test_manifest_freeze(west_update_tmpdir):
     # - there isn't any random YAML tag
     expected_res = [
         '^manifest:$',
+        '^  version: .*$',
         '^  projects:$',
         '^  - name: Kconfiglib$',
         '^    description: |',
@@ -493,6 +494,7 @@ def test_manifest_freeze_active(west_update_tmpdir):
     # Same as test_manifest_freeze but without inactive projects
     expected_res = [
         '^manifest:$',
+        '^  version: .*$',
         '^  projects:$',
         '^  - name: tagged_repo$',
         '^    url: .*$',
@@ -515,6 +517,7 @@ def test_manifest_resolve(west_update_tmpdir):
     # Similar as test_manifest_freeze but with resolved projects
     expected_res = [
         '^manifest:$',
+        '^  version: .*$',
         '^  projects:$',
         '^  - name: Kconfiglib$',
         '^    description: |',
@@ -549,6 +552,7 @@ def test_manifest_resolve_active(west_update_tmpdir):
     # Same as test_manifest_resolve but without inactive projects
     expected_res = [
         '^manifest:$',
+        '^  version: .*$',
         '^  projects:$',
         '^  - name: tagged_repo$',
         '^    url: .*$',
@@ -1263,6 +1267,7 @@ def test_update_submodules_list(repos_tmpdir):
     actual = cmd('manifest --freeze', cwd=ws).splitlines()
     expected_res = [
         '^manifest:$',
+        '^  version: .*$',
         '^  projects:$',
         '^  - name: zephyr$',
         f'^    url: {re.escape(str(zephyr))}$',
@@ -1386,6 +1391,7 @@ def test_update_all_submodules(repos_tmpdir):
     actual = cmd('manifest --freeze', cwd=ws).splitlines()
     expected_res = [
         '^manifest:$',
+        '^  version: .*$',
         '^  projects:$',
         '^  - name: zephyr$',
         f'^    url: {re.escape(str(zephyr))}$',
@@ -1478,6 +1484,7 @@ def test_update_no_submodules(repos_tmpdir):
     actual = cmd('manifest --freeze', cwd=ws).splitlines()
     expected_res = [
         '^manifest:$',
+        '^  version: .*$',
         '^  projects:$',
         '^  - name: zephyr$',
         f'^    url: {re.escape(str(zephyr))}$',
@@ -1623,6 +1630,7 @@ def test_update_submodules_strategy(repos_tmpdir):
     actual = cmd('manifest --freeze', cwd=ws).splitlines()
     expected_res = [
         '^manifest:$',
+        '^  version: .*$',
         '^  projects:$',
         '^  - name: zephyr$',
         f'^    url: {re.escape(str(zephyr))}$',


### PR DESCRIPTION
`west manifest --resolve` and `--freeze` dropped the `manifest: version:` key from their output. That output is a single manifest synthesized from the input and its imports -- which may each declare a different version -- so no single declared version describes it, and an older west would silently mis-parse newer content instead of failing with a clean `ManifestVersionError`.

Stamp the output with `SCHEMA_VERSION`, the highest manifest schema version this west supports. That is a safe upper bound: west cannot emit anything newer than the schema it implements, and it covers imports that declare a newer version than the top-level manifest.