### PR TITLE
app: suggest closest match for unknown commands

### DIFF
--- a/src/west/app/main.py
+++ b/src/west/app/main.py
@@ -12,6 +12,7 @@ Nothing in here is public API.
 '''
 
 import argparse
+import difflib
 import logging
 import os
 import platform
@@ -719,7 +720,35 @@ class WestApp:
             )
         else:
             extra_help = 'do you need to run this inside a workspace?'
-        self.print_usage_and_exit(f'west: unknown command "{command_name}"; {extra_help}')
+
+        suggestion = self.suggest_command(command_name)
+        suggestion_msg = f' Did you mean "{suggestion}"?' if suggestion else ''
+        self.print_usage_and_exit(
+            f'west: unknown command "{command_name}"; {extra_help}{suggestion_msg}'
+        )
+
+    def suggest_command(self, command_name):
+        candidates = set(self.builtins)
+        if self.extensions:
+            candidates.update(self.extensions)
+        if self.aliases:
+            candidates.update(self.aliases)
+        if not candidates:
+            return None
+
+        lower_to_name = {}
+        for name in candidates:
+            lower_to_name.setdefault(name.lower(), name)
+
+        lowered = command_name.lower()
+        if lowered in lower_to_name and command_name not in candidates:
+            return lower_to_name[lowered]
+
+        matches = difflib.get_close_matches(lowered, lower_to_name.keys(), n=1, cutoff=0.6)
+        if matches:
+            return lower_to_name[matches[0]]
+
+        return None
 
     def print_usage_and_exit(self, message):
         self.west_parser.print_usage(file=sys.stderr)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,7 +3,7 @@ import sys
 from pathlib import Path
 
 import pytest
-from conftest import cmd, cmd_subprocess
+from conftest import cmd, cmd_raises, cmd_subprocess
 
 import west.version
 
@@ -48,3 +48,10 @@ def test_module_run(tmp_path, monkeypatch):
     # check that that the sys.path was correctly inserted
     expected_path = Path(__file__).parents[1] / 'src'
     assert actual_path == [f'{expected_path}', 'initial-path']
+
+
+def test_unknown_command_suggests_closest_match():
+    exc_info, _ = cmd_raises('updat', SystemExit)
+
+    assert 'unknown command "updat"' in str(exc_info.value)
+    assert 'Did you mean "update"?' in str(exc_info.value)


### PR DESCRIPTION
Add a helpful suggestion when a user enters an unknown command by matching against built-ins, extensions, and aliases.

Example:
  west updat
  west: unknown command "updat"; do you need to run this inside a workspace? Did you mean "update"?