### PR TITLE
ci: fix and harden the Linux distro test workflow

### DIFF
--- a/.github/workflows/test-distros.yml
+++ b/.github/workflows/test-distros.yml
@@ -53,7 +53,7 @@ jobs:
           - "debian:stable"
           - "debian:testing"
           - "fedora:latest"
-          - "fedora:rawhide"
+          # - "fedora:rawhide"
           - "opensuse/tumbleweed:latest"
           - "ubuntu:devel"
     steps:

--- a/.github/workflows/test-distros.yml
+++ b/.github/workflows/test-distros.yml
@@ -79,14 +79,14 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Display Python version
-        run: python3 -c "import sys; print(sys.version); print(sys.platform)"
-
       - name: Install uv
         run: pip3 install uv --break-system-packages
 
       - name: Install Python dependencies
         run: uv sync --frozen
 
+      - name: Display Python version
+        run: uv run --frozen python -c "import sys; print(sys.version); print(sys.platform)"
+
       - name: Run tasks
-        run: uv run poe all
+        run: uv run --frozen poe all

--- a/.github/workflows/test-distros.yml
+++ b/.github/workflows/test-distros.yml
@@ -17,8 +17,8 @@ on:
 # 1. Start a docker container with (read-only) access to the source files
 # $ docker run -it -v $(pwd):/west:ro <container>
 #
-# 2. Install, depending on the OS, git, python-pip and curl, for example in Arch linux:
-# $ pacman -Syu --noconfirm git python-pip curl
+# 2. Install, depending on the OS, git, python and curl, for example in Arch linux:
+# $ pacman -Syu --noconfirm git python curl
 #
 # 3. Clone the repository to a temporary directory
 # $ git config --global --add safe.directory /west
@@ -65,20 +65,20 @@ jobs:
     steps:
       - if: ${{ startsWith(matrix.container, 'archlinux') }}
         run: |
-          pacman -Syu --noconfirm git python-pip curl
+          pacman -Syu --noconfirm git python curl
 
       - if: ${{ startsWith(matrix.container, 'debian') || startsWith(matrix.container, 'ubuntu') }}
         run: |
           apt-get update
-          apt-get install -y git python3-pip python3-venv curl
+          apt-get install -y git python3 curl
 
       - if: ${{ startsWith(matrix.container, 'fedora') }}
         run: |
-          dnf install -y git python3-pip curl
+          dnf install -y git python3 curl
 
       - if: ${{ startsWith(matrix.container, 'opensuse') }}
         run: |
-          zypper -n install git python3-pip python3-sqlite3 curl
+          zypper -n install git python3 python3-sqlite3 curl
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/test-distros.yml
+++ b/.github/workflows/test-distros.yml
@@ -13,22 +13,24 @@ on:
 
 # Running this workflow locally can be done using docker, with the following commands in
 # your local clone of the west repository:
-
+#
 # 1. Start a docker container with (read-only) access to the source files
 # $ docker run -it -v $(pwd):/west:ro <container>
 #
-# 2. Install, depending on the OS, git and python-pip, for example in Arch linux:
-# $ pacman -Syu --noconfirm git python-pip
+# 2. Install, depending on the OS, git, python-pip and curl, for example in Arch linux:
+# $ pacman -Syu --noconfirm git python-pip curl
 #
 # 3. Clone the repository to a temporary directory
 # $ git config --global --add safe.directory /west
-# $ git clone -q /west /west-tmp
+# $ git clone -q /west /west-tmp && cd /west-tmp
 #
-# 4. Install tox
-# $ pip3 install tox --break-system-packages
+# 4. Install uv (see https://docs.astral.sh/uv/getting-started/installation/)
+# $ curl -LsSf https://astral.sh/uv/install.sh | sh
 #
-# 5. Run tox
-# $ tox -c /west-tmp -- -W error
+# 5. Sync and run the checks against the distro's own Python
+# $ export UV_NO_MANAGED_PYTHON=1 UV_PYTHON_DOWNLOADS=never
+# $ uv sync --frozen
+# $ uv run --frozen poe all
 
 permissions:
   contents: read
@@ -45,6 +47,10 @@ jobs:
       # to use the system Python and never fetch a managed one.
       UV_NO_MANAGED_PYTHON: "1"
       UV_PYTHON_DOWNLOADS: "never"
+      # Install uv into a directory already on PATH so later steps find it without
+      # $GITHUB_PATH, which some distro container images do not extend correctly.
+      UV_INSTALL_DIR: /usr/local/bin
+      UV_NO_MODIFY_PATH: "1"
     strategy:
       fail-fast: false
       matrix:
@@ -59,20 +65,20 @@ jobs:
     steps:
       - if: ${{ startsWith(matrix.container, 'archlinux') }}
         run: |
-          pacman -Syu --noconfirm git python-pip
+          pacman -Syu --noconfirm git python-pip curl
 
       - if: ${{ startsWith(matrix.container, 'debian') || startsWith(matrix.container, 'ubuntu') }}
         run: |
           apt-get update
-          apt-get install -y git python3-pip python3-venv
+          apt-get install -y git python3-pip python3-venv curl
 
       - if: ${{ startsWith(matrix.container, 'fedora') }}
         run: |
-          dnf install -y git python3-pip
+          dnf install -y git python3-pip curl
 
       - if: ${{ startsWith(matrix.container, 'opensuse') }}
         run: |
-          zypper -n install git python3-pip python3-sqlite3
+          zypper -n install git python3-pip python3-sqlite3 curl
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -80,7 +86,7 @@ jobs:
           persist-credentials: false
 
       - name: Install uv
-        run: pip3 install uv --break-system-packages
+        run: curl -LsSf https://astral.sh/uv/install.sh | sh
 
       - name: Install Python dependencies
         run: uv sync --frozen

--- a/.github/workflows/test-distros.yml
+++ b/.github/workflows/test-distros.yml
@@ -38,6 +38,13 @@ jobs:
     name: Run Python Tests on Linux distros
     runs-on: ubuntu-latest
     container: ${{ matrix.container }}
+    env:
+      # The point of this workflow is to test west against each distro's *own*
+      # Python and packaging. By default uv prefers (and will download) its own
+      # managed Python, which silently bypasses the distro interpreter. Force uv
+      # to use the system Python and never fetch a managed one.
+      UV_NO_MANAGED_PYTHON: "1"
+      UV_PYTHON_DOWNLOADS: "never"
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Fixes the `fedora:rawhide` failure in the distro test workflow and corrects a deeper issue: the workflow was not actually testing each distro's Python.

- Use each distro's own Python. `uv` defaults to python-preference=managed and silently downloads its own standalone CPython, bypassing the distro interpreter on every matrix entry. Set `UV_NO_MANAGED_PYTHON` and `UV_PYTHON_DOWNLOADS=never` so uv uses the system Python — what this workflow is meant to test.
- Disable `fedora:rawhide`. It ships a prerelease Python (3.15) that west doesn't support and that lacks dev-dependency wheels; on the distro's own interpreter it only exercises an unsupported config. `fedora:latest` keeps Fedora covered on a released Python.
- Coherent run steps. Report the interpreter `uv` actually resolves (via `uv run`, after sync) instead of the bare `python3`, and pass `--frozen` to the `poe run` for parity with `uv sync` and the main test workflow.
- Refresh local-run docs. Replace the stale `tox` instructions with the current `uv + poe` commands.