### PR TITLE
alias: support early args in alias expansion

### DIFF
--- a/src/west/app/main.py
+++ b/src/west/app/main.py
@@ -619,7 +619,10 @@ class WestApp:
                     if arg == early_args.command_name:
                         argv = argv[:i] + alias.args + argv[i + 1 :]
                         break
-                early_args = early_args._replace(command_name=alias.args[0])
+                # Re-parse the expanded argv so early args coming from the
+                # alias itself (e.g. "-v") are handled instead of being
+                # mistaken for the command name.
+                early_args = parse_early_args(argv)
 
         self.handle_early_arg_errors(early_args)
         args, unknown = self.west_parser.parse_known_args(args=argv)

--- a/src/west/app/main.py
+++ b/src/west/app/main.py
@@ -89,9 +89,9 @@ class EarlyArgs(NamedTuple):
     # - setting up log levels from the verbosity level
 
     # Expected arguments:
-    help: bool  # True if -h was given
-    version: bool  # True if -V was given
-    zephyr_base: str | None  # -z argument value
+    help: bool  # True if -h/--help was given
+    version: bool  # True if -V/--version was given
+    zephyr_base: str | None  # -z/--zephyr-base argument value
     verbosity: int  # 0 if not given, otherwise counts
     command_name: str | None
 
@@ -142,28 +142,37 @@ def parse_early_args(argv: list[str]) -> EarlyArgs:
         else:
             unexpected_arguments.append(rest)
 
+    # Keep the long options in sync with make_parsers(). Abbreviations
+    # are not handled on purpose: the top level parser is created with
+    # allow_abbrev=False, so it doesn't accept them either.
     for arg in argv:
         if expecting_zephyr_base:
             zephyr_base = arg
             expecting_zephyr_base = False
+        elif arg == '--help':
+            help = True
+        elif arg == '--version':
+            version = True
+        elif arg == '--verbose':
+            verbosity += 1
+        elif arg == '--quiet':
+            verbosity -= 1
+        elif arg == '--zephyr-base':
+            expecting_zephyr_base = True
+        elif arg.startswith('--zephyr-base='):
+            zephyr_base = arg[len('--zephyr-base=') :]
         elif arg.startswith('-h'):
             help = True
             consume_more_args(arg[2:])
         elif arg.startswith('-V'):
             version = True
             consume_more_args(arg[2:])
-        elif arg == '--version':
-            version = True
         elif arg.startswith('-v'):
             verbosity += 1
             consume_more_args(arg[2:])
         elif arg.startswith('-q'):
             verbosity -= 1
             consume_more_args(arg[2:])
-        elif arg == '--verbose':
-            verbosity += 1
-        elif arg == '--quiet':
-            verbosity -= 1
         elif arg.startswith('-z'):
             if arg == '-z':
                 expecting_zephyr_base = True

--- a/src/west/app/main.py
+++ b/src/west/app/main.py
@@ -637,6 +637,10 @@ class WestApp:
             # mistaken for the command name.
             early_args = parse_early_args(argv)
 
+            # The alias may have changed the verbosity; west's own log
+            # level was set up from the pre-expansion arguments.
+            self.set_west_log_level(early_args.verbosity)
+
         self.handle_early_arg_errors(early_args)
         args, unknown = self.west_parser.parse_known_args(args=argv)
 
@@ -752,6 +756,10 @@ class WestApp:
         sys.exit(message)
 
     def setup_west_logging(self, verbosity):
+        self.set_west_log_level(verbosity)
+        logging.getLogger('west.manifest').addHandler(LogHandler())
+
+    def set_west_log_level(self, verbosity):
         logger = logging.getLogger('west.manifest')
 
         if verbosity >= 2:
@@ -764,8 +772,6 @@ class WestApp:
             logger.setLevel(logging.ERROR)
         else:
             logger.setLevel(logging.CRITICAL)
-
-        logger.addHandler(LogHandler())
 
     def run_builtin(self, args, unknown):
         self.queued_io.append(

--- a/src/west/app/main.py
+++ b/src/west/app/main.py
@@ -145,6 +145,7 @@ def parse_early_args(argv: list[str]) -> EarlyArgs:
     for arg in argv:
         if expecting_zephyr_base:
             zephyr_base = arg
+            expecting_zephyr_base = False
         elif arg.startswith('-h'):
             help = True
             consume_more_args(arg[2:])

--- a/src/west/app/main.py
+++ b/src/west/app/main.py
@@ -602,32 +602,40 @@ class WestApp:
         # If we're running an extension, instantiate it from its
         # spec and re-parse arguments before running.
 
-        if not early_args.help and early_args.command_name != "help":
-            # Recursively replace alias command(s) if set
-            aliases = self.aliases.copy()
-            while early_args.command_name in aliases:
-                # Make sure we don't end up in an infinite loop
-                alias = aliases.pop(early_args.command_name)
+        # Recursively replace alias command(s) if set.
+        #
+        # The loop conditions are re-evaluated on every iteration on
+        # purpose: an alias can expand to early args of its own, and
+        # those must be treated like the ones the user typed. In
+        # particular "-h" stops the expansion, so that help is printed
+        # for the alias instead of for whatever it expands to.
+        aliases = self.aliases.copy()
+        while (
+            not early_args.help
+            and early_args.command_name != "help"
+            and early_args.command_name in aliases
+        ):
+            # Make sure we don't end up in an infinite loop
+            alias = aliases.pop(early_args.command_name)
 
-                self.queued_io.append(
-                    lambda cmd, alias=alias: cmd.dbg(
-                        f'Replacing alias {alias.name} with {alias.args}'
-                    )
-                )
+            self.queued_io.append(
+                lambda cmd, alias=alias: cmd.dbg(f'Replacing alias {alias.name} with {alias.args}')
+            )
 
-                if len(alias.args) == 0:
-                    # This loses the cmd.dbg() above - too bad, don't use empty aliases
-                    self.print_usage_and_exit(f'west: empty alias "{alias.name}"')
+            if len(alias.args) == 0:
+                # This loses the cmd.dbg() above - too bad, don't use empty aliases
+                self.print_usage_and_exit(f'west: empty alias "{alias.name}"')
 
-                # Replace the command name with the alias arguments. Early
-                # args before it and user arguments after it are preserved.
-                i = early_args.command_index
-                assert i is not None  # implied by command_name being set
-                argv = argv[:i] + alias.args + argv[i + 1 :]
-                # Re-parse the expanded argv so early args coming from the
-                # alias itself (e.g. "-v") are handled instead of being
-                # mistaken for the command name.
-                early_args = parse_early_args(argv)
+            # Replace the command name with the alias arguments. Early
+            # args before it and user arguments after it are preserved.
+            i = early_args.command_index
+            assert i is not None  # implied by command_name being set
+            argv = argv[:i] + alias.args + argv[i + 1 :]
+
+            # Re-parse the expanded argv so early args coming from the
+            # alias itself (e.g. "-v") are handled instead of being
+            # mistaken for the command name.
+            early_args = parse_early_args(argv)
 
         self.handle_early_arg_errors(early_args)
         args, unknown = self.west_parser.parse_known_args(args=argv)

--- a/src/west/app/main.py
+++ b/src/west/app/main.py
@@ -94,6 +94,7 @@ class EarlyArgs(NamedTuple):
     zephyr_base: str | None  # -z/--zephyr-base argument value
     verbosity: int  # 0 if not given, otherwise counts
     command_name: str | None
+    command_index: int | None  # index of command_name in argv
 
     # Other arguments are appended here.
     unexpected_arguments: list[str]
@@ -107,6 +108,7 @@ def parse_early_args(argv: list[str]) -> EarlyArgs:
     zephyr_base = None
     verbosity = 0
     command_name = None
+    command_index = None
     unexpected_arguments = []
 
     expecting_zephyr_base = False
@@ -145,7 +147,7 @@ def parse_early_args(argv: list[str]) -> EarlyArgs:
     # Keep the long options in sync with make_parsers(). Abbreviations
     # are not handled on purpose: the top level parser is created with
     # allow_abbrev=False, so it doesn't accept them either.
-    for arg in argv:
+    for i, arg in enumerate(argv):
         if expecting_zephyr_base:
             zephyr_base = arg
             expecting_zephyr_base = False
@@ -184,9 +186,12 @@ def parse_early_args(argv: list[str]) -> EarlyArgs:
             unexpected_arguments.append(arg)
         else:
             command_name = arg
+            command_index = i
             break
 
-    return EarlyArgs(help, version, zephyr_base, verbosity, command_name, unexpected_arguments)
+    return EarlyArgs(
+        help, version, zephyr_base, verbosity, command_name, command_index, unexpected_arguments
+    )
 
 
 class LogFormatter(logging.Formatter):
@@ -614,11 +619,11 @@ class WestApp:
                     # This loses the cmd.dbg() above - too bad, don't use empty aliases
                     self.print_usage_and_exit(f'west: empty alias "{alias.name}"')
 
-                # Find and replace the command name. Must skip any other early args like -v
-                for i, arg in enumerate(argv):
-                    if arg == early_args.command_name:
-                        argv = argv[:i] + alias.args + argv[i + 1 :]
-                        break
+                # Replace the command name with the alias arguments. Early
+                # args before it and user arguments after it are preserved.
+                i = early_args.command_index
+                assert i is not None  # implied by command_name being set
+                argv = argv[:i] + alias.args + argv[i + 1 :]
                 # Re-parse the expanded argv so early args coming from the
                 # alias itself (e.g. "-v") are handled instead of being
                 # mistaken for the command name.

--- a/tests/test_alias.py
+++ b/tests/test_alias.py
@@ -86,6 +86,14 @@ def test_alias_early_args_with_values():
     assert cmd(['--zephyr-base=/some/path', 'test1']) == topdir_out
 
 
+def test_alias_name_matching_early_arg_value():
+    # Only the command name is replaced by the alias expansion, even if
+    # an earlier early arg happens to have the same value.
+    cmd('config alias.test1 topdir')
+
+    assert cmd(['-z', 'test1', 'test1']) == cmd('topdir')
+
+
 def test_alias_expands_to_early_arg():
     # An alias whose expansion starts with an early/global option (e.g. -v)
     # should apply that option to west itself instead of mistaking it for the

--- a/tests/test_alias.py
+++ b/tests/test_alias.py
@@ -160,6 +160,19 @@ def test_alias_expands_to_help():
     assert cmd('test1') == cmd('help topdir')
 
 
+def test_alias_expands_to_help_stops_expansion():
+    # Once help is requested, the expansion must stop: help is about the
+    # alias, not about what it would have expanded to. This matches
+    # "west -h <alias>".
+    cmd(['config', '--', 'alias.test1', '-h test2'])
+    cmd('config alias.test2 topdir')
+
+    output = cmd('test1')
+
+    assert "An alias that expands to: topdir" in output
+    assert output == cmd('help test2')
+
+
 def test_alias_command_with_arguments():
     list_format = '{revision} TESTALIAS {name}'
     cmd(['config', 'alias.revs', f'list -f "{list_format}"'])

--- a/tests/test_alias.py
+++ b/tests/test_alias.py
@@ -86,6 +86,72 @@ def test_alias_early_args_with_values():
     assert cmd(['--zephyr-base=/some/path', 'test1']) == topdir_out
 
 
+def test_alias_expands_to_early_arg():
+    # An alias whose expansion starts with an early/global option (e.g. -v)
+    # should apply that option to west itself instead of mistaking it for the
+    # command name.
+    cmd(['config', 'alias.test1', '-v topdir'])
+
+    output = cmd('test1')
+
+    # The '-v' from the alias enables debug output, proving it was handled as
+    # an early arg (this line is not printed without increased verbosity).
+    assert "Replacing alias test1 with ['-v', 'topdir']" in output
+    # ... and the actual command still runs.
+    assert cmd('topdir').strip() in output
+
+
+def test_alias_expands_to_early_arg_recursive():
+    # An early arg introduced by an alias must survive further alias
+    # expansion, i.e. the expanded argv is re-parsed on every iteration.
+    cmd(['config', 'alias.test1', '-v test2'])
+    cmd(['config', 'alias.test2', 'topdir'])
+
+    output = cmd('test1')
+
+    assert "Replacing alias test1 with ['-v', 'test2']" in output
+    assert "Replacing alias test2 with ['topdir']" in output
+    assert cmd('topdir').strip() in output
+
+
+def test_alias_early_arg_with_trailing_args():
+    # User arguments given after the alias are preserved and appended after
+    # the alias expansion (which itself starts with an early arg).
+    cmd(['config', 'alias.test1', '-v list'])
+
+    output = cmd(['test1', '-f', '{name}'])
+
+    assert "Replacing alias test1 with ['-v', 'list']" in output
+    assert cmd(['list', '-f', '{name}']).strip() in output
+
+
+def test_alias_expands_to_early_arg_with_value():
+    # Early args from an alias that take a value work too, and don't
+    # stop the expansion from finding the command name.
+    cmd(['config', 'alias.test1', '-z /some/path topdir'])
+    cmd(['config', 'alias.test2', '--zephyr-base /some/path topdir'])
+
+    topdir_out = cmd('topdir')
+
+    assert cmd('test1') == topdir_out
+    assert cmd('test2') == topdir_out
+
+
+def test_alias_expands_to_version():
+    # "-V" from an alias prints west's version instead of being
+    # mistaken for a command name.
+    cmd(['config', '--', 'alias.test1', '-V'])
+
+    assert 'West version:' in cmd('test1')
+
+
+def test_alias_expands_to_help():
+    # "-h" from an alias asks for help, just like a "-h" typed by the user.
+    cmd(['config', '--', 'alias.test1', '-h topdir'])
+
+    assert cmd('test1') == cmd('help topdir')
+
+
 def test_alias_command_with_arguments():
     list_format = '{revision} TESTALIAS {name}'
     cmd(['config', 'alias.revs', f'list -f "{list_format}"'])

--- a/tests/test_alias.py
+++ b/tests/test_alias.py
@@ -33,6 +33,8 @@ def test_alias_help():
 
     assert "An alias that expands to: topdir" in help_out
     assert cmd('-h test') == help_out
+    # The long option must behave like the short one.
+    assert cmd('--help test') == help_out
 
 
 def test_alias_recursive_commands():
@@ -67,6 +69,7 @@ def test_alias_early_args():
 
     # An alias with an early command argument shouldn't fail
     assert "Replacing alias test1 with ['topdir']" in cmd('-v test1')
+    assert "Replacing alias test1 with ['topdir']" in cmd('--verbose test1')
 
 
 def test_alias_early_args_with_values():
@@ -79,6 +82,8 @@ def test_alias_early_args_with_values():
     assert cmd(['-z', '/some/path', 'test1']) == topdir_out
     assert cmd(['-z/some/path', 'test1']) == topdir_out
     assert cmd(['-z=/some/path', 'test1']) == topdir_out
+    assert cmd(['--zephyr-base', '/some/path', 'test1']) == topdir_out
+    assert cmd(['--zephyr-base=/some/path', 'test1']) == topdir_out
 
 
 def test_alias_command_with_arguments():

--- a/tests/test_alias.py
+++ b/tests/test_alias.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import logging
+
 import pytest
 from conftest import cmd, cmd_raises
 
@@ -171,6 +173,22 @@ def test_alias_expands_to_help_stops_expansion():
 
     assert "An alias that expands to: topdir" in output
     assert output == cmd('help test2')
+
+
+def test_alias_expands_to_verbosity_sets_west_log_level():
+    # Verbosity coming from an alias must set up west's own logging,
+    # like verbosity typed by the user does.
+    cmd(['config', 'alias.test1', '-vv topdir'])
+
+    logger = logging.getLogger('west.manifest')
+    original_level = logger.level
+    try:
+        logger.setLevel(logging.WARNING)
+        cmd('test1')
+
+        assert logger.level == logging.DEBUG
+    finally:
+        logger.setLevel(original_level)
 
 
 def test_alias_command_with_arguments():

--- a/tests/test_alias.py
+++ b/tests/test_alias.py
@@ -69,6 +69,18 @@ def test_alias_early_args():
     assert "Replacing alias test1 with ['topdir']" in cmd('-v test1')
 
 
+def test_alias_early_args_with_values():
+    # Early args taking a value must not swallow the alias name, in any
+    # of the forms the top level parser accepts.
+    cmd('config alias.test1 topdir')
+
+    topdir_out = cmd('topdir')
+
+    assert cmd(['-z', '/some/path', 'test1']) == topdir_out
+    assert cmd(['-z/some/path', 'test1']) == topdir_out
+    assert cmd(['-z=/some/path', 'test1']) == topdir_out
+
+
 def test_alias_command_with_arguments():
     list_format = '{revision} TESTALIAS {name}'
     cmd(['config', 'alias.revs', f'list -f "{list_format}"'])

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -6,6 +6,7 @@ import pytest
 from conftest import cmd, cmd_subprocess
 
 import west.version
+from west.app.main import parse_early_args
 
 
 def test_main():
@@ -48,3 +49,47 @@ def test_module_run(tmp_path, monkeypatch):
     # check that that the sys.path was correctly inserted
     expected_path = Path(__file__).parents[1] / 'src'
     assert actual_path == [f'{expected_path}', 'initial-path']
+
+
+# What parse_early_args() returns when given no arguments at all.
+EARLY_ARGS_DEFAULTS = {
+    'help': False,
+    'version': False,
+    'zephyr_base': None,
+    'verbosity': 0,
+    'command_name': None,
+    'unexpected_arguments': [],
+}
+
+
+@pytest.mark.parametrize(
+    ('argv', 'expected'),
+    [
+        ([], {}),
+        (['topdir'], {'command_name': 'topdir'}),
+        (['-h'], {'help': True}),
+        (['-h', 'topdir'], {'help': True, 'command_name': 'topdir'}),
+        (['-V'], {'version': True}),
+        (['--version'], {'version': True}),
+        (['-v', 'topdir'], {'verbosity': 1, 'command_name': 'topdir'}),
+        (['--verbose', 'topdir'], {'verbosity': 1, 'command_name': 'topdir'}),
+        (['-q', 'topdir'], {'verbosity': -1, 'command_name': 'topdir'}),
+        (['--quiet', 'topdir'], {'verbosity': -1, 'command_name': 'topdir'}),
+        (['-vvv', 'topdir'], {'verbosity': 3, 'command_name': 'topdir'}),
+        # An option taking a value must not swallow the command name.
+        (['-z', '/p', 'topdir'], {'zephyr_base': '/p', 'command_name': 'topdir'}),
+        (['-z/p', 'topdir'], {'zephyr_base': '/p', 'command_name': 'topdir'}),
+        (['-z=/p', 'topdir'], {'zephyr_base': '/p', 'command_name': 'topdir'}),
+        (['-vz', '/p', 'topdir'], {'verbosity': 1, 'zephyr_base': '/p', 'command_name': 'topdir'}),
+        (['-hV', 'topdir'], {'help': True, 'version': True, 'command_name': 'topdir'}),
+        # Everything after the command name belongs to the command.
+        (['topdir', '-h', '-z', '/p'], {'command_name': 'topdir'}),
+        # Unknown options are collected, not treated as the command name.
+        (['--nope', 'topdir'], {'command_name': 'topdir', 'unexpected_arguments': ['--nope']}),
+    ],
+)
+def test_parse_early_args(argv, expected):
+    # parse_early_args() must agree with the top level argument parser
+    # about which arguments are west's own and where the command name
+    # is. Alias expansion depends on both.
+    assert parse_early_args(argv)._asdict() == EARLY_ARGS_DEFAULTS | expected

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -58,6 +58,7 @@ EARLY_ARGS_DEFAULTS = {
     'zephyr_base': None,
     'verbosity': 0,
     'command_name': None,
+    'command_index': None,
     'unexpected_arguments': [],
 }
 
@@ -66,30 +67,48 @@ EARLY_ARGS_DEFAULTS = {
     ('argv', 'expected'),
     [
         ([], {}),
-        (['topdir'], {'command_name': 'topdir'}),
+        (['topdir'], {'command_name': 'topdir', 'command_index': 0}),
         (['-h'], {'help': True}),
         (['--help'], {'help': True}),
-        (['-h', 'topdir'], {'help': True, 'command_name': 'topdir'}),
-        (['--help', 'topdir'], {'help': True, 'command_name': 'topdir'}),
+        (['-h', 'topdir'], {'help': True, 'command_name': 'topdir', 'command_index': 1}),
+        (['--help', 'topdir'], {'help': True, 'command_name': 'topdir', 'command_index': 1}),
         (['-V'], {'version': True}),
         (['--version'], {'version': True}),
-        (['-v', 'topdir'], {'verbosity': 1, 'command_name': 'topdir'}),
-        (['--verbose', 'topdir'], {'verbosity': 1, 'command_name': 'topdir'}),
-        (['-q', 'topdir'], {'verbosity': -1, 'command_name': 'topdir'}),
-        (['--quiet', 'topdir'], {'verbosity': -1, 'command_name': 'topdir'}),
-        (['-vvv', 'topdir'], {'verbosity': 3, 'command_name': 'topdir'}),
+        (['-v', 'topdir'], {'verbosity': 1, 'command_name': 'topdir', 'command_index': 1}),
+        (['--verbose', 'topdir'], {'verbosity': 1, 'command_name': 'topdir', 'command_index': 1}),
+        (['-q', 'topdir'], {'verbosity': -1, 'command_name': 'topdir', 'command_index': 1}),
+        (['--quiet', 'topdir'], {'verbosity': -1, 'command_name': 'topdir', 'command_index': 1}),
+        (['-vvv', 'topdir'], {'verbosity': 3, 'command_name': 'topdir', 'command_index': 1}),
         # An option taking a value must not swallow the command name.
-        (['-z', '/p', 'topdir'], {'zephyr_base': '/p', 'command_name': 'topdir'}),
-        (['-z/p', 'topdir'], {'zephyr_base': '/p', 'command_name': 'topdir'}),
-        (['-z=/p', 'topdir'], {'zephyr_base': '/p', 'command_name': 'topdir'}),
-        (['--zephyr-base', '/p', 'topdir'], {'zephyr_base': '/p', 'command_name': 'topdir'}),
-        (['--zephyr-base=/p', 'topdir'], {'zephyr_base': '/p', 'command_name': 'topdir'}),
-        (['-vz', '/p', 'topdir'], {'verbosity': 1, 'zephyr_base': '/p', 'command_name': 'topdir'}),
-        (['-hV', 'topdir'], {'help': True, 'version': True, 'command_name': 'topdir'}),
+        (
+            ['-z', '/p', 'topdir'],
+            {'zephyr_base': '/p', 'command_name': 'topdir', 'command_index': 2},
+        ),
+        (['-z/p', 'topdir'], {'zephyr_base': '/p', 'command_name': 'topdir', 'command_index': 1}),
+        (['-z=/p', 'topdir'], {'zephyr_base': '/p', 'command_name': 'topdir', 'command_index': 1}),
+        (
+            ['--zephyr-base', '/p', 'topdir'],
+            {'zephyr_base': '/p', 'command_name': 'topdir', 'command_index': 2},
+        ),
+        (
+            ['--zephyr-base=/p', 'topdir'],
+            {'zephyr_base': '/p', 'command_name': 'topdir', 'command_index': 1},
+        ),
+        (
+            ['-vz', '/p', 'topdir'],
+            {'verbosity': 1, 'zephyr_base': '/p', 'command_name': 'topdir', 'command_index': 2},
+        ),
+        (
+            ['-hV', 'topdir'],
+            {'help': True, 'version': True, 'command_name': 'topdir', 'command_index': 1},
+        ),
         # Everything after the command name belongs to the command.
-        (['topdir', '-h', '-z', '/p'], {'command_name': 'topdir'}),
+        (['topdir', '-h', '-z', '/p'], {'command_name': 'topdir', 'command_index': 0}),
         # Unknown options are collected, not treated as the command name.
-        (['--nope', 'topdir'], {'command_name': 'topdir', 'unexpected_arguments': ['--nope']}),
+        (
+            ['--nope', 'topdir'],
+            {'command_name': 'topdir', 'command_index': 1, 'unexpected_arguments': ['--nope']},
+        ),
     ],
 )
 def test_parse_early_args(argv, expected):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -68,7 +68,9 @@ EARLY_ARGS_DEFAULTS = {
         ([], {}),
         (['topdir'], {'command_name': 'topdir'}),
         (['-h'], {'help': True}),
+        (['--help'], {'help': True}),
         (['-h', 'topdir'], {'help': True, 'command_name': 'topdir'}),
+        (['--help', 'topdir'], {'help': True, 'command_name': 'topdir'}),
         (['-V'], {'version': True}),
         (['--version'], {'version': True}),
         (['-v', 'topdir'], {'verbosity': 1, 'command_name': 'topdir'}),
@@ -80,6 +82,8 @@ EARLY_ARGS_DEFAULTS = {
         (['-z', '/p', 'topdir'], {'zephyr_base': '/p', 'command_name': 'topdir'}),
         (['-z/p', 'topdir'], {'zephyr_base': '/p', 'command_name': 'topdir'}),
         (['-z=/p', 'topdir'], {'zephyr_base': '/p', 'command_name': 'topdir'}),
+        (['--zephyr-base', '/p', 'topdir'], {'zephyr_base': '/p', 'command_name': 'topdir'}),
+        (['--zephyr-base=/p', 'topdir'], {'zephyr_base': '/p', 'command_name': 'topdir'}),
         (['-vz', '/p', 'topdir'], {'verbosity': 1, 'zephyr_base': '/p', 'command_name': 'topdir'}),
         (['-hV', 'topdir'], {'help': True, 'version': True, 'command_name': 'topdir'}),
         # Everything after the command name belongs to the command.


### PR DESCRIPTION
An alias whose expansion starts with an early/global option (e.g. `-v`) previously failed: alias expansion assigned `alias.args[0]` as the command name without re-parsing early args, so the option was treated as an unknown command.

- Fix parsing of the `-z` early argument
The early parser never cleared the "expecting a value" flag, so `-z <path>` swallowed the rest of argv and no command name was found; `west -z /p <alias>` crashed with a KeyError.
- Handle long early arguments
`--help` and `--zephyr-base[=…]` are accepted by the top-level parser but were unknown to the early parser, so `west --zephyr-base /p <cmd>` errored on the path and `west --help <alias>` expanded the alias instead of describing it.
- Support early args in alias expansion
 Re-parse the expanded argv on each iteration, so early args coming from an alias (`-v`, `-h`, `-z`, `-V`, …) are handled instead of being taken as the command name.
- Replace the command name by position
The expansion looked the command name up in argv by value, which could splice over an earlier option value, e.g. `west -z <alias> <alias>`.
- Stop expanding aliases when help is requested
The check was done once before the loop, so an alias expanding to `-h` kept expanding and help described the final command instead of the alias.
- Apply verbosity from an alias to west logging
West's own log level is set up before the command line is fully known, so an alias's `-v` only reached the command, not the west API loggers.

See commits for more details.