### PR TITLE
main: remove special handling of ZEPHYR_BASE

### DIFF
--- a/src/west/app/main.py
+++ b/src/west/app/main.py
@@ -24,7 +24,7 @@ import textwrap
 import traceback
 from collections import OrderedDict
 from io import StringIO
-from pathlib import Path, PurePath
+from pathlib import Path
 from subprocess import CalledProcessError
 from typing import NamedTuple
 
@@ -260,8 +260,6 @@ class WestApp:
         colorama.init()
 
         # See if we're in a workspace. It's fine if we're not.
-        # Note that this falls back on searching from ZEPHYR_BASE
-        # if the current directory isn't inside a west workspace.
         try:
             self.topdir = west_topdir()
         except WestNotFound:
@@ -547,9 +545,9 @@ class WestApp:
             '-z',
             '--zephyr-base',
             default=None,
-            help='''Override the Zephyr base directory. The
-                    default is the manifest project with path
-                    "zephyr".''',
+            help='''Deprecated and ignored. West no longer manages the
+                    Zephyr base directory; this option has no effect and
+                    will be removed in a future release.''',
         )
 
         parser.add_argument(
@@ -779,135 +777,7 @@ class WestApp:
         for io_hook in self.queued_io:
             self.cmd.add_pre_run_hook(io_hook)
 
-        # HACK: try to set ZEPHYR_BASE.
-        #
-        # Currently required by zephyr extensions like "west build".
-        #
-        # TODO: get rid of this. Instead:
-        #
-        # - support a WEST_DIR environment variable to specify the
-        #   workspace if we're not running under a .west directory
-        #   (controversial)
-        # - make zephyr extensions that need ZEPHYR_BASE just set it
-        #   themselves (easy if above is OK, unnecessary if it isn't)
-        self.set_zephyr_base(args)
-
         self.cmd.run(args, unknown, self.topdir, manifest=self.manifest, config=self.config)
-
-    def set_zephyr_base(self, args):
-        '''Ensure ZEPHYR_BASE is set
-        Order of precedence:
-        1) Value given as command line argument
-        2) Value from environment setting: ZEPHYR_BASE
-        3) Value of zephyr.base setting in west config file
-        4) Project in the manifest with name, or path, "zephyr" (will
-           be persisted as zephyr.base in the local config if found)
-
-        Order of precedence between 2) and 3) can be changed with the setting
-        zephyr.base-prefer.
-        zephyr.base-prefer takes the values 'env' and 'configfile'
-
-        If 2) and 3) have different values and zephyr.base-prefer is unset,
-        a warning is printed.'''
-        manifest = self.manifest
-        topdir = self.topdir
-        config = self.config
-
-        if args.zephyr_base:
-            # The command line --zephyr-base takes precedence over
-            # everything else.
-            zb = os.path.abspath(args.zephyr_base)
-            zb_origin = 'command line'
-        else:
-            # If the user doesn't specify it concretely, then use ZEPHYR_BASE
-            # from the environment or zephyr.base from west.configuration.
-            #
-            # (We will configure zephyr.base to the project that has path
-            # 'zephyr' as a last resort here.)
-            #
-            # At some point, we need a more flexible way to set environment
-            # variables based on manifest contents, but this is good enough
-            # to get started with and to ask for wider testing.
-            zb_env = os.environ.get('ZEPHYR_BASE')
-            zb_prefer = config.get('zephyr.base-prefer')
-            rel_zb_config = config.get('zephyr.base')
-            if rel_zb_config is None:
-                # Try to find a project named 'zephyr', or with path
-                # 'zephyr' inside the workspace.
-                projects = None
-                try:
-                    projects = manifest.get_projects(['zephyr'], allow_paths=False)
-                except ValueError:
-                    try:
-                        projects = manifest.get_projects([Path(topdir) / 'zephyr'])
-                    except ValueError:
-                        pass
-                if projects:
-                    zephyr = projects[0]
-                    config.set('zephyr.base', zephyr.path)
-                    rel_zb_config = zephyr.path
-            if rel_zb_config is not None:
-                zb_config = Path(topdir) / rel_zb_config
-            else:
-                zb_config = None
-
-            if zb_prefer == 'env' and zb_env is not None:
-                zb = zb_env
-                zb_origin = 'env'
-            elif zb_prefer == 'configfile' and zb_config is not None:
-                zb = str(zb_config)
-                zb_origin = 'configfile'
-            elif zb_env is not None:
-                zb = zb_env
-                zb_origin = 'env'
-                try:
-                    different = zb_config and not zb_config.samefile(zb_env)
-                except FileNotFoundError:
-                    different = zb_config and (PurePath(zb_config)) != PurePath(zb_env)
-                if different:
-                    # The environment ZEPHYR_BASE takes precedence
-                    # over the config setting, but is different than
-                    # the zephyr.base config value.
-                    #
-                    # Therefore, issue a warning as the user might have
-                    # run zephyr-env.sh/cmd in some other zephyr
-                    # workspace and forgotten about it.
-                    self.queued_io.append(
-                        lambda cmd: cmd.wrn(
-                            f'ZEPHYR_BASE={zb_env} '
-                            f'in the calling environment will be used,\n'
-                            f'but the zephyr.base config option in {topdir} '
-                            f'is "{rel_zb_config}"\n'
-                            'which implies a different '
-                            f'ZEPHYR_BASE={zb_config}\n'
-                            f'To disable this warning in the future, execute '
-                            f"'west config --global zephyr.base-prefer env'"
-                        )
-                    )
-            elif zb_config:
-                zb = str(zb_config)
-                zb_origin = 'configfile'
-            else:
-                zb = None
-                zb_origin = None
-                # No --zephyr-base, no ZEPHYR_BASE, and no zephyr.base.
-                self.queued_io.append(
-                    lambda cmd: cmd.wrn(
-                        "can't find the zephyr repository\n"
-                        '  - no --zephyr-base given\n'
-                        '  - ZEPHYR_BASE is unset\n'
-                        '  - west config contains no zephyr.base setting\n'
-                        '  - no manifest project has name or path "zephyr"\n'
-                        '\n'
-                        "  If this isn't a Zephyr workspace, you can "
-                        "  silence this warning with something like this:\n"
-                        '    west config zephyr.base not-using-zephyr'
-                    )
-                )
-
-        if zb is not None:
-            os.environ['ZEPHYR_BASE'] = zb
-            self.queued_io.append(lambda cmd: cmd.dbg(f'ZEPHYR_BASE={zb} (origin: {zb_origin})'))
 
 
 class Help(WestCommand):

--- a/src/west/app/project.py
+++ b/src/west/app/project.py
@@ -443,22 +443,12 @@ below.
 
     def do_run(self, args, _):
         if self.topdir:
-            zb = os.environ.get('ZEPHYR_BASE')
-            if zb:
-                msg = textwrap.dedent(f'''
-                Note:
-                    In your environment, ZEPHYR_BASE is set to:
-                    {zb}
-
-                    This forces west to search for a workspace there.
-                    Try unsetting ZEPHYR_BASE and re-running this command.''')
-            else:
-                west_dir = Path(self.topdir) / WEST_DIR
-                msg = (
-                    "\n  Hint: if you do not want a workspace there, \n"
-                    "  remove this directory and re-run this command:\n\n"
-                    f"  {west_dir}"
-                )
+            west_dir = Path(self.topdir) / WEST_DIR
+            msg = (
+                "\n  Hint: if you do not want a workspace there, \n"
+                "  remove this directory and re-run this command:\n\n"
+                f"  {west_dir}"
+            )
 
             self.die_already(self.topdir, msg)
 
@@ -513,7 +503,7 @@ below.
         # manifest path.
         for check in (topdir, abs_manifest_path):
             try:
-                already = util.west_topdir(check, fall_back=False)
+                already = util.west_topdir(check)
                 self.die_already(already)
             except util.WestNotFound:
                 pass
@@ -576,7 +566,7 @@ below.
         west_dir = topdir / WEST_DIR
 
         try:
-            already = util.west_topdir(topdir, fall_back=False)
+            already = util.west_topdir(topdir)
             self.die_already(already)
         except util.WestNotFound:
             pass
@@ -666,7 +656,7 @@ below.
         # level somewhere between the new topdir and the new manifest_path. This check will be
         # especially useful once the new --topdir feature is available, see
         # https://github.com/zephyrproject-rtos/west/issues/774
-        already = util.west_topdir(manifest_abspath, fall_back=False)
+        already = util.west_topdir(manifest_abspath)
         if not topdir.samefile(already):
             self.die_already(already)
 

--- a/src/west/commands.py
+++ b/src/west/commands.py
@@ -78,7 +78,6 @@ def _no_topdir_msg(cwd, name):
 no west workspace found from "{cwd}"; "west {name}" requires one.
 Things to try:
   - Change directory to somewhere inside a west workspace and retry.
-  - Set ZEPHYR_BASE to a zephyr repository path in a west workspace.
   - Run "west init" to set up a workspace here.
   - Run "west init -h" for additional information.
 '''

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -557,7 +557,7 @@ def manifest_path() -> str:
         - ``FileNotFoundError`` if no manifest file exists as determined by
           ``manifest.path`` and ``manifest.file``
     '''
-    topdir = Path(util.west_topdir(start=Path.cwd(), fall_back=True))
+    topdir = Path(util.west_topdir(start=Path.cwd()))
     config = Configuration(topdir=topdir)
     manifest_path = config.get('manifest.path', configfile=ConfigFile.LOCAL)
     if manifest_path is None:
@@ -1313,7 +1313,7 @@ class Manifest:
         :param import_flags: passed to Manifest()
         '''
         if topdir is None:
-            topdir = Path(util.west_topdir(start=Path.cwd(), fall_back=False)).resolve()
+            topdir = Path(util.west_topdir(start=Path.cwd())).resolve()
         return Manifest(topdir=topdir, config=config, importer=importer, import_flags=import_flags)
 
     @staticmethod
@@ -1355,14 +1355,12 @@ class Manifest:
         '''
         if source_file is None:
             start = Path.cwd()
-            fall_back = True
         else:
             source_file = Path(source_file).resolve()
             start = source_file.parent
-            fall_back = False
 
         # Find the workspace topdir.
-        topdir = Path(util.west_topdir(start=start, fall_back=fall_back)).resolve()
+        topdir = Path(util.west_topdir(start=start)).resolve()
 
         # Load a Configuration.
         if source_file is None:

--- a/src/west/util.py
+++ b/src/west/util.py
@@ -70,6 +70,10 @@ def west_topdir(start: PathType | None = None, fall_back: bool = True) -> str:
     '''
     Like west_dir(), but returns the path to the parent directory of the .west/
     directory instead, where project repositories are stored
+
+    The *fall_back* argument is deprecated and ignored. It used to enable a
+    fall back to the ZEPHYR_BASE environment variable, which relied on Zephyr
+    internals and is no longer supported.
     '''
     cur_dir = Path(start or os.getcwd())
 
@@ -79,13 +83,8 @@ def west_topdir(start: PathType | None = None, fall_back: bool = True) -> str:
 
         parent_dir = cur_dir.parent
         if cur_dir == parent_dir:
-            # At the root. Should we fall back?
-            if fall_back and os.environ.get('ZEPHYR_BASE'):
-                return west_topdir(os.environ['ZEPHYR_BASE'], fall_back=False)
-            else:
-                raise WestNotFound(
-                    'Could not find a west workspace in this or any parent directory'
-                )
+            # At the root.
+            raise WestNotFound('Could not find a west workspace in this or any parent directory')
         cur_dir = parent_dir
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -186,9 +186,8 @@ def setup_teardown_test_environment(tmpdir_factory):
     used nor touched during test, as WEST_CONFIG_* env variables are set,
     whereby no config files are created at these locations.
 
-    The fixture sets ZEPHYR_BASE (to avoid complaints in subcommand stderr),
-    but to a spurious location (so that attempts to read from inside of it are
-    caught here).
+    The fixture unsets ZEPHYR_BASE so that a value present in the developer's
+    environment does not leak into tests.
 
     The fixture also ensures that any environment modifications made by a test
     do not leak into subsequent tests, as the environment is restored when the
@@ -209,7 +208,7 @@ def setup_teardown_test_environment(tmpdir_factory):
                 'WEST_CONFIG_SYSTEM': str(system),
                 'WEST_CONFIG_GLOBAL': str(glbl),
                 'WEST_CONFIG_LOCAL': None,
-                'ZEPHYR_BASE': str(tmpdir / 'no-zephyr-here'),
+                'ZEPHYR_BASE': None,
             }
         ),
     ):

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -33,7 +33,6 @@ from conftest import (
     create_repo,
     create_workspace,
     rev_parse,
-    update_env,
 )
 
 from west.configuration import ConfigFile, Configuration, MalformedConfig
@@ -165,19 +164,6 @@ def test_manifest_from_data_without_topdir():
     )
     assert manifest.projects[-1].name == 'foo'
     assert manifest.projects[-1].abspath is None
-
-
-def test_manifest_from_file_with_fall_back(manifest_repo):
-    with open(manifest_repo / 'west.yml', 'w') as f:
-        f.write('''
-        manifest:
-          projects: []
-        ''')
-    repo_abspath = Path(str(manifest_repo))
-    os.chdir(repo_abspath.parent.parent)  # this is the tmp_workspace dir
-    with update_env({'ZEPHYR_BASE': os.fspath(manifest_repo)}):
-        manifest = MF()
-    assert Path(manifest.repo_abspath) == repo_abspath
 
 
 def test_validate():


### PR DESCRIPTION
West is a general-purpose tool and should not rely on Zephyr internals. Drop the `ZEPHYR_BASE` special handling:

- west no longer sets the `ZEPHYR_BASE` environment variable, and the `zephyr.base` / `zephyr.base`-prefer config options are no longer used.
- `west_topdir()` no longer falls back to searching from `ZEPHYR_BASE`.

The public `west_topdir()` `fall_back` argument and the `-z/--zephyr-base` command line option are kept as ignored no-ops for backwards compatibility.