### PR TITLE
project: fix cached update of a project containing nested projects

### DIFF
--- a/src/west/app/project.py
+++ b/src/west/app/project.py
@@ -1981,6 +1981,71 @@ class Update(_ProjectCommand):
             self.dbg(f'{project.name}: update auto-cache ({cache_dir}) with remote')
             project.git(['remote', 'update', '--prune'], cwd=cache_dir, check=False)
 
+    def init_project_in_place(self, project):
+        # init_project() helper. Create the project's repository at
+        # project.abspath and set up the convenience remote, without
+        # fetching anything.
+
+        init_cmd = ['init', project.abspath]
+        # Silence the very verbose and repetitive init.defaultBranch
+        # warning (10 lines per new git clone). The branch
+        # 'placeholder' will never have any commit so it will never
+        # actually exist.
+        if self.git_version_info >= (2, 28, 0):
+            init_cmd.insert(1, '--initial-branch=init_placeholder')
+
+        project.git(init_cmd, cwd=self.topdir)
+
+        # This remote is added as a convenience for the user.
+        # However, west always fetches project data by URL, not name.
+        # The user is therefore free to change the URL of this remote.
+        project.git(['remote', 'add', '--', project.remote_name, project.url])
+
+    def init_project_from_cache(self, project, cache_dir):
+        # Initialize a project in a non-empty directory and seed it from cache.
+        #
+        # The fetch below runs inside the project, so a relative cache path
+        # would resolve against the wrong directory.
+        cache_dir = abspath(cache_dir)
+        refspecs = [f'+refs/heads/*:refs/remotes/{project.remote_name}/*']
+
+        # That refspec only brings the cache's branch tips, but a manifest
+        # usually pins a SHA that is an ancestor of one rather than a tip
+        # itself. Naming the object in the fetch is what brings it along, and
+        # that needs protocol v2: under v0 upload-pack rejects requests for
+        # unadvertised objects and fails the whole fetch. Protocol v2 appeared
+        # in Git 2.18 and is the default since 2.26. Request it explicitly even
+        # on newer Git because configuration can select v0. Older Git seeds
+        # branch tips only, leaving west to fetch the revision from the network
+        # as it would without a cache.
+        config = []
+        if self.git_version_info >= (2, 18, 0):
+            config = ['-c', 'protocol.version=2']
+            if _maybe_sha(project.revision):
+                cp = project.git(
+                    ['rev-parse', '--verify', f'{project.revision}^{{object}}'],
+                    cwd=cache_dir,
+                    check=False,
+                    capture_stdout=True,
+                    capture_stderr=True,
+                )
+                if cp.returncode == 0:
+                    refspecs.append(cp.stdout.decode('ascii').strip())
+
+        git_dir = Path(project.abspath) / '.git'
+        remove_git_dir = not os.path.lexists(git_dir)
+        seeded = False
+        try:
+            self.init_project_in_place(project)
+            project.git([*config, 'fetch', '--tags', '--', cache_dir, *refspecs])
+            seeded = True
+        finally:
+            if remove_git_dir and not seeded and os.path.lexists(git_dir):
+                try:
+                    shutil.rmtree(git_dir)
+                except OSError as e:
+                    self.err(f'failed to remove incomplete repository {git_dir}: {e}')
+
     def init_project(self, project):
         # update() helper. Initialize an uncloned project repository.
         # If there's a local clone available, it uses that. Otherwise,
@@ -1993,21 +2058,10 @@ class Update(_ProjectCommand):
 
         if cache_dir is None:
             self.small_banner(f'{project.name}: initializing')
-
-            init_cmd = ['init', project.abspath]
-            # Silence the very verbose and repetitive init.defaultBranch
-            # warning (10 lines per new git clone). The branch
-            # 'placeholder' will never have any commit so it will never
-            # actually exist.
-            if self.git_version_info >= (2, 28, 0):
-                init_cmd.insert(1, '--initial-branch=init_placeholder')
-
-            project.git(init_cmd, cwd=self.topdir)
-
-            # This remote is added as a convenience for the user.
-            # However, west always fetches project data by URL, not name.
-            # The user is therefore free to change the URL of this remote.
-            project.git(['remote', 'add', '--', project.remote_name, project.url])
+            self.init_project_in_place(project)
+        elif os.path.isdir(project.abspath) and os.listdir(project.abspath):
+            self.small_banner(f'{project.name}: initializing, seeding from {cache_dir}')
+            self.init_project_from_cache(project, cache_dir)
         else:
             self.small_banner(f'{project.name}: cloning from {cache_dir}')
             # Clone the project from a local cache repository. Set the

--- a/tests/test_project_caching.py
+++ b/tests/test_project_caching.py
@@ -6,11 +6,13 @@ import subprocess
 import textwrap
 from pathlib import Path
 
+import pytest
 from conftest import (
     GIT,
     add_commit,
     chdir,
     cmd,
+    cmd_raises,
     create_branch,
     create_repo,
     create_workspace,
@@ -18,6 +20,8 @@ from conftest import (
     rev_list,
     rev_parse,
 )
+
+from west.commands import WestCommand
 
 #
 # Helpers
@@ -49,6 +53,58 @@ def setup_cache_workspace(workspace, foo_remote, foo_head, bar_remote, bar_head)
             url: file://{bar_remote}
             revision: {bar_head}
         ''')
+
+
+def setup_nested_cache_workspace(workspace, outer_remote, outer_head, inner_remote, inner_head):
+    # Shared helper code that sets up a workspace in which one
+    # project's path contains another project's path.
+
+    create_workspace(workspace)
+
+    # The directory tree of the workspace looks like following:
+    # (workspace)
+    # └── outer
+    #     └── nested
+    #         └── inner
+    #
+    # 'inner' is listed first on purpose: 'west update' visits projects
+    # in manifest order, so 'outer' is initialized after its own
+    # directory has already been created for 'inner'.
+
+    manifest_project = workspace / 'mp'
+    with open(manifest_project / 'west.yml', 'w') as f:
+        f.write(f'''
+        manifest:
+          projects:
+          - name: inner
+            path: outer/nested/inner
+            url: file://{inner_remote}
+            revision: {inner_head}
+          - name: outer
+            path: outer
+            url: file://{outer_remote}
+            revision: {outer_head}
+        ''')
+
+
+def setup_nested_path_cache(tmpdir):
+    path_cache_dir = tmpdir / 'path_cache_dir'
+    outer_cache = path_cache_dir / 'outer'
+    inner_cache = outer_cache / 'nested' / 'inner'
+    create_repo(outer_cache)
+    create_repo(inner_cache)
+
+    outer_head = rev_parse(outer_cache, 'HEAD')
+    inner_head = rev_parse(inner_cache, 'HEAD')
+    workspace = tmpdir / 'workspace'
+    setup_nested_cache_workspace(
+        workspace,
+        outer_remote=(Path('non-existent') / 'outer'),
+        outer_head=outer_head,
+        inner_remote=(Path('non-existent') / 'inner'),
+        inner_head=inner_head,
+    )
+    return path_cache_dir, workspace, outer_head, inner_head
 
 
 #
@@ -180,6 +236,174 @@ def test_update_path_cache(tmpdir):
     assert rev_parse(bar, 'HEAD') == bar_head
     assert remote_get_url(foo) == "file://" + os.fspath(Path('non-existent') / 'here')
     assert remote_get_url(bar) == "file://" + os.fspath(Path('non-existent') / 'there')
+
+
+def test_update_cache_nested_projects(tmpdir):
+    # Test that a cached 'west update' can initialize a project whose
+    # path contains another project that was updated first.
+    #
+    # 'git clone' refuses to write into a directory that already exists
+    # and is not empty, so west cannot clone such a project from the
+    # cache. Without a cache the same layout works, because 'git init'
+    # has no such restriction.
+    #
+    # Note: the remote URLs are non-existent, so this can only pass if
+    # every object still comes from the cache.
+
+    # The directory tree of the path cache looks like following:
+    # (path cache)
+    # └── outer
+    #     └── nested
+    #         └── inner
+
+    path_cache_dir, workspace, outer_head, inner_head = setup_nested_path_cache(tmpdir)
+    workspace.chdir()
+    outer = workspace / 'outer'
+    inner = workspace / 'outer' / 'nested' / 'inner'
+
+    # A relative cache path must keep the same meaning when the outer
+    # project's in-place initialization runs Git from inside the project.
+    path_cache_arg = os.path.relpath(path_cache_dir, workspace)
+    cmd(['update', '--path-cache', path_cache_arg])
+
+    assert outer.check(dir=1)
+    assert inner.check(dir=1)
+    assert rev_parse(outer, 'HEAD') == outer_head
+    assert rev_parse(inner, 'HEAD') == inner_head
+    assert remote_get_url(outer) == "file://" + os.fspath(Path('non-existent') / 'outer')
+    assert remote_get_url(inner) == "file://" + os.fspath(Path('non-existent') / 'inner')
+
+
+def test_update_cache_nested_project_sha_from_remote_ref(tmpdir):
+    # A local clone copies non-tip objects reachable only through remote-tracking
+    # refs. In-place cache seeding must make the same objects available.
+    #
+    # Naming such an object in a fetch needs protocol v2, so west only asks
+    # for it from git v2.18 on. Below that the seed copies branch tips only
+    # and the revision comes from the remote instead, which this test's
+    # deliberately non-existent URL cannot serve.
+    git_version = WestCommand._parse_git_version(subprocess.check_output([GIT, '--version']))
+    if git_version is None or git_version < (2, 18, 0):
+        pytest.skip('seeding an unadvertised object requires fetch protocol v2 (git v2.18)')
+
+    outer_remote = tmpdir / 'outer_remote'
+    create_repo(outer_remote)
+    create_branch(outer_remote, 'side', checkout=True)
+    add_commit(outer_remote, 'side commit')
+    outer_head = rev_parse(outer_remote, 'HEAD')
+    add_commit(outer_remote, 'later side commit')
+    subprocess.check_call([GIT, 'checkout', 'master'], cwd=outer_remote)
+
+    path_cache_dir = tmpdir / 'path_cache_dir'
+    outer_cache = path_cache_dir / 'outer'
+    subprocess.check_call([GIT, 'clone', '--', outer_remote, outer_cache])
+    create_repo(outer_cache / 'nested' / 'inner')
+    inner_head = rev_parse(outer_cache / 'nested' / 'inner', 'HEAD')
+
+    workspace = tmpdir / 'workspace'
+    setup_nested_cache_workspace(
+        workspace,
+        outer_remote=(Path('non-existent') / 'outer'),
+        outer_head=outer_head,
+        inner_remote=(Path('non-existent') / 'inner'),
+        inner_head=inner_head,
+    )
+    workspace.chdir()
+
+    env = {
+        'GIT_CONFIG_COUNT': '1',
+        'GIT_CONFIG_KEY_0': 'protocol.version',
+        'GIT_CONFIG_VALUE_0': '0',
+    }
+    cmd(['update', '--path-cache', path_cache_dir], env=env)
+
+    assert rev_parse(workspace / 'outer', 'HEAD') == outer_head
+
+
+def test_update_cache_nested_project_sha_from_remote_if_cache_stale(tmpdir):
+    outer_remote = tmpdir / 'outer_remote'
+    create_repo(outer_remote)
+
+    path_cache_dir = tmpdir / 'path_cache_dir'
+    outer_cache = path_cache_dir / 'outer'
+    subprocess.check_call([GIT, 'clone', '--', outer_remote, outer_cache])
+    add_commit(outer_remote, 'uncached commit')
+    outer_head = rev_parse(outer_remote, 'HEAD')
+
+    create_repo(outer_cache / 'nested' / 'inner')
+    inner_head = rev_parse(outer_cache / 'nested' / 'inner', 'HEAD')
+
+    workspace = tmpdir / 'workspace'
+    setup_nested_cache_workspace(
+        workspace,
+        outer_remote=outer_remote,
+        outer_head=outer_head,
+        inner_remote=(Path('non-existent') / 'inner'),
+        inner_head=inner_head,
+    )
+    workspace.chdir()
+
+    cmd(['update', '--path-cache', path_cache_dir])
+
+    assert rev_parse(workspace / 'outer', 'HEAD') == outer_head
+    assert rev_parse(workspace / 'outer' / 'nested' / 'inner', 'HEAD') == inner_head
+
+
+def test_update_cache_nested_project_retries_failed_seed(tmpdir):
+    path_cache_dir, workspace, outer_head, inner_head = setup_nested_path_cache(tmpdir)
+    outer_cache = path_cache_dir / 'outer'
+    workspace.chdir()
+
+    # Make the outer cache invalid for one update attempt, then restore it.
+    # A retry must seed the newly initialized outer repository again instead
+    # of treating the failed initialization as a complete clone.
+    saved_git_dir = tmpdir / 'outer.git'
+    shutil.move(os.fspath(outer_cache / '.git'), saved_git_dir)
+    cmd_raises(['update', '--path-cache', path_cache_dir], SystemExit)
+    assert rev_parse(workspace / 'outer' / 'nested' / 'inner', 'HEAD') == inner_head
+    assert not (workspace / 'outer' / '.git').exists()
+    shutil.move(saved_git_dir, os.fspath(outer_cache / '.git'))
+
+    cmd(['update', '--path-cache', path_cache_dir])
+
+    assert rev_parse(workspace / 'outer', 'HEAD') == outer_head
+    assert rev_parse(workspace / 'outer' / 'nested' / 'inner', 'HEAD') == inner_head
+
+
+def test_update_cache_nested_project_preserves_preexisting_git_dir(tmpdir):
+    path_cache_dir, workspace, _, _ = setup_nested_path_cache(tmpdir)
+    outer_cache = path_cache_dir / 'outer'
+    outer_git_dir = workspace / 'outer' / '.git'
+    outer_git_dir.ensure(dir=True)
+    sentinel = outer_git_dir / 'keep-me'
+    sentinel.write('user data')
+    workspace.chdir()
+
+    saved_git_dir = tmpdir / 'outer.git'
+    shutil.move(os.fspath(outer_cache / '.git'), saved_git_dir)
+    cmd_raises(['update', '--path-cache', path_cache_dir], SystemExit)
+
+    assert sentinel.read() == 'user data'
+
+
+def test_update_cache_nested_project_reports_failed_cleanup(tmpdir, monkeypatch):
+    path_cache_dir, workspace, _, _ = setup_nested_path_cache(tmpdir)
+    outer_cache = path_cache_dir / 'outer'
+    workspace.chdir()
+
+    # Force cache seeding and its cleanup to fail. The cleanup error must be
+    # reported without replacing the original update failure.
+    shutil.move(os.fspath(outer_cache / '.git'), tmpdir / 'outer.git')
+
+    def fail_cleanup(_):
+        raise OSError('cleanup failed')
+
+    monkeypatch.setattr(shutil, 'rmtree', fail_cleanup)
+    _, stderr = cmd_raises(['update', '--path-cache', path_cache_dir], SystemExit)
+
+    cleanup_error = f'failed to remove incomplete repository {workspace / "outer" / ".git"}'
+    assert f'{cleanup_error}: cleanup failed' in stderr
+    assert 'update failed for project outer' in stderr
 
 
 def test_update_auto_cache(tmpdir):


### PR DESCRIPTION
The manifest format allows one project's path to contain another project's path: _check_paths_are_unique() only rejects projects that share the exact same path. Zephyr's west.yml relies on this today, with bsim at tools/bsim and the babblesim components under tools/bsim/components/.

Without a cache such a layout updates fine, because init_project() runs 'git init', which happily initializes a repository in a directory that already exists and is not empty. With any cache configured the same code path runs 'git clone' instead, and git clone refuses a non-empty destination:

    === updating bsim (tools/bsim):
    --- bsim: cloning from /cache-zephyrproject/tools/bsim
    fatal: destination path '/builds/.../tools/bsim' already exists and
    is not an empty directory.
    ERROR: update failed for project bsim

Whether this triggers depends on the update order. Manifests are updated in order, so it fails whenever a nested project is listed before the project whose path contains it. In Zephyr's alphabetically sorted manifest every babblesim_* component sorts before bsim, so enabling the babblesim group together with any cache fails deterministically.

Keep 'git clone' as the normal path: cloning from a local cache hardlinks objects, which is what makes caching fast. When the destination is not empty, fall back to the 'git init' sequence and seed the new repository from the cache with a fetch, so its objects still come from the cache rather than from the network. With the default smart fetch strategy a SHA revision present in the cache then needs no network access at all, exactly as for a cloned project.

Fixes #934

Assisted-by: Claude:claude-opus-5