### PR TITLE
ci: Skip DCO check for dependabot pull requests

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -13,8 +13,9 @@ concurrency:
 
 jobs:
   commit-check:
-    name: Check commits
+    name: Check DCO sign-off
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
Bots can't sign off with a DCO.