### PR TITLE
ruff: Bump version and drop preview mode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ west = "west.app.main:main"
 
 [dependency-groups]
 lint = [
-    "ruff~=0.13",
+    "ruff~=0.16",
 ]
 test = [
     "coverage~=7.10",
@@ -86,6 +86,7 @@ source = [
 line-length = 100
 
 [tool.ruff.lint]
+# Extend Ruff's (broad, curated) default rule set with a few extra families.
 extend-select = [
   "B",   # flake8-bugbear
   "E",   # pycodestyle errors
@@ -98,8 +99,6 @@ extend-select = [
 [tool.ruff.format]
 quote-style = "preserve"
 line-ending = "lf"
-# Enable preview mode for Github Annotations added in 0.13.3
-preview = true
 
 [tool.mypy]
 mypy_path = "src"

--- a/src/west/app/config.py
+++ b/src/west/app/config.py
@@ -193,9 +193,8 @@ class Config(WestCommand):
                 )
         elif not args.name:
             self.parser.error('missing argument name (to list all options and values, use -l)')
-        elif args.append:
-            if args.value is None:
-                self.parser.error('-a requires both name and value')
+        elif args.append and args.value is None:
+            self.parser.error('-a requires both name and value')
 
         if args.list_paths:
             self.list_paths(args)

--- a/src/west/app/main.py
+++ b/src/west/app/main.py
@@ -1081,7 +1081,7 @@ class WestArgumentParser(argparse.ArgumentParser):
                 #
                 # This has its own wrinkle: we can't let a failed
                 # import break the built-in commands.
-                for _path, specs in self.west_app.extension_groups.items():
+                for specs in self.west_app.extension_groups.values():
                     # This may occur in case a project defines commands already
                     # defined, in which case it has been filtered out.
                     if not specs:

--- a/src/west/app/project.py
+++ b/src/west/app/project.py
@@ -19,6 +19,7 @@ from functools import partial
 from os.path import abspath, basename, relpath
 from pathlib import Path, PurePath
 from time import perf_counter
+from typing import ClassVar
 from urllib.parse import urlparse
 
 from west import util
@@ -2503,17 +2504,17 @@ class Grep(_ProjectCommand):
     #
     # - the 'failed' handling below for proper exit codes
     # - color handling works as expected
-    TOOLS = ['git-grep', 'ripgrep', 'grep']
+    TOOLS: ClassVar[list[str]] = ['git-grep', 'ripgrep', 'grep']
 
     DEFAULT_TOOL = 'git-grep'
 
-    DEFAULT_TOOL_ARGS = {
+    DEFAULT_TOOL_ARGS: ClassVar[dict[str, list[str]]] = {
         'git-grep': [],
         'ripgrep': [],
         'grep': ['--recursive'],
     }
 
-    DEFAULT_TOOL_EXECUTABLES = {
+    DEFAULT_TOOL_EXECUTABLES: ClassVar[dict[str, list[str]]] = {
         # git-grep is intentionally omitted: use self._git
         'ripgrep': ['rg', 'ripgrep'],
         'grep': ['grep'],

--- a/src/west/app/project.py
+++ b/src/west/app/project.py
@@ -2697,13 +2697,15 @@ def _clean_west_refspace(project):
 
 
 def _update_manifest_rev(project, new_manifest_rev):
-    project.git([
-        'update-ref',
-        '-m',
-        f'west update: moving to {new_manifest_rev}',
-        QUAL_MANIFEST_REV,
-        new_manifest_rev,
-    ])
+    project.git(
+        [
+            'update-ref',
+            '-m',
+            f'west update: moving to {new_manifest_rev}',
+            QUAL_MANIFEST_REV,
+            new_manifest_rev,
+        ]
+    )
 
 
 def _maybe_sha(rev):

--- a/src/west/app/project.py
+++ b/src/west/app/project.py
@@ -1817,7 +1817,7 @@ class Update(_ProjectCommand):
 
     def update(self, project):
         if self.args.stats:
-            stats = dict()
+            stats = {}
             update_start = perf_counter()
         else:
             stats = None

--- a/src/west/app/project.py
+++ b/src/west/app/project.py
@@ -704,7 +704,7 @@ below.
             self.die(f'Cannot initialize in {directory}: permission denied')
         except FileExistsError:
             self.die(f'Cannot initialize in {directory}: it already exists')
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 intentional catch-all for a clean error message
             self.die(f"Can't create {directory}: {e}")
 
 

--- a/src/west/commands.py
+++ b/src/west/commands.py
@@ -350,7 +350,8 @@ class WestCommand(ABC):
         the call at Verbosity.DBG_MORE level.'''
 
         self._log_subproc(args, **kwargs)
-        return subprocess.run(args, errors='backslashreplace', **kwargs)
+        # check is intentionally left to the caller via kwargs
+        return subprocess.run(args, errors='backslashreplace', **kwargs)  # noqa: PLW1510
 
     def die_if_no_git(self):
         '''Abort if git is not installed on PATH.'''

--- a/src/west/configuration.py
+++ b/src/west/configuration.py
@@ -309,11 +309,10 @@ class Configuration:
         if configfile == ConfigFile.ALL:
             # We need a real configuration file; ALL doesn't make sense here.
             raise ValueError(configfile)
-        elif configfile == ConfigFile.LOCAL:
-            if not self._local_locs:
-                raise ValueError(
-                    f'{configfile}: file not found; retry in a workspace or set WEST_CONFIG_LOCAL'
-                )
+        elif configfile == ConfigFile.LOCAL and not self._local_locs:
+            raise ValueError(
+                f'{configfile}: file not found; retry in a workspace or set WEST_CONFIG_LOCAL'
+            )
 
         # ensure that only one config is in use
         configs = self.get_search_paths(configfile)

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -2372,11 +2372,10 @@ class Manifest:
         # md = manifest defaults (dictionary with values parsed from
         # the manifest)
         mdrem: str | None = defaults.get('remote')
-        if mdrem:
-            # The default remote name, if provided, must refer to a
-            # well-defined remote.
-            if mdrem not in url_bases:
-                self._malformed(f'default remote {mdrem} is not defined')
+        # The default remote name, if provided, must refer to a
+        # well-defined remote.
+        if mdrem and mdrem not in url_bases:
+            self._malformed(f'default remote {mdrem} is not defined')
         return _defaults(mdrem, defaults.get('revision', _DEFAULT_REV))
 
     def _load_projects(

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -2203,7 +2203,7 @@ class Manifest:
         slf: dict[str, Any] | None = manifest_data.get('self')
 
         if not slf:
-            return None
+            return
 
         yaml_path = slf.get('path')
         if 'path' in slf and not yaml_path:

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -803,8 +803,6 @@ class _MLS(str):
     then dumped into YAML using block style literals ("|").
     '''
 
-    pass
-
 
 class Project:
     '''Represents a project defined in a west manifest.

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -500,8 +500,7 @@ def _update_disabled_groups(disabled_groups: set[str], group_filter: GroupFilter
             disabled_groups.add(item[1:])
         elif item.startswith('+'):
             group = item[1:]
-            if group in disabled_groups:
-                disabled_groups.remove(group)
+            disabled_groups.discard(group)
         else:
             # We should never get here. This private helper is only
             # meant to be invoked on valid data.

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -909,7 +909,7 @@ class Project:
         self.userdata: Any = userdata
 
         # Internal helpers
-        self._west_commands_manifest_dirs: dict[str, str] = dict()
+        self._west_commands_manifest_dirs: dict[str, str] = {}
 
     @property
     def path(self) -> str:
@@ -1270,7 +1270,7 @@ class ManifestProject(Project):
 
         # Extension commands.
         self.west_commands = _west_commands_list(west_commands)
-        self._west_commands_manifest_dirs: dict[str, str] = dict()
+        self._west_commands_manifest_dirs: dict[str, str] = {}
 
     @property
     def abspath(self) -> str | None:

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -474,7 +474,7 @@ def _compose_imap_filters(
         # These type annotated versions silence mypy warnings.
         fn1: Callable[[Project], bool] = imap_filter1
         fn2: Callable[[Project], bool] = imap_filter2
-        return lambda project: (fn1(project) and fn2(project))
+        return lambda project: fn1(project) and fn2(project)
     else:
         return imap_filter1 or imap_filter2
 

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -169,7 +169,7 @@ def _update_project_filter(project_filter: ProjectFilterType, option_value: str 
         try:
             pattern = re.compile(regexp)
         except re.error as e:
-            _err(f'invalid regular expression "{regexp}": {str(e)}')
+            _err(f'invalid regular expression "{regexp}": {e!s}')
 
         project_filter.append(ProjectFilterElt(pattern=pattern, make_active=make_active))
 
@@ -846,12 +846,12 @@ class Project:
     def __repr__(self):
         return (
             f'Project("{self.name}", "{self.url}", '
-            f'revision="{self.revision}", path={repr(self.path)}, '
+            f'revision="{self.revision}", path={self.path!r}, '
             f'clone_depth={self.clone_depth}, '
             f'west_commands={self.west_commands}, '
-            f'topdir={repr(self.topdir)}, '
-            f'groups={repr(self.groups)}, '
-            f'userdata={repr(self.userdata)})'
+            f'topdir={self.topdir!r}, '
+            f'groups={self.groups!r}, '
+            f'userdata={self.userdata!r})'
         )
 
     def __str__(self):
@@ -1221,10 +1221,10 @@ class ManifestProject(Project):
 
     def __repr__(self):
         return (
-            f'ManifestProject(path={repr(self.path)}, '
+            f'ManifestProject(path={self.path!r}, '
             f'west_commands={self.west_commands}, '
-            f'topdir={repr(self.topdir)}, '
-            f'userdata={repr(self.userdata)})'
+            f'topdir={self.topdir!r}, '
+            f'userdata={self.userdata!r})'
         )
 
     def __init__(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -445,10 +445,10 @@ def _cmd(cmd, cwd=None, env=None):
             main.main(cmd)
         except SystemExit as e:
             if e.code:
-                raise e
+                raise
         except Exception as e:
             print(f'Uncaught exception type {e}', file=sys.stderr)
-            raise e
+            raise
 
 
 def cmd(cmd: list | str, cwd=None, stderr: io.StringIO | None = None, env=None):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -204,12 +204,14 @@ def setup_teardown_test_environment(tmpdir_factory):
     # run with environment variables set
     with (
         chdir(tmp_cwd),
-        update_env({
-            'WEST_CONFIG_SYSTEM': str(system),
-            'WEST_CONFIG_GLOBAL': str(glbl),
-            'WEST_CONFIG_LOCAL': None,
-            'ZEPHYR_BASE': str(tmpdir / 'no-zephyr-here'),
-        }),
+        update_env(
+            {
+                'WEST_CONFIG_SYSTEM': str(system),
+                'WEST_CONFIG_GLOBAL': str(glbl),
+                'WEST_CONFIG_LOCAL': None,
+                'ZEPHYR_BASE': str(tmpdir / 'no-zephyr-here'),
+            }
+        ),
     ):
         yield
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -885,7 +885,7 @@ def test_no_args():
 
 def test_list():
     def sorted_list(other_args=''):
-        return list(sorted(cmd('config -l ' + other_args).splitlines()))
+        return sorted(cmd('config -l ' + other_args).splitlines())
 
     _, err_msg = cmd_raises('config -l pytest.foo', SystemExit)
     assert '-l cannot be combined with name argument' in err_msg

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -448,14 +448,16 @@ def test_append():
     assert cfg(f=GLOBAL)['build']['cmake-args'] == '-DCONF_FILE=foo.conf'
 
     # Use a list instead of a string to avoid one level of nested quoting
-    cmd([
-        'config',
-        '--global',
-        '-a',
-        'build.cmake-args',
-        '--',
-        ' -DEXTRA_CFLAGS=\'-Wextra -g0\' -DFOO=BAR',
-    ])
+    cmd(
+        [
+            'config',
+            '--global',
+            '-a',
+            'build.cmake-args',
+            '--',
+            ' -DEXTRA_CFLAGS=\'-Wextra -g0\' -DFOO=BAR',
+        ]
+    )
 
     assert (
         cfg(f=GLOBAL)['build']['cmake-args']

--- a/tests/test_extension_commands.py
+++ b/tests/test_extension_commands.py
@@ -332,15 +332,17 @@ def test_call_imported_project_submanifest_commands_from_project_subdirectory(re
     with yaml_editor(manifest_path / 'west.yml') as mf:
         net_tools_project = next(p for p in mf['manifest']['projects'] if p['name'] == 'net-tools')
         net_tools_project['import'] = 'mf_subdir/west.yml'
-    subprocess.check_call([
-        GIT,
-        '-C',
-        str(manifest_path),
-        'commit',
-        '-m',
-        'import mf_subdir/west.yml',
-        'west.yml',
-    ])
+    subprocess.check_call(
+        [
+            GIT,
+            '-C',
+            str(manifest_path),
+            'commit',
+            '-m',
+            'import mf_subdir/west.yml',
+            'west.yml',
+        ]
+    )
 
     workspace = repos_tmpdir / 'workspace'
     cmd(['init', '-m', str(manifest_path), str(workspace)])
@@ -411,15 +413,17 @@ def test_call_imported_project_submanifest_commands_from_project_subdirectory_sp
     with yaml_editor(manifest_path / 'west.yml') as mf:
         net_tools_project = next(p for p in mf['manifest']['projects'] if p['name'] == 'net-tools')
         net_tools_project['import'] = r'mf_subdir/west.yml'
-    subprocess.check_call([
-        GIT,
-        '-C',
-        str(manifest_path),
-        'commit',
-        '-m',
-        'import mf_subdir\\west.yml',
-        'west.yml',
-    ])
+    subprocess.check_call(
+        [
+            GIT,
+            '-C',
+            str(manifest_path),
+            'commit',
+            '-m',
+            'import mf_subdir\\west.yml',
+            'west.yml',
+        ]
+    )
 
     workspace = repos_tmpdir / 'workspace'
     cmd(['init', '-m', str(manifest_path), str(workspace)])

--- a/tests/test_extension_commands.py
+++ b/tests/test_extension_commands.py
@@ -330,7 +330,7 @@ def test_call_imported_project_submanifest_commands_from_project_subdirectory(re
     )
 
     with yaml_editor(manifest_path / 'west.yml') as mf:
-        net_tools_project = [p for p in mf['manifest']['projects'] if p['name'] == 'net-tools'][0]
+        net_tools_project = next(p for p in mf['manifest']['projects'] if p['name'] == 'net-tools')
         net_tools_project['import'] = 'mf_subdir/west.yml'
     subprocess.check_call([
         GIT,
@@ -409,7 +409,7 @@ def test_call_imported_project_submanifest_commands_from_project_subdirectory_sp
     )
 
     with yaml_editor(manifest_path / 'west.yml') as mf:
-        net_tools_project = [p for p in mf['manifest']['projects'] if p['name'] == 'net-tools'][0]
+        net_tools_project = next(p for p in mf['manifest']['projects'] if p['name'] == 'net-tools')
         net_tools_project['import'] = r'mf_subdir/west.yml'
     subprocess.check_call([
         GIT,

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -160,9 +160,9 @@ def test_manifest_from_data_without_topdir():
     assert manifest.projects[-1].name == 'foo'
     assert manifest.projects[-1].abspath is None
 
-    manifest = Manifest.from_data({
-        'manifest': {'projects': [{'name': 'foo', 'url': 'https:foo.com'}]}
-    })
+    manifest = Manifest.from_data(
+        {'manifest': {'projects': [{'name': 'foo', 'url': 'https:foo.com'}]}}
+    )
     assert manifest.projects[-1].name == 'foo'
     assert manifest.projects[-1].abspath is None
 
@@ -613,7 +613,7 @@ def test_project_repr():
         == 'Project("zephyr", "https://foo.com", revision="r", path=\'zephyr\', '
         'clone_depth=None, west_commands=[\'some-path/west-commands.yml\'], '
         'topdir=None, groups=[], userdata=None)'
-    )  # noqa: E501
+    )
 
 
 def test_project_sha(tmpdir):

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -2283,7 +2283,7 @@ _IMPORT_SELF_MANIFESTS = [
           - west.d/01-libraries.yml
           - west.d/02-vendor-hals.yml
           - west.d/03-applications.yml
-    '''
+    ''',
     # as an equivalent map:
     '''\
     manifest:
@@ -2350,7 +2350,7 @@ def _setup_import_self(tmp_workspace, manifests):
             f.write(content)
 
 
-@pytest.mark.parametrize('content', _IMPORT_SELF_MANIFESTS, ids=['dir', 'files'])
+@pytest.mark.parametrize('content', _IMPORT_SELF_MANIFESTS, ids=['dir', 'files', 'map'])
 def test_import_self_directory(content, tmp_workspace):
     # Test a couple of different equivalent ways to import content
     # from the manifest repository.

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1874,7 +1874,7 @@ def test_update_narrow(tmpdir):
     # Test that 'west update --narrow' doesn't fetch tags, and that
     # 'west update' respects the 'update.narrow' config option.
 
-    remote, workspace = setup_narrow(tmpdir)
+    _remote, workspace = setup_narrow(tmpdir)
     workspace.chdir()
 
     def project_tags():
@@ -1901,7 +1901,7 @@ def test_update_narrow_depth1(tmpdir):
     # one commit, regardless of how many there are in the remote
     # repository.
 
-    remote, workspace = setup_narrow(tmpdir)
+    _remote, workspace = setup_narrow(tmpdir)
 
     cmd('update --narrow --fetch-opt=--depth=1', cwd=workspace)
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -244,7 +244,7 @@ def test_list_groups(west_init_tmpdir):
     check(_list_f('{name} .{groups}. {path}') + ['baz'], ['baz .baz-group. baz'])
 
     check(
-        _list_f("{name} .{groups}. {path}") + 'foo bar baz'.split(),
+        _list_f("{name} .{groups}. {path}") + ['foo', 'bar', 'baz'],
         ['foo .foo-group-1,foo-group-2. foo', 'bar .. path-for-bar', 'baz .baz-group. baz'],
     )
 
@@ -264,7 +264,7 @@ def test_list_groups(west_init_tmpdir):
     )
 
     check(
-        _list_f("{name} .{groups}. {path} {active}") + ['--all'] + 'foo bar'.split(),
+        _list_f("{name} .{groups}. {path} {active}") + ['--all'] + ['foo', 'bar'],
         ['foo .foo-group-1,foo-group-2. foo inactive', 'bar .. path-for-bar active'],
     )
 
@@ -825,7 +825,7 @@ def test_forall(west_init_tmpdir):
     ]
 
     assert cmd_subprocess(
-        'forall --group Kconfiglib-group -c'.split() + ['echo foo']
+        ['forall', '--group', 'Kconfiglib-group', '-c'] + ['echo foo']
     ).splitlines() == [
         '=== running "echo foo" in Kconfiglib (subdir/Kconfiglib):',
         'foo',

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -2735,13 +2735,12 @@ def test_extension_command_multiproject(repos_tmpdir):
 
     # The newline shenanigans are for Windows.
     help_text = '\n'.join(cmd('-h').splitlines())
-    expected = '\n'.join([
-        'extension commands from project Kconfiglib (path: subdir/Kconfiglib):',  # noqa: E501
-        '  kconfigtest:          (no help provided; try "west kconfigtest -h")',  # noqa: E501
-        '',
-        'extension commands from project net-tools (path: net-tools):',
-        '  test-extension:       test-extension-help',
-    ])
+    expected = textwrap.dedent('''\
+        extension commands from project Kconfiglib (path: subdir/Kconfiglib):
+          kconfigtest:          (no help provided; try "west kconfigtest -h")
+
+        extension commands from project net-tools (path: net-tools):
+          test-extension:       test-extension-help''')
     assert expected in help_text, help_text
 
     actual = cmd('test-extension')

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -2850,8 +2850,10 @@ def test_extension_command_duplicate(repos_tmpdir):
 
     expected_warns = [
         'WARNING: ignoring project Kconfiglib extension command "list"; this is a built in command',
-        'WARNING: ignoring project net-tools extension command "test-extension"; '
-        'command "test-extension" is already defined as extension command',
+        (
+            'WARNING: ignoring project net-tools extension command "test-extension"; '
+            'command "test-extension" is already defined as extension command'
+        ),
     ]
 
     # Expect output from the built-in command, not its Kconfiglib duplicate.

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -357,55 +357,63 @@ def test_manifest_untracked(west_update_tmpdir):
     clone(topdir / "net-tools", Path('subdir/acopy'))
     clone(topdir / "net-tools", Path('tmpcopy'))
 
-    check([
-        'dir',
-        'file.txt',
-        str(Path('subdir/acopy')),
-        str(Path('subdir/new')),
-        str(Path('subdir/z.py')),
-        'tmpcopy',
-        'unt',
-    ])
+    check(
+        [
+            'dir',
+            'file.txt',
+            str(Path('subdir/acopy')),
+            str(Path('subdir/new')),
+            str(Path('subdir/z.py')),
+            'tmpcopy',
+            'unt',
+        ]
+    )
 
     # Empty a project so it's not a Git repo anymore
     (topdir / "net-tools" / ".git").rename(topdir / "net-tools" / "former-git")
     # Should make no difference
-    check([
-        'dir',
-        'file.txt',
-        str(Path('subdir/acopy')),
-        str(Path('subdir/new')),
-        str(Path('subdir/z.py')),
-        'tmpcopy',
-        'unt',
-    ])
+    check(
+        [
+            'dir',
+            'file.txt',
+            str(Path('subdir/acopy')),
+            str(Path('subdir/new')),
+            str(Path('subdir/z.py')),
+            'tmpcopy',
+            'unt',
+        ]
+    )
 
     # Same with an inactive project
     (kconfiglib / ".git").rename(kconfiglib / "former-git")
     # Should make no difference
-    check([
-        'dir',
-        'file.txt',
-        str(Path('subdir/acopy')),
-        str(Path('subdir/new')),
-        str(Path('subdir/z.py')),
-        'tmpcopy',
-        'unt',
-    ])
+    check(
+        [
+            'dir',
+            'file.txt',
+            str(Path('subdir/acopy')),
+            str(Path('subdir/new')),
+            str(Path('subdir/z.py')),
+            'tmpcopy',
+            'unt',
+        ]
+    )
 
     # Even if we make the whole inactive project disappear it should make no
     # difference at all, except that the renamed dir will show up.
     (kconfiglib).rename(topdir / "subdir" / "other")
-    check([
-        'dir',
-        'file.txt',
-        str(Path('subdir/acopy')),
-        str(Path('subdir/new')),
-        str(Path('subdir/other')),
-        str(Path('subdir/z.py')),
-        'tmpcopy',
-        'unt',
-    ])
+    check(
+        [
+            'dir',
+            'file.txt',
+            str(Path('subdir/acopy')),
+            str(Path('subdir/new')),
+            str(Path('subdir/other')),
+            str(Path('subdir/z.py')),
+            'tmpcopy',
+            'unt',
+        ]
+    )
 
 
 @pytest.mark.skipif(sys.platform.startswith("win"), reason="symbolic links not tested on Windows")
@@ -434,13 +442,15 @@ def test_manifest_untracked_with_symlinks(west_update_tmpdir):
     # File symlink tests, should all be displayed as untracked as well
     Path('filesl.yml').symlink_to(Path('zephyr/west.yml'))
     Path('subdir/afsl.py').symlink_to(Path('net-tools/scripts/test.py'))
-    check([
-        'anothersl',
-        'asl',
-        'filesl.yml',
-        str(Path('subdir/afsl.py')),
-        str(Path('subdir/yetanothersl')),
-    ])
+    check(
+        [
+            'anothersl',
+            'asl',
+            'filesl.yml',
+            str(Path('subdir/afsl.py')),
+            str(Path('subdir/yetanothersl')),
+        ]
+    )
 
 
 def test_manifest_freeze(west_update_tmpdir):
@@ -691,11 +701,13 @@ def test_compare_format_projects(config_tmpdir, west_init_tmpdir):
     assert re.match(r'^[0-9a-f]{40}$', sha)
 
     # All remaining keys.
-    out = cmd([
-        'compare',
-        '-f',
-        '{name}|{url}|{path}|{abspath}|{posixpath}|{revision}|{groups}',
-    ]).strip()
+    out = cmd(
+        [
+            'compare',
+            '-f',
+            '{name}|{url}|{path}|{abspath}|{posixpath}|{revision}|{groups}',
+        ]
+    ).strip()
     fields = out.split('|')
     assert fields[0] == 'Kconfiglib'
     assert fields[1].endswith('/Kconfiglib')  # url from test fixture's url-base
@@ -1717,17 +1729,19 @@ manifest:
     )
 
     def add_submodule(superproject, submodule_name, submodule_url, submodule_path):
-        subprocess.check_call([
-            GIT,
-            '-C',
-            os.fspath(superproject),
-            'submodule',
-            'add',
-            '--name',
-            submodule_name,
-            submodule_url,
-            submodule_path,
-        ])
+        subprocess.check_call(
+            [
+                GIT,
+                '-C',
+                os.fspath(superproject),
+                'submodule',
+                'add',
+                '--name',
+                submodule_name,
+                submodule_url,
+                submodule_path,
+            ]
+        )
         add_commit(superproject, f'add submodule {submodule_name}')
 
     add_submodule(pseudo_remotes / 'project-1', 'sub-1-1', '../submodule-1-1', 'submodule-1-1')

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -310,7 +310,7 @@ def test_manifest_untracked(west_update_tmpdir):
     topdir = Path(west_update_tmpdir)
 
     # No untracked files yet
-    check(list())
+    check([])
 
     (topdir / "dir").mkdir()
     # Untracked dir

--- a/tests/test_project_caching.py
+++ b/tests/test_project_caching.py
@@ -425,18 +425,22 @@ def test_update_caches_priorities(tmpdir):
     create_repo(tmpdir / 'name_cache_remotes' / 'bar')
     name_cache_foo_head = rev_parse(tmpdir / 'name_cache_remotes' / 'foo', 'HEAD')
     name_cache_bar_head = rev_parse(tmpdir / 'name_cache_remotes' / 'bar', 'HEAD')
-    subprocess.check_call([
-        GIT,
-        'clone',
-        os.fspath(tmpdir / 'name_cache_remotes' / 'foo'),
-        os.fspath(name_cache_dir / "foo"),
-    ])
-    subprocess.check_call([
-        GIT,
-        'clone',
-        os.fspath(tmpdir / 'name_cache_remotes' / 'bar'),
-        os.fspath(name_cache_dir / "bar"),
-    ])
+    subprocess.check_call(
+        [
+            GIT,
+            'clone',
+            os.fspath(tmpdir / 'name_cache_remotes' / 'foo'),
+            os.fspath(name_cache_dir / "foo"),
+        ]
+    )
+    subprocess.check_call(
+        [
+            GIT,
+            'clone',
+            os.fspath(tmpdir / 'name_cache_remotes' / 'bar'),
+            os.fspath(name_cache_dir / "bar"),
+        ]
+    )
 
     # setup remote repositories and local cache for --path-cache
     # (path_cache)
@@ -447,18 +451,22 @@ def test_update_caches_priorities(tmpdir):
     create_repo(tmpdir / 'path_cache_remotes' / 'bar')
     path_cache_foo_head = rev_parse(tmpdir / 'path_cache_remotes' / 'foo', 'HEAD')
     path_cache_bar_head = rev_parse(tmpdir / 'path_cache_remotes' / 'bar', 'HEAD')
-    subprocess.check_call([
-        GIT,
-        'clone',
-        os.fspath(tmpdir / 'path_cache_remotes' / 'foo'),
-        os.fspath(path_cache_dir / "subdir" / "foo"),
-    ])
-    subprocess.check_call([
-        GIT,
-        'clone',
-        os.fspath(tmpdir / 'path_cache_remotes' / 'bar'),
-        os.fspath(path_cache_dir / "bar"),
-    ])
+    subprocess.check_call(
+        [
+            GIT,
+            'clone',
+            os.fspath(tmpdir / 'path_cache_remotes' / 'foo'),
+            os.fspath(path_cache_dir / "subdir" / "foo"),
+        ]
+    )
+    subprocess.check_call(
+        [
+            GIT,
+            'clone',
+            os.fspath(tmpdir / 'path_cache_remotes' / 'bar'),
+            os.fspath(path_cache_dir / "bar"),
+        ]
+    )
 
     # setup remote repositories for auto cache
     create_repo(tmpdir / 'auto_cache_remotes' / 'foo')
@@ -487,13 +495,15 @@ def test_update_caches_priorities(tmpdir):
         bar_head=name_cache_bar_head,
     )
     workspace1.chdir()
-    cmd([
-        'update',
-        '--name-cache',
-        os.fspath(name_cache_dir),
-        '--path-cache',
-        os.fspath(path_cache_dir),
-    ])
+    cmd(
+        [
+            'update',
+            '--name-cache',
+            os.fspath(name_cache_dir),
+            '--path-cache',
+            os.fspath(path_cache_dir),
+        ]
+    )
     assert foo.check(dir=1)
     assert bar.check(dir=1)
     assert rev_parse(foo, 'HEAD') == name_cache_foo_head
@@ -521,13 +531,15 @@ def test_update_caches_priorities(tmpdir):
         bar_head=name_cache_bar_head,
     )
     workspace2.chdir()
-    cmd([
-        'update',
-        '--name-cache',
-        os.fspath(name_cache_dir),
-        '--path-cache',
-        os.fspath(path_cache_dir),
-    ])
+    cmd(
+        [
+            'update',
+            '--name-cache',
+            os.fspath(name_cache_dir),
+            '--path-cache',
+            os.fspath(path_cache_dir),
+        ]
+    )
     assert foo.check(dir=1)
     assert bar.check(dir=1)
     assert rev_parse(foo, 'HEAD') == path_cache_foo_head
@@ -551,13 +563,15 @@ def test_update_caches_priorities(tmpdir):
         bar_head=path_cache_bar_head,
     )
     workspace3.chdir()
-    cmd([
-        'update',
-        '--path-cache',
-        os.fspath(path_cache_dir),
-        '--auto-cache',
-        os.fspath(auto_cache_dir),
-    ])
+    cmd(
+        [
+            'update',
+            '--path-cache',
+            os.fspath(path_cache_dir),
+            '--auto-cache',
+            os.fspath(auto_cache_dir),
+        ]
+    )
     assert foo.check(dir=1)
     assert bar.check(dir=1)
     assert rev_parse(foo, 'HEAD') == path_cache_foo_head
@@ -581,15 +595,17 @@ def test_update_caches_priorities(tmpdir):
 
     assert not (auto_cache_dir / 'foo').exists()
     assert not (auto_cache_dir / 'bar').exists()
-    cmd([
-        'update',
-        '--name-cache',
-        os.fspath(Path('non-existent')),
-        '--path-cache',
-        os.fspath(Path('non-existent')),
-        '--auto-cache',
-        os.fspath(auto_cache_dir),
-    ])
+    cmd(
+        [
+            'update',
+            '--name-cache',
+            os.fspath(Path('non-existent')),
+            '--path-cache',
+            os.fspath(Path('non-existent')),
+            '--auto-cache',
+            os.fspath(auto_cache_dir),
+        ]
+    )
     assert foo.check(dir=1)
     assert bar.check(dir=1)
     assert rev_parse(foo, 'HEAD') == auto_cache_foo_head

--- a/tests/test_project_caching.py
+++ b/tests/test_project_caching.py
@@ -231,8 +231,8 @@ def test_update_auto_cache(tmpdir):
 
     # Check that some info file was created with basic info
     # e.g. /path/to/auto/cache/foo/<hash>.info
-    foo_hash = sorted(os.listdir(auto_cache_dir / 'foo'))[0]
-    bar_hash = sorted(os.listdir(auto_cache_dir / 'bar'))[0]
+    foo_hash = min(os.listdir(auto_cache_dir / 'foo'))
+    bar_hash = min(os.listdir(auto_cache_dir / 'bar'))
     expected_foo_info = textwrap.dedent(f"""
         The following local cache directory was automatically created by west:
         - Local Cache:  {foo_hash}

--- a/uv.lock
+++ b/uv.lock
@@ -126,7 +126,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -541,28 +541,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.14.9"
+version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f6/1b/ab712a9d5044435be8e9a2beb17cbfa4c241aa9b5e4413febac2a8b79ef2/ruff-0.14.9.tar.gz", hash = "sha256:35f85b25dd586381c0cc053f48826109384c81c00ad7ef1bd977bfcc28119d5b", size = 5809165, upload-time = "2025-12-11T21:39:47.381Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/94/1e5e4967626faf12fa56999cd6222dff6992ceb086ad7945756baf70c7a7/ruff-0.16.0.tar.gz", hash = "sha256:e460aafd5495ec89efaa6ced2e4a9a581116451e1c88b9d37ef497e0f8e93982", size = 4790557, upload-time = "2026-07-23T19:11:30.981Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b8/1c/d1b1bba22cffec02351c78ab9ed4f7d7391876e12720298448b29b7229c1/ruff-0.14.9-py3-none-linux_armv6l.whl", hash = "sha256:f1ec5de1ce150ca6e43691f4a9ef5c04574ad9ca35c8b3b0e18877314aba7e75", size = 13576541, upload-time = "2025-12-11T21:39:14.806Z" },
-    { url = "https://files.pythonhosted.org/packages/94/ab/ffe580e6ea1fca67f6337b0af59fc7e683344a43642d2d55d251ff83ceae/ruff-0.14.9-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ed9d7417a299fc6030b4f26333bf1117ed82a61ea91238558c0268c14e00d0c2", size = 13779363, upload-time = "2025-12-11T21:39:20.29Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/f8/2be49047f929d6965401855461e697ab185e1a6a683d914c5c19c7962d9e/ruff-0.14.9-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d5dc3473c3f0e4a1008d0ef1d75cee24a48e254c8bed3a7afdd2b4392657ed2c", size = 12925292, upload-time = "2025-12-11T21:39:38.757Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/e9/08840ff5127916bb989c86f18924fd568938b06f58b60e206176f327c0fe/ruff-0.14.9-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:84bf7c698fc8f3cb8278830fb6b5a47f9bcc1ed8cb4f689b9dd02698fa840697", size = 13362894, upload-time = "2025-12-11T21:39:02.524Z" },
-    { url = "https://files.pythonhosted.org/packages/31/1c/5b4e8e7750613ef43390bb58658eaf1d862c0cc3352d139cd718a2cea164/ruff-0.14.9-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:aa733093d1f9d88a5d98988d8834ef5d6f9828d03743bf5e338bf980a19fce27", size = 13311482, upload-time = "2025-12-11T21:39:17.51Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/3a/459dce7a8cb35ba1ea3e9c88f19077667a7977234f3b5ab197fad240b404/ruff-0.14.9-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6a1cfb04eda979b20c8c19550c8b5f498df64ff8da151283311ce3199e8b3648", size = 14016100, upload-time = "2025-12-11T21:39:41.948Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/31/f064f4ec32524f9956a0890fc6a944e5cf06c63c554e39957d208c0ffc45/ruff-0.14.9-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:1e5cb521e5ccf0008bd74d5595a4580313844a42b9103b7388eca5a12c970743", size = 15477729, upload-time = "2025-12-11T21:39:23.279Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/6d/f364252aad36ccd443494bc5f02e41bf677f964b58902a17c0b16c53d890/ruff-0.14.9-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cd429a8926be6bba4befa8cdcf3f4dd2591c413ea5066b1e99155ed245ae42bb", size = 15122386, upload-time = "2025-12-11T21:39:33.125Z" },
-    { url = "https://files.pythonhosted.org/packages/20/02/e848787912d16209aba2799a4d5a1775660b6a3d0ab3944a4ccc13e64a02/ruff-0.14.9-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ab208c1b7a492e37caeaf290b1378148f75e13c2225af5d44628b95fd7834273", size = 14497124, upload-time = "2025-12-11T21:38:59.33Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/51/0489a6a5595b7760b5dbac0dd82852b510326e7d88d51dbffcd2e07e3ff3/ruff-0.14.9-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:72034534e5b11e8a593f517b2f2f2b273eb68a30978c6a2d40473ad0aaa4cb4a", size = 14195343, upload-time = "2025-12-11T21:39:44.866Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/53/3bb8d2fa73e4c2f80acc65213ee0830fa0c49c6479313f7a68a00f39e208/ruff-0.14.9-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:712ff04f44663f1b90a1195f51525836e3413c8a773574a7b7775554269c30ed", size = 14346425, upload-time = "2025-12-11T21:39:05.927Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/04/bdb1d0ab876372da3e983896481760867fc84f969c5c09d428e8f01b557f/ruff-0.14.9-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a111fee1db6f1d5d5810245295527cda1d367c5aa8f42e0fca9a78ede9b4498b", size = 13258768, upload-time = "2025-12-11T21:39:08.691Z" },
-    { url = "https://files.pythonhosted.org/packages/40/d9/8bf8e1e41a311afd2abc8ad12be1b6c6c8b925506d9069b67bb5e9a04af3/ruff-0.14.9-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:8769efc71558fecc25eb295ddec7d1030d41a51e9dcf127cbd63ec517f22d567", size = 13326939, upload-time = "2025-12-11T21:39:53.842Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/56/a213fa9edb6dd849f1cfbc236206ead10913693c72a67fb7ddc1833bf95d/ruff-0.14.9-py3-none-musllinux_1_2_i686.whl", hash = "sha256:347e3bf16197e8a2de17940cd75fd6491e25c0aa7edf7d61aa03f146a1aa885a", size = 13578888, upload-time = "2025-12-11T21:39:35.988Z" },
-    { url = "https://files.pythonhosted.org/packages/33/09/6a4a67ffa4abae6bf44c972a4521337ffce9cbc7808faadede754ef7a79c/ruff-0.14.9-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:7715d14e5bccf5b660f54516558aa94781d3eb0838f8e706fb60e3ff6eff03a8", size = 14314473, upload-time = "2025-12-11T21:39:50.78Z" },
-    { url = "https://files.pythonhosted.org/packages/12/0d/15cc82da5d83f27a3c6b04f3a232d61bc8c50d38a6cd8da79228e5f8b8d6/ruff-0.14.9-py3-none-win32.whl", hash = "sha256:df0937f30aaabe83da172adaf8937003ff28172f59ca9f17883b4213783df197", size = 13202651, upload-time = "2025-12-11T21:39:26.628Z" },
-    { url = "https://files.pythonhosted.org/packages/32/f7/c78b060388eefe0304d9d42e68fab8cffd049128ec466456cef9b8d4f06f/ruff-0.14.9-py3-none-win_amd64.whl", hash = "sha256:c0b53a10e61df15a42ed711ec0bda0c582039cf6c754c49c020084c55b5b0bc2", size = 14702079, upload-time = "2025-12-11T21:39:11.954Z" },
-    { url = "https://files.pythonhosted.org/packages/26/09/7a9520315decd2334afa65ed258fed438f070e31f05a2e43dd480a5e5911/ruff-0.14.9-py3-none-win_arm64.whl", hash = "sha256:8e821c366517a074046d92f0e9213ed1c13dbc5b37a7fc20b07f79b64d62cc84", size = 13744730, upload-time = "2025-12-11T21:39:29.659Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/81/1c8818fee7ce1a04cd7d1b3172e0a8f8e4f1dc4feb7fc390e16daa8af323/ruff-0.16.0-py3-none-linux_armv6l.whl", hash = "sha256:e5115729eb08c585e5121978ba5d5b60caeae394ce21b9fb5e6cd33a1c6c9b1e", size = 10754633, upload-time = "2026-07-23T19:10:46.415Z" },
+    { url = "https://files.pythonhosted.org/packages/23/df/beaf59c09d68db84304d555f188b276a77132a5d5b0b67a5c762aa143628/ruff-0.16.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3c954b1d580bfa035b41654f7858cc7e71d5fc3ac5b723dd62bd9133830ed522", size = 10969164, upload-time = "2026-07-23T19:10:50.271Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ce/741cd197496a1abbf51352710fd15ed995d2a2be87189c1da26a450d6e83/ruff-0.16.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e01c21d10eb1b29f47b7454e1f4056db9a3f0260c646aa88457c610291db9f81", size = 10488846, upload-time = "2026-07-23T19:10:52.639Z" },
+    { url = "https://files.pythonhosted.org/packages/52/2a/a2db8e88cade358f5cdcb05674a917751074109315d014eb6352d9a893f7/ruff-0.16.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e364e5ed22ed8dc05082fd78e35308618260907ac2d3c1d637b2e682415b6c9", size = 10889729, upload-time = "2026-07-23T19:10:54.89Z" },
+    { url = "https://files.pythonhosted.org/packages/42/65/62a771694ebd63029dc953e27dbad40e1588bd4860ff9fe881018fddaa49/ruff-0.16.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d327b8fc113a1d4421a04f3839d3752057c8dd1ee320223a6f3f52d04ada462a", size = 10568275, upload-time = "2026-07-23T19:10:56.993Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e2/ced249fe8af5f086c5c58cc21cc3356d50f32f7401c5df87050c999620a7/ruff-0.16.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a9b50c55e263103586b3dcf5f73d479eb8cb5fdb6098fec59a62891dab653717", size = 11385112, upload-time = "2026-07-23T19:10:59.615Z" },
+    { url = "https://files.pythonhosted.org/packages/87/0b/05154977a8fd69eeb6c103271f55403bfd8711f5c0f8ed07489d95a504e7/ruff-0.16.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0ff4a79ce3ec0172f3241943835de1c4cb4e2dcd07f0f8c2d02603dbbbee4b17", size = 12207008, upload-time = "2026-07-23T19:11:02.154Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/29/98225831a3a1eab0e02f4acc6ca6559a98611dcc68b6965ff4b7234627c1/ruff-0.16.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e95c448fca1fb2a18372a9440926c5a6ee789639bb975c72e7ae6d0b04218ab4", size = 11650842, upload-time = "2026-07-23T19:11:04.557Z" },
+    { url = "https://files.pythonhosted.org/packages/91/66/6bd3cf90500653d55dc0ffc8507aa8300bd49d0214b2e8cb4d3fef2943ba/ruff-0.16.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f11a8d11010301d0a398a2fdef67691feca7294da6aef55e2150e8fa2cd520b", size = 11400718, upload-time = "2026-07-23T19:11:09.233Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a2/a54eb4eae05d66364050a5d3b8a9c5ef88196531b3cbe7109d873f87f819/ruff-0.16.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:48044c678e9cb8698246c99b14aaccfa6601dea7379eb48a6f8f73f7a6d86cd0", size = 11426177, upload-time = "2026-07-23T19:11:11.994Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/be/16e3eea4b2a478a496919f5e36f17c4559e54620bd3bbac5d6affa068006/ruff-0.16.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7aa0959bad8eb8bef50340154fc9b58678dae31fa4293afa38b44b6e552c0213", size = 10856126, upload-time = "2026-07-23T19:11:14.221Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/252eb8b868a16eec7257c14f504f77537e734b2d69c762e639e588e304a3/ruff-0.16.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:28ea2b7df8ebf7f9da6b7d47b230ab48f387c0a29be3b474c4d0740e197bb9af", size = 10571208, upload-time = "2026-07-23T19:11:16.378Z" },
+    { url = "https://files.pythonhosted.org/packages/21/09/817a482f542f7570cbb4554b26e896610c7114f539b1d9e2d2145bf6bef6/ruff-0.16.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:33a3dfac8c35f81498dea9181bccc2f4c4bc8f1521a1dd9406e77643e0f0fb09", size = 11063329, upload-time = "2026-07-23T19:11:19.173Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/23/9403c180ca1cb9b1f7335f5c3e5305c09d49ea5b345196682a36028bde4a/ruff-0.16.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a5237a0bda500d30d81b8e07a6973a5cbc772864cbf746ae2f4e8a2e01c9f4ed", size = 11489751, upload-time = "2026-07-23T19:11:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/1d/1b2ef7bcde851c78d7f17f1cca13fd6dc695fc4b3d6197941e72cae5b132/ruff-0.16.0-py3-none-win32.whl", hash = "sha256:7fab76fa065c873f41ff744347c6e77bcc3dfec4bcc754dc26b63d23c0f7f5fb", size = 10785885, upload-time = "2026-07-23T19:11:23.947Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a3/d5e4ef7a56be3f928ffb90b94c25ba7d3cb9c7fe0736aeaaedf361770712/ruff-0.16.0-py3-none-win_amd64.whl", hash = "sha256:429c117f022bf481fabd9d551e7a3952b24c65e6ef44337ea09d90bebef14472", size = 11923141, upload-time = "2026-07-23T19:11:26.409Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/9a/8415f2657cbe200f41a4531ccededf135505a92d4a012229121f885b26f9/ruff-0.16.0-py3-none-win_arm64.whl", hash = "sha256:14296fedcd2705c77ab8235439278bbb38f285cf7da5528b00b3e330c3d4872d", size = 11273407, upload-time = "2026-07-23T19:11:28.705Z" },
 ]
 
 [[package]]
@@ -693,10 +692,10 @@ dev = [
     { name = "pytest", specifier = ">=8.4,<10.0" },
     { name = "pytest-cov", specifier = "~=7.0" },
     { name = "pytest-xdist", specifier = ">=3" },
-    { name = "ruff", specifier = "~=0.13" },
+    { name = "ruff", specifier = "~=0.16" },
     { name = "types-pyyaml", specifier = "~=6.0" },
 ]
-lint = [{ name = "ruff", specifier = "~=0.13" }]
+lint = [{ name = "ruff", specifier = "~=0.16" }]
 test = [
     { name = "coverage", specifier = "~=7.10" },
     { name = "pytest", specifier = ">=8.4,<10.0" },


### PR DESCRIPTION
Ruff 0.16 broadens the default rule set that extend-select builds on, fix issues before the actual bump.
See individual commits for details.

Preview mode was only enabled to get GitHub annotation output from the formatter, which is stable as of Ruff 0.16. Drop it and reformat the files that relied on the preview-only hug-parens style.

Sadly this does format some (mostly test) files, if not desired, the preview mode could be kept.