### PR TITLE
project: fix TypeError in 'update --stats --keep-descendants'

### DIFF
--- a/src/west/app/project.py
+++ b/src/west/app/project.py
@@ -1841,7 +1841,7 @@ class Update(_ProjectCommand):
                 start = perf_counter()
             project.git('status')
             if take_stats:
-                stats['get current status'] = perf_counter - start
+                stats['get current status'] = perf_counter() - start
         elif try_rebase:
             # Attempt a rebase.
             self.inf(f'west update: rebasing to {MANIFEST_REV} {sha}')

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -976,6 +976,18 @@ def test_update_projects_local_branch_commits(west_init_tmpdir):
     assert kconfiglib_prev == head_subject('subdir/Kconfiglib')
     assert tagged_repo_prev == head_subject('tagged_repo')
 
+    # Provide test coverage for 'update --stats --keep-descendants' with
+    # a local branch that descends from manifest-rev: the update must
+    # leave the branch checked out and gather statistics.
+    checkout_branch('net-tools', 'manifest-rev')
+    checkout_branch('net-tools', 'descendant_branch', create=True)
+    add_commit('net-tools', 'net-tools descendant commit', reconfigure=True)
+
+    out = cmd('update --stats --keep-descendants net-tools')
+    assert 'left descendant branch "descendant_branch" checked out' in out
+    assert 'get current status' in out
+    assert head_subject('net-tools') == 'net-tools descendant commit'
+
 
 def test_update_tag_to_tag(west_init_tmpdir):
     # Verify we can update the tagged_repo repo to a new tag.


### PR DESCRIPTION
The keep-descendants branch of `Update.update()` measures how long the 'git status' invocation takes, but the elapsed time was computed from `perf_counter` without calling it, subtracting a float from the function object. As a result 'west update --stats --keep-descendants' crashed with a `TypeError` whenever a descendant branch was left checked out.
Add the missing call parentheses.