### PR TITLE
Support executable extension commands

### DIFF
--- a/src/west/commands.py
+++ b/src/west/commands.py
@@ -617,6 +617,108 @@ WARNING: in file {self.py_file},
         return cmd
 
 
+class _ExecExtensionCommand(WestCommand):
+    # An extension command backed by an executable.
+    #
+    # Unlike class-based extensions, which are Python WestCommand subclasses
+    # with access to the full west API, an executable extension is any
+    # executable (in any language) named by the 'file' key of a west-commands
+    # file, selected with the 'exec' key of a command. West does not parse its
+    # arguments: everything after the command name (including -h/--help) is
+    # forwarded verbatim, and workspace context is passed via WEST_*
+    # environment variables. The invoked command name is passed as
+    # WEST_COMMAND so that a single executable registered under several names
+    # can dispatch on the subcommand.
+    #
+    # If 'interpreter' is empty, the file is run directly; otherwise it is run
+    # as arguments to 'interpreter' (e.g. ['python3']).
+
+    def __init__(
+        self,
+        name: str,
+        help: str,
+        exec_file: str,
+        interpreter: list[str],
+        project_path: str,
+    ):
+        super().__init__(
+            name,
+            # 'help' is ignored for extensions, see
+            # https://github.com/zephyrproject-rtos/west/issues/927
+            help='',
+            description=help,
+            accepts_unknown_args=True,
+            requires_workspace=True,
+        )
+        self._exec_file = exec_file
+        self._interpreter = interpreter
+        self._project_path = project_path
+
+    def do_add_parser(self, parser_adder):
+        # add_help=False so that -h/--help is forwarded to the executable
+        # instead of being intercepted by west's argument parser.
+        return parser_adder.add_parser(
+            self.name,
+            help=self.help,
+            description=self.description,
+            add_help=False,
+        )
+
+    def do_run(self, args: argparse.Namespace, unknown: list[str]):
+        # The backing file must exist however it is run, whether directly or
+        # as an argument to an interpreter. Check this first on every platform,
+        # since os.access(..., X_OK) below returns False for a missing file
+        # too, which would otherwise be reported as the misleading "not
+        # executable".
+        if not os.path.exists(self._exec_file):
+            self.die(f'extension command executable "{self._exec_file}" not found')
+
+        # When run directly (no interpreter), the file itself must also be
+        # executable. This X_OK check is only meaningful on POSIX; on Windows
+        # it is not, so let subprocess report any such failure instead.
+        if not self._interpreter and os.name == 'posix':
+            if not os.access(self._exec_file, os.X_OK):
+                self.die(f'extension command executable "{self._exec_file}" is not executable')
+
+        env = os.environ.copy()
+        # The context "API" for executable extensions. Keep this small
+        # and stable; it is a much looser contract than the Python API.
+        env['WEST'] = sys.argv[0]
+        # The command name as invoked by the user, so a single executable
+        # registered under multiple names can dispatch on the subcommand.
+        env['WEST_COMMAND'] = self.name
+        assert self.topdir is not None  # requires_workspace is True
+        env['WEST_TOPDIR'] = self.topdir
+        if self.has_manifest and self.manifest.abspath:
+            env['WEST_MANIFEST_PATH'] = self.manifest.abspath
+        env['WEST_PROJECT_PATH'] = self._project_path
+        env['WEST_VERBOSE'] = str(int(self.verbosity))
+
+        argv = [*self._interpreter, self._exec_file, *unknown]
+        self._log_subproc(argv)
+        try:
+            proc = subprocess.run(argv, env=env)
+        except OSError as e:
+            self.die(f'could not run extension command "{self.name}": {e}')
+
+        if proc.returncode:
+            raise CommandError(proc.returncode)
+
+
+@dataclass
+class _ExecExtFactory:
+    exec_file: str
+    interpreter: list[str]
+    name: str
+    help: str
+    project_path: str
+
+    def __call__(self):
+        return _ExecExtensionCommand(
+            self.name, self.help, self.exec_file, self.interpreter, self.project_path
+        )
+
+
 @dataclass
 class WestExtCommandSpec:
     # An object which allows instantiating a west extension.
@@ -712,26 +814,54 @@ def _ext_specs(project):
 
 
 def _ext_specs_from_desc(project, commands_desc, base_dir):
-    py_file = os.path.join(base_dir, commands_desc['file'])
+    file = os.path.join(base_dir, commands_desc['file'])
 
-    # Verify the YAML's python file doesn't escape the project directory.
-    if escapes_directory(py_file, project.abspath):
+    # Verify the YAML's file doesn't escape the project directory.
+    if escapes_directory(file, project.abspath):
         raise ExtensionCommandError(
-            hint=f'extension command python file "{commands_desc["file"]}" '
+            hint=f'extension command file "{commands_desc["file"]}" '
             f'escapes project path {project.path}'
         )
 
-    # Create the command thunks.
+    # Create the command thunks. Each command is either a class-based
+    # extension, selected with 'class', or an executable extension, selected
+    # with 'exec'.
     thunks = []
     for command_desc in commands_desc['commands']:
         name = command_desc['name']
-        attr = command_desc.get('class', name)
         help = command_desc.get('help', f'(no help provided; try "west {name} -h")')
-        factory = _ExtFactory(py_file, name, attr)
+
+        if 'exec' in command_desc:
+            if 'class' in command_desc:
+                raise ExtensionCommandError(
+                    hint=f"west command '{name}' sets both 'class' and 'exec'"
+                )
+            interpreter = _exec_interpreter(name, command_desc['exec'])
+            factory = _ExecExtFactory(file, interpreter, name, help, project.path)
+        else:
+            attr = command_desc.get('class', name)
+            factory = _ExtFactory(file, name, attr)
+
         thunks.append(WestExtCommandSpec(name, project, help, factory))
 
     # Return the thunks for this project.
     return thunks
+
+
+def _exec_interpreter(name, value):
+    # Turn the 'exec' value of a command into the interpreter argument list
+    # to prefix the file with. 'true' means "run the file directly" (empty
+    # list); a string or list of strings names the interpreter.
+    if value is True:
+        return []
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, list) and all(isinstance(v, str) for v in value):
+        return list(value)
+    raise ExtensionCommandError(
+        hint=f"west command '{name}' has an invalid 'exec' value; "
+        "expected true, a string, or a list of strings"
+    )
 
 
 def _commands_module_from_file(file):

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -59,7 +59,7 @@ QUAL_REFS_WEST = 'refs/west/'
 #: v1.0.x, so that users can say "I want schema version 1" instead of
 #: having to keep using '0.13', which was the previous version this
 #: changed.)
-SCHEMA_VERSION = '1.2'
+SCHEMA_VERSION = '1.6'
 # MAINTAINERS:
 #
 # - Make sure to update _VALID_SCHEMA_VERS if you change this.
@@ -216,6 +216,7 @@ _VALID_SCHEMA_VERS = [
     '0.12',
     '0.13',
     '1.0',
+    '1.2',
     SCHEMA_VERSION,
 ]
 

--- a/src/west/west-commands-schema.yml
+++ b/src/west/west-commands-schema.yml
@@ -18,6 +18,9 @@ mapping:
     sequence:
       - type: map
         mapping:
+          # The file backing the commands below. For "class" commands it is
+          # imported as a Python module; for "exec" commands it is run as an
+          # executable.
           file:
             required: true
             type: str
@@ -30,9 +33,23 @@ mapping:
                   name:
                     required: false
                     type: str
+                  # "class" (class-based extension): the file is imported as
+                  # a Python module and this WestCommand subclass is used.
+                  # Defaults to "name". Mutually exclusive with "exec".
                   class:
                     required: false
                     type: str
+                  # "exec" (executable extension): the file is run as a
+                  # program instead of imported. Its value is either:
+                  #   - true: run the file directly, or
+                  #   - an interpreter command (string, e.g. "python3", or a
+                  #     list, e.g. ["/usr/bin/env", "python3"]) to run it with.
+                  # The type (bool/str/seq) can't be expressed in pykwalify,
+                  # so it is checked in west.commands. Mutually exclusive with
+                  # "class".
+                  exec:
+                    required: false
+                    type: any
                   help:
                     required: false
                     type: str

--- a/tests/test_extension_commands.py
+++ b/tests/test_extension_commands.py
@@ -2,12 +2,24 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import os
+import stat
 import subprocess
+import sys
 import textwrap
 from pathlib import Path
 
+import pytest
 import yaml
-from conftest import GIT, WINDOWS, add_commit, cmd, cmd_raises, yaml_editor
+from conftest import (
+    GIT,
+    WINDOWS,
+    add_commit,
+    cmd,
+    cmd_raises,
+    cmd_subprocess,
+    yaml_editor,
+)
 
 
 def _yaml_get_proj(mf: dict, projname: str):
@@ -515,3 +527,300 @@ def test_extension_special_chars(west_update_tmpdir):
     resolved_mf = cmd('manifest --resolve')
     resolved_mf = yaml.safe_load(resolved_mf)
     assert resolved_mf["manifest"]["self"]["west-commands"] == weird_cmds
+
+
+#
+# Executable (exec) extension commands
+#
+
+
+# A Python script that echoes the WEST_* context and its forwarded arguments.
+# It is run through an interpreter, so it works on every platform.
+_ENV_ECHO_PY = textwrap.dedent('''\
+    import os
+    import sys
+
+    print("hello from exec extension")
+    print("command=" + os.environ.get("WEST_COMMAND", ""))
+    print("topdir=" + os.environ.get("WEST_TOPDIR", ""))
+    print("project=" + os.environ.get("WEST_PROJECT_PATH", ""))
+    _mf = os.environ.get("WEST_MANIFEST_PATH", "")
+    print("have_manifest=" + ("yes" if os.path.isfile(_mf) else "no"))
+    print("args=" + " ".join(sys.argv[1:]))
+    ''')
+
+# YAML scalar for the interpreter that runs this test's Python. Single-quoted
+# so backslashes and spaces in the path survive on Windows.
+_PY = f"'{sys.executable}'"
+
+
+def _add_exec_extension(west_update_tmpdir, files, *, make_executable=None):
+    # Commit 'files' to the net-tools project and mark 'make_executable'
+    # (a project-relative path) as executable in the working tree.
+    net_tools_path = west_update_tmpdir / 'net-tools'
+    add_commit(net_tools_path, 'add exec extension', files=files)
+    if make_executable is not None:
+        script_path = net_tools_path / make_executable
+        mode = os.stat(script_path).st_mode
+        os.chmod(script_path, mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return net_tools_path
+
+
+def test_exec_extension_interpreter(west_update_tmpdir):
+    # An interpreter-backed executable extension: the file is run as an
+    # argument to the interpreter and exposes workspace context through the
+    # WEST_* environment variables. This works on every platform.
+    _add_exec_extension(
+        west_update_tmpdir,
+        files={
+            'scripts/echo.py': _ENV_ECHO_PY,
+            'scripts/west-commands.yml': textwrap.dedent(f'''\
+                west-commands:
+                  - file: scripts/echo.py
+                    commands:
+                      - name: greet
+                        exec: {_PY}
+                        help: greet through an interpreter
+                '''),
+        },
+    )
+
+    out = cmd_subprocess(['greet', 'foo', 'bar'], cwd=west_update_tmpdir)
+    assert 'hello from exec extension' in out
+    assert f'topdir={west_update_tmpdir}' in out
+    assert 'project=net-tools' in out
+    assert 'have_manifest=yes' in out
+    # Everything after the command name is forwarded verbatim, including
+    # arguments west knows nothing about.
+    assert 'args=foo bar' in out
+
+
+def test_exec_extension_interpreter_list(west_update_tmpdir):
+    # 'exec' may be a list, e.g. to pass interpreter options.
+    _add_exec_extension(
+        west_update_tmpdir,
+        files={
+            'scripts/echo.py': _ENV_ECHO_PY,
+            'scripts/west-commands.yml': textwrap.dedent(f'''\
+                west-commands:
+                  - file: scripts/echo.py
+                    commands:
+                      - name: greet
+                        exec: [{_PY}, '-B']
+                        help: greet through an interpreter with options
+                '''),
+        },
+    )
+
+    out = cmd_subprocess(['greet'], cwd=west_update_tmpdir)
+    assert 'hello from exec extension' in out
+
+
+@pytest.mark.skipif(WINDOWS, reason='direct execution needs a real executable on Windows')
+def test_exec_extension_direct(west_update_tmpdir):
+    # 'exec: true' runs the file directly (no interpreter). On POSIX a
+    # shebang + executable bit makes a shell script directly runnable.
+    _add_exec_extension(
+        west_update_tmpdir,
+        files={
+            'scripts/greet.sh': textwrap.dedent('''\
+                #!/bin/sh
+                echo "hello from direct exec"
+                echo "command=$WEST_COMMAND"
+                echo "topdir=$WEST_TOPDIR"
+                echo "args=$*"
+                '''),
+            'scripts/west-commands.yml': textwrap.dedent('''\
+                west-commands:
+                  - file: scripts/greet.sh
+                    commands:
+                      - name: greet
+                        exec: true
+                        help: greet from a shell script
+                '''),
+        },
+        make_executable='scripts/greet.sh',
+    )
+
+    out = cmd_subprocess(['greet', 'foo', 'bar'], cwd=west_update_tmpdir)
+    assert 'hello from direct exec' in out
+    assert f'topdir={west_update_tmpdir}' in out
+    assert 'args=foo bar' in out
+
+
+def test_exec_extension_dispatch_on_command_name(west_update_tmpdir):
+    # A single file registered under multiple names can tell which
+    # subcommand was invoked through WEST_COMMAND.
+    _add_exec_extension(
+        west_update_tmpdir,
+        files={
+            'scripts/echo.py': _ENV_ECHO_PY,
+            'scripts/west-commands.yml': textwrap.dedent(f'''\
+                west-commands:
+                  - file: scripts/echo.py
+                    commands:
+                      - name: sub-one
+                        exec: {_PY}
+                        help: first subcommand
+                      - name: sub-two
+                        exec: {_PY}
+                        help: second subcommand
+                '''),
+        },
+    )
+
+    assert 'command=sub-one' in cmd_subprocess(['sub-one'], cwd=west_update_tmpdir)
+    assert 'command=sub-two' in cmd_subprocess(['sub-two'], cwd=west_update_tmpdir)
+
+
+def test_exec_extension_forwards_options(west_update_tmpdir):
+    # Options that would otherwise look like west arguments (including -h)
+    # must be forwarded to the executable, not intercepted by west.
+    _add_exec_extension(
+        west_update_tmpdir,
+        files={
+            'scripts/echo.py': _ENV_ECHO_PY,
+            'scripts/west-commands.yml': textwrap.dedent(f'''\
+                west-commands:
+                  - file: scripts/echo.py
+                    commands:
+                      - name: echo-args
+                        exec: {_PY}
+                        help: echo forwarded arguments
+                '''),
+        },
+    )
+
+    out = cmd_subprocess(['echo-args', '--help', '-v', '--unknown'], cwd=west_update_tmpdir)
+    assert 'args=--help -v --unknown' in out
+
+
+def test_exec_extension_exit_code(west_update_tmpdir):
+    # West propagates the executable's exit code.
+    _add_exec_extension(
+        west_update_tmpdir,
+        files={
+            'scripts/fail.py': 'import sys\nsys.exit(3)\n',
+            'scripts/west-commands.yml': textwrap.dedent(f'''\
+                west-commands:
+                  - file: scripts/fail.py
+                    commands:
+                      - name: fail-cmd
+                        exec: {_PY}
+                        help: always fails
+                '''),
+        },
+    )
+
+    with pytest.raises(subprocess.CalledProcessError) as exc_info:
+        cmd_subprocess(['fail-cmd'], cwd=west_update_tmpdir)
+    assert exc_info.value.returncode == 3
+
+
+@pytest.mark.skipif(WINDOWS, reason='file executable bit is a POSIX concept')
+def test_exec_extension_not_executable(west_update_tmpdir):
+    # 'exec: true' with a non-executable file produces a clear error.
+    _add_exec_extension(
+        west_update_tmpdir,
+        files={
+            'scripts/not-exec.sh': '#!/bin/sh\necho nope\n',
+            'scripts/west-commands.yml': textwrap.dedent('''\
+                west-commands:
+                  - file: scripts/not-exec.sh
+                    commands:
+                      - name: not-exec
+                        exec: true
+                        help: not executable
+                '''),
+        },
+        # Intentionally do not mark it executable.
+    )
+
+    _, err_msg = cmd_raises('not-exec', SystemExit)
+    assert 'is not executable' in err_msg
+
+
+@pytest.mark.parametrize('exec_value', ['true', _PY])
+def test_exec_extension_file_not_found(west_update_tmpdir, exec_value):
+    # A missing backing file reports "not found" rather than the misleading
+    # "not executable", both when run directly and through an interpreter.
+    # This check is platform-independent.
+    _add_exec_extension(
+        west_update_tmpdir,
+        files={
+            'scripts/west-commands.yml': textwrap.dedent(f'''\
+                west-commands:
+                  - file: scripts/missing
+                    commands:
+                      - name: missing-cmd
+                        exec: {exec_value}
+                        help: missing file
+                '''),
+        },
+    )
+
+    _, err_msg = cmd_raises('missing-cmd', SystemExit)
+    assert 'not found' in err_msg
+
+
+def test_exec_extension_class_and_exec_conflict(west_update_tmpdir):
+    # 'class' and 'exec' are mutually exclusive on a command.
+    _add_exec_extension(
+        west_update_tmpdir,
+        files={
+            'scripts/echo.py': _ENV_ECHO_PY,
+            'scripts/west-commands.yml': textwrap.dedent(f'''\
+                west-commands:
+                  - file: scripts/echo.py
+                    commands:
+                      - name: conflict-cmd
+                        class: SomeClass
+                        exec: {_PY}
+                        help: invalid
+                '''),
+        },
+    )
+
+    _, err_msg = cmd_raises('conflict-cmd', SystemExit)
+    assert "sets both 'class' and 'exec'" in err_msg
+
+
+def test_exec_extension_invalid_exec_value(west_update_tmpdir):
+    # 'exec' must be true, a string, or a list of strings.
+    _add_exec_extension(
+        west_update_tmpdir,
+        files={
+            'scripts/echo.py': _ENV_ECHO_PY,
+            'scripts/west-commands.yml': textwrap.dedent('''\
+                west-commands:
+                  - file: scripts/echo.py
+                    commands:
+                      - name: bad-exec
+                        exec: 123
+                        help: invalid
+                '''),
+        },
+    )
+
+    _, err_msg = cmd_raises('bad-exec', SystemExit)
+    assert "invalid 'exec' value" in err_msg
+
+
+def test_exec_extension_directory_escape(west_update_tmpdir):
+    # The file must not escape the project directory.
+    _add_exec_extension(
+        west_update_tmpdir,
+        files={
+            'scripts/west-commands.yml': textwrap.dedent('''\
+                west-commands:
+                  - file: ../../zephyr/evil.sh
+                    commands:
+                      - name: evil-exec
+                        exec: true
+                        help: escape attempt
+                '''),
+        },
+    )
+
+    _, err_msg = cmd_raises('evil-exec', SystemExit)
+    assert 'escapes project path' in err_msg


### PR DESCRIPTION
West extension commands currently must be Python `WestCommand` subclasses, coupling every extension to the west API even when it only needs west's ability to locate and run a workspace-relative command.

This adds a second kind of extension command: one backed by an executable in any language. It reuses the existing `file:` key and adds a per-command `exec:` selector:

```yaml
west-commands:
  # WestCommand extension: the file is imported and this subclass is
  # instantiated, with full access to the west API.
  - file: scripts/west_commands.py
    commands:
      - name: my-api-cmd
        class: MyApiCommand

  # Executable extension run through an interpreter.
  - file: scripts/gen_report.py
    commands:
      - name: gen-report
        exec: python3        # runs: python3 scripts/gen_report.py <args...>

  # Executable extension run directly (compiled binary or +x script).
  - file: tools/provision
    commands:
      - name: provision
        exec: true           # runs: tools/provision <args...>
```

- `exec:` may be `true` (run the file directly), a string, or a list (interpreter + args).
- `class` and `exec` are mutually exclusive; commands without `exec` keep the current Python behavior, so existing extensions are unaffected.
- West forwards all arguments (including `-h/--help`) verbatim and passes workspace context via `WEST_*` env vars (`WEST`, `WEST_TOPDIR`, `WEST_MANIFEST_PATH`, `WEST_PROJECT_PATH`, `WEST_VERBOSE`, and `WEST_COMMAND` for dispatch when one file is registered under several names).
- The interpreter form makes interpreted scripts work on Windows too, where a bare script can't be executed directly.

Fixes: https://github.com/zephyrproject-rtos/west/issues/974