### PR TITLE
project: Add support for .westenv file (#967)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ htmlcov/
 .dir-locals.el
 .venv/
 junit.xml
+.idea/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "packaging~=25.0",
     "pykwalify~=1.8",
     "pyyaml~=6.0",
+    "python-dotenv~=1.2.2",
 ]
 license = "Apache-2.0"
 license-files = ["LICENSE"]

--- a/src/west/util.py
+++ b/src/west/util.py
@@ -9,6 +9,9 @@ import shlex
 import textwrap
 from collections.abc import Iterable
 from pathlib import Path
+from typing import Optional
+
+import dotenv
 
 # What west's APIs accept for paths.
 #
@@ -66,6 +69,26 @@ def west_dir(start: PathType | None = None) -> str:
     return os.path.join(west_topdir(start), WEST_DIR)
 
 
+class WestEnvFileError(RuntimeError):
+    '''And error with the .westenv file.'''
+
+
+def _parse_westenv_file(file_path: Path) -> Optional[str]:
+    '''
+    Parses the .westenv file to extract the ZEPHYR_BASE variable.
+    Also ensures that no invalid entries exist in that file.
+
+    Returns the ZEPHYR_BASE value of the file, if it exists.
+    Raises WestEnvFileError when the file is invalid
+    '''
+    file_data = dotenv.dotenv_values(file_path)
+    unknown_keys = set(file_data.keys()).difference({'ZEPHYR_BASE'})
+    if unknown_keys:
+        raise WestEnvFileError(f'.westenv file contains invalid keys: {", ".join(unknown_keys)}')
+
+    return file_data.get('ZEPHYR_BASE')
+
+
 def west_topdir(start: PathType | None = None, fall_back: bool = True) -> str:
     '''
     Like west_dir(), but returns the path to the parent directory of the .west/
@@ -76,6 +99,16 @@ def west_topdir(start: PathType | None = None, fall_back: bool = True) -> str:
     while True:
         if (cur_dir / WEST_DIR).is_dir():
             return os.fspath(cur_dir)
+
+        if fall_back and (files := list(cur_dir.glob('.westenv'))):
+            zephyr_base_path = _parse_westenv_file(files[0])
+            if zephyr_base_path:
+                zephyr_base_path = Path(zephyr_base_path)
+
+                if not zephyr_base_path.is_absolute():
+                    zephyr_base_path = Path(cur_dir / zephyr_base_path).resolve()
+
+                return west_topdir(str(zephyr_base_path), fall_back=False)
 
         parent_dir = cur_dir.parent
         if cur_dir == parent_dir:

--- a/tests/test_workspace_resolution.py
+++ b/tests/test_workspace_resolution.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2026, Draeger Safety AG & Co. KGaA
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+from pathlib import Path
+
+import pytest
+
+from conftest import tmp_west_topdir, update_env
+from west.util import WestEnvFileError, WestNotFound, west_topdir
+
+
+def test_absolute_zephyr_base(tmp_path):
+    # A .westenv file with an absolute ZEPHYR_BASE path resolves the workspace.
+    workspace = tmp_path / 'workspace'
+    project = tmp_path / 'project'
+    project.mkdir()
+
+    with tmp_west_topdir(workspace):
+        (project / '.westenv').write_text(f'ZEPHYR_BASE={workspace}\n')
+        result = west_topdir(str(project))
+
+    assert Path(result).resolve() == workspace.resolve()
+
+
+def test_relative_zephyr_base(tmp_path):
+    # A .westenv file with a relative ZEPHYR_BASE is resolved against the file's directory.
+    workspace = tmp_path / 'workspace'
+    project = tmp_path / 'project'
+    project.mkdir()
+
+    with tmp_west_topdir(workspace):
+        rel = os.path.relpath(workspace, project)
+        (project / '.westenv').write_text(f'ZEPHYR_BASE={rel}\n')
+        result = west_topdir(str(project))
+
+    assert Path(result).resolve() == workspace.resolve()
+
+
+def test_no_zephyr_base_key_falls_through_to_parent(tmp_path):
+    # A .westenv with no ZEPHYR_BASE key is ignored; the search continues up the tree.
+    subdir = tmp_path / 'subdir'
+    subdir.mkdir()
+    (subdir / '.westenv').write_text('# no ZEPHYR_BASE\n')
+
+    with tmp_west_topdir(tmp_path):
+        result = west_topdir(str(subdir))
+
+    assert Path(result).resolve() == tmp_path.resolve()
+
+
+def test_invalid_key_raises_westenv_error(tmp_path):
+    # A .westenv file containing an unrecognized key raises WestEnvFileError.
+    project = tmp_path / 'project'
+    project.mkdir()
+    (project / '.westenv').write_text('UNKNOWN_KEY=value\n')
+
+    with pytest.raises(WestEnvFileError):
+        west_topdir(str(project))
+
+
+def test_zephyr_base_env_fallback(tmp_path):
+    # When no .west directory is found anywhere, and no .westenv file exists, the ZEPHYR_BASE env var is tried
+    # as a fallback.
+    workspace = tmp_path / 'workspace'
+    project = tmp_path / 'project'
+    project.mkdir()
+
+    with tmp_west_topdir(workspace), update_env({'ZEPHYR_BASE': str(workspace)}):
+        result = west_topdir(str(project))
+
+    assert Path(result).resolve() == workspace.resolve()
+
+
+def test_no_workspace_raises_west_not_found(tmp_path):
+    # With no .west, no .westenv, and no ZEPHYR_BASE env, WestNotFound is raised.
+    project = tmp_path / 'project'
+    project.mkdir()
+
+    with update_env({'ZEPHYR_BASE': None}):
+        with pytest.raises(WestNotFound):
+            west_topdir(str(project))

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 
 [[package]]
@@ -410,6 +410,15 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -649,6 +658,7 @@ dependencies = [
     { name = "colorama" },
     { name = "packaging" },
     { name = "pykwalify" },
+    { name = "python-dotenv" },
     { name = "pyyaml" },
 ]
 
@@ -682,6 +692,7 @@ requires-dist = [
     { name = "colorama", specifier = "~=0.4" },
     { name = "packaging", specifier = "~=25.0" },
     { name = "pykwalify", specifier = "~=1.8" },
+    { name = "python-dotenv", specifier = "~=1.2.2" },
     { name = "pyyaml", specifier = "~=6.0" },
 ]
 


### PR DESCRIPTION
This commit adds support for a .westenv file to configure the zephyr workspace. Fixes ticket #967.