### PR TITLE
Support `remapping` of west project url

### DIFF
--- a/src/west/manifest-schema.yml
+++ b/src/west/manifest-schema.yml
@@ -66,6 +66,25 @@ mapping:
             required: true
             type: str
 
+  # allow some remapping of values by downstream projects
+  remapping:
+    required: false
+    type: map
+    mapping:
+      # search-replace within URLs (e.g. to use mirror URLs)
+      url:
+        required: false
+        type: seq
+        sequence:
+          - type: map
+            mapping:
+              old:
+                required: true
+                type: str
+              new:
+                required: true
+                type: str
+
   # The "projects" key specifies a sequence of "projects", each of which has a
   # remote, and may specify additional configuration.
   #

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -7,6 +7,7 @@
 Parser and abstract data types for west manifests.
 '''
 
+import copy
 import enum
 import errno
 import logging
@@ -181,6 +182,34 @@ ManifestDataType = str | dict
 # Logging
 
 _logger = logging.getLogger(__name__)
+
+
+# Representation of remapping
+
+
+class ImportRemapping:
+    """Represents `remapping` within a manifest."""
+
+    def __init__(self, manifest_data: dict | None = None):
+        """Initialize a new ImportRemapping instance."""
+        self.url_replaces: list[tuple[str, str]] = []
+        self.append(manifest_data or {})
+
+    def append(self, manifest_data: dict):
+        """Append values from a manifest data (dictionary) to this instance."""
+        for kind, values in manifest_data.get('remapping', {}).items():
+            if kind == 'url':
+                self.url_replaces += [(v['old'], v['new']) for v in values]
+
+    def merge(self, other):
+        """Merge another ImportRemapping instance into this one."""
+        if not isinstance(other, ImportRemapping):
+            raise TypeError(f"Unsupported type'{type(other).__name__}'")
+        self.url_replaces += other.url_replaces
+
+    def copy(self):
+        """Return a deep copy of this instance."""
+        return copy.deepcopy(self)
 
 
 # Type for the submodule value passed through the manifest file.
@@ -456,6 +485,9 @@ class _import_ctx(NamedTuple):
 
     # Bit vector of flags that modify import behavior.
     import_flags: 'ImportFlag'
+
+    # remapping
+    remapping: ImportRemapping
 
 
 def _imap_filter_allows(imap_filter: ImapFilterFnType, project: 'Project') -> bool:
@@ -2070,6 +2102,7 @@ class Manifest:
             current_repo_abspath=current_repo_abspath,
             project_importer=project_importer,
             import_flags=import_flags,
+            remapping=ImportRemapping(),
         )
 
     def _recursive_init(self, ctx: _import_ctx):
@@ -2091,6 +2124,10 @@ class Manifest:
         _logger.debug('loading %s', loading_what)
 
         manifest_data = self._ctx.current_data['manifest']
+
+        # append values from resolved manifest_data to current context
+        new_remapping = ImportRemapping(manifest_data)
+        self._ctx.remapping.merge(new_remapping)
 
         schema_version = str(manifest_data.get('version', SCHEMA_VERSION))
 
@@ -2340,6 +2377,7 @@ class Manifest:
             current_abspath=pathobj_abs,
             current_relpath=pathobj,
             current_data=pathobj_abs.read_text(encoding=Manifest.encoding),
+            remapping=self._ctx.remapping.copy(),
         )
         try:
             Manifest(topdir=self.topdir, internal_import_ctx=child_ctx)
@@ -2468,6 +2506,13 @@ class Manifest:
             url = url_bases[remote] + '/' + (repo_path or name)
         else:
             self._malformed(f'project {name} has no remote or url and no default remote is set')
+
+        # modify the url
+        if url:
+            url_replaces = self._ctx.remapping.url_replaces
+            for url_replace in reversed(url_replaces):
+                old, new = url_replace
+                url = url.replace(old, new)
 
         # The project's path needs to respect any import: path-prefix,
         # regardless of self._ctx.import_flags. The 'ignore' type flags
@@ -2724,6 +2769,7 @@ class Manifest:
             # We therefore use a separate list for tracking them
             # from our current list.
             manifest_west_commands=[],
+            remapping=self._ctx.remapping.copy(),
         )
         try:
             submanifest = Manifest(topdir=self.topdir, internal_import_ctx=child_ctx)

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -44,6 +44,7 @@ from west.manifest import (
     MANIFEST_PROJECT_INDEX,
     SCHEMA_VERSION,
     ImportFlag,
+    ImportRemapping,
     MalformedManifest,
     Manifest,
     ManifestImportFailed,
@@ -144,6 +145,40 @@ def test_project_init():
     assert p.topdir == TOPDIR
     assert p.abspath == os.path.join(TOPDIR, 'p')
     assert p.posixpath == TOPDIR_POSIX + '/p'
+
+
+def test_import_remapping():
+    # Basic tests of the ImportRemapping helper class used to implement
+    # the 'remapping' manifest section.
+
+    empty = ImportRemapping()
+    assert empty.url_replaces == []
+
+    r1 = ImportRemapping({'remapping': {'url': [{'old': 'foo', 'new': 'bar'}]}})
+    assert r1.url_replaces == [('foo', 'bar')]
+
+    # append() adds to the existing list instead of replacing it.
+    r1.append({'remapping': {'url': [{'old': 'baz', 'new': 'qux'}]}})
+    assert r1.url_replaces == [('foo', 'bar'), ('baz', 'qux')]
+
+    # merge() concatenates another instance's url_replaces onto this one.
+    r2 = ImportRemapping({'remapping': {'url': [{'old': 'a', 'new': 'b'}]}})
+    r1.merge(r2)
+    assert r1.url_replaces == [
+        ('foo', 'bar'),
+        ('baz', 'qux'),
+        ('a', 'b'),
+    ]
+
+    # merge() rejects anything that isn't an ImportRemapping.
+    with pytest.raises(TypeError):
+        r1.merge(object())
+
+    # copy() returns an independent deep copy.
+    r3 = r1.copy()
+    assert r3.url_replaces == r1.url_replaces
+    r3.url_replaces.append(('another', 'pair'))
+    assert r3.url_replaces != r1.url_replaces
 
 
 def test_manifest_from_data_without_topdir():

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -112,6 +112,183 @@ def test_workspace(west_update_tmpdir):
     assert wct.join('zephyr', 'subsys', 'bluetooth', 'code.c').check(file=1)
 
 
+def test_workspace_remap_url(tmpdir, repos_tmpdir):
+    remotes_dir = repos_tmpdir / 'repos'
+    workspace_dir = tmpdir / 'workspace'
+    workspace_dir.mkdir()
+
+    # use remote zephyr
+    remote_zephyr = tmpdir / 'repos' / 'zephyr'
+
+    # create a local base project with a west.yml
+    project_base = remotes_dir / 'base'
+    create_repo(project_base)
+    add_commit(
+        project_base,
+        'manifest commit',
+        # zephyr revision is implicitly master, see #821
+        files={
+            'west.yml': textwrap.dedent('''
+            manifest:
+              remapping:
+                url:
+                - old: xxx
+                  new: yyy
+              remotes:
+                - name: upstream
+                  url-base: xxx
+              projects:
+              - name: zephyr
+                remote: upstream
+                path: zephyr-rtos
+                import: True
+              ''')
+        },
+    )
+
+    # create another project with another west.yml (stacked on base)
+    project_middle = remotes_dir / 'middle'
+    create_repo(project_middle)
+    add_commit(
+        project_middle,
+        'manifest commit',
+        # zephyr revision is implicitly master:
+        files={
+            'west.yml': f'''
+                      manifest:
+                        remapping:
+                          url:
+                          - old: yyy
+                            new: zzz
+                        projects:
+                        - name: base
+                          url: {project_base}
+                          import: True
+                      '''
+        },
+    )
+
+    # create an app that uses middle project
+    project_app = workspace_dir / 'app'
+    project_app.mkdir()
+    with open(project_app / 'west.yml', 'w') as f:
+        f.write(
+            textwrap.dedent(f'''\
+            manifest:
+              remapping:
+                url:
+                  - old: zzz
+                    new: {os.path.dirname(remote_zephyr)}
+              projects:
+                - name: middle
+                  url: {project_middle}
+                  import: True
+        ''')
+        )
+
+    # init workspace in projects_dir (project_app's parent)
+    cmd(['init', '-l', project_app])
+
+    # update workspace in projects_dir
+    cmd('update', cwd=workspace_dir)
+
+    # zephyr projects from base are cloned
+    for project_subdir in [
+        Path('subdir') / 'Kconfiglib',
+        'tagged_repo',
+        'net-tools',
+        'zephyr-rtos',
+    ]:
+        assert (workspace_dir / project_subdir).check(dir=1)
+        assert (workspace_dir / project_subdir / '.git').check(dir=1)
+
+
+def test_workspace_remap_url_from_self_import(repos_tmpdir):
+    remote_zephyr = repos_tmpdir / 'repos' / 'zephyr'
+    projects_dir = repos_tmpdir / 'projects'
+    projects_dir.mkdir()
+
+    # create a local base project with a west.yml
+    project_base = projects_dir / 'base'
+    project_base.mkdir()
+    with open(project_base / 'west.yml', 'w') as f:
+        f.write(
+            textwrap.dedent('''\
+            manifest:
+              remotes:
+                - name: upstream
+                  url-base: nonexistent
+              projects:
+              - name: zephyr
+                remote: upstream
+                path: zephyr-rtos
+                import: True
+        ''')
+        )
+
+    # create another project with another west.yml (stacked on base)
+    project_middle = projects_dir / 'middle'
+    project_middle.mkdir()
+    with open(project_middle / 'west.yml', 'w') as f:
+        f.write(
+            textwrap.dedent('''\
+            manifest:
+              self:
+                import: ../base
+        ''')
+        )
+
+    # create another project with another west.yml (stacked on base)
+    project_another = projects_dir / 'another'
+    project_another.mkdir()
+    with open(project_another / 'west.yml', 'w') as f:
+        f.write(
+            textwrap.dedent('''\
+            manifest:
+              # this should not have any effect since there are no imports
+              remapping:
+                url:
+                  - old: nonexistent
+                    new: from-another
+        ''')
+        )
+
+    # create another project with another west.yml (stacked on base)
+    project_app = projects_dir / 'app'
+    project_app.mkdir()
+    with open(project_app / 'west.yml', 'w') as f:
+        f.write(
+            textwrap.dedent(f'''\
+            manifest:
+              remapping:
+                url:
+                  - old: nonexistent
+                    new: {os.path.dirname(remote_zephyr)}
+              self:
+                import:
+                - ../another
+                - ../middle
+        ''')
+        )
+
+    # init workspace in projects_dir (project_app's parent)
+    cmd(['init', '-l', project_app])
+
+    # update workspace in projects_dir
+    cmd('update', cwd=projects_dir)
+
+    ws = projects_dir
+    # zephyr projects from base are cloned
+    for project_subdir in [
+        Path('subdir') / 'Kconfiglib',
+        'tagged_repo',
+        'net-tools',
+        'zephyr-rtos',
+    ]:
+        assert (ws / project_subdir).check(dir=1)
+        assert (ws / project_subdir / '.git').check(dir=1)
+
+
 def test_list(west_update_tmpdir):
     # Projects shall be listed in the order they appear in the manifest.
     # Check the behavior for some format arguments of interest as well.


### PR DESCRIPTION
Proposal for #615 (Reopened #869 with no conversation)

CC: @tobiaskaestner

## Problem

West manifests can import other manifests, and those can import further manifests — chains that often span organizational boundaries (e.g. app → internal platform manifest → Zephyr's own manifest). Every project URL in that chain is fixed by whoever wrote the manifest it came from; upstream has no way to know about a downstream consumer's specific setup or needs — most commonly, using mirrored repositories:

- **Mirrored/cached repositories.** Many organizations mirror upstream repos internally (GitHub Enterprise, Gitea, Artifactory, etc.). Today, using those mirrors means either forking and hand-editing every upstream manifest that references the original URLs, or maintaining a fully rewritten manifest tree in parallel — in both cases you lose upstream's revision pins and any future updates unless you keep re-merging them by hand.
- **Fixed URL layouts from an intermediate manifest.** A downstream consumer of a shared "category" manifest doesn't get to choose where the referenced repos live — the URLs are baked in by whoever authored that manifest. There is currently no supported way for a manifest further downstream to change *only* the URL while leaving everything else (revision, path, groups, submodules, ...) untouched.

Manifest imports intentionally don't let you override individual project fields, and duplicating a project entry to change its URL breaks the import mechanism. There's currently no way to point an inherited project at a different remote without listing the whole project metadata in your manifest again.

## Solution

A new, optional `remapping` section, under a `url` key, lets any manifest declare plain search-and-replace patterns (`old` → `new`, literal substrings, not regex) that get applied to every project URL resolved during import — including URLs pulled in from imported/nested manifests, recursively.

```yaml
manifest:
  remapping:
    url:
      - old: github.com/zephyr-rtos
        new: github.company.com/mirrors
```

With this, all URLs your workspace resolves under `github.com/zephyr-rtos/...` — whether the project is declared directly in your manifest or pulled in through several levels of imports — get rewritten to your mirror, while everything else about the project (`revision`, `path`, `groups`, `west-commands`, ...) still comes from upstream untouched. Updating upstream's manifest (e.g. bumping a revision) keeps working with zero merge conflicts, because you never touched upstream's file.

Multiple, more targeted patterns are also supported, applied in the order listed within a manifest, so you can mirror different repos to different places:

```yaml
manifest:
  remapping:
    url:
      - old: github.com/foo/libfoo
        new: github.company.com/foo/mirrored-libfoo
      - old: github.com/foo/libbar
        new: github.othercompany.com/forked/libbar
```

## How resolution order works across imports

Remapping rules accumulate as the manifest tree is walked and are applied **innermost-first, outermost-last**: a rule declared by a manifest deep in the import chain (e.g. Zephyr's own manifest, or an intermediate platform manifest) is applied before a rule declared by the manifest closer to your actual workspace. This means the manifest you control directly — the one at the root of your workspace — always has the last word on a project's final URL, even if several layers of imported manifests each rewrote it along the way. Each manifest's own `remapping` only affects itself and anything it imports; it has no effect on manifests that import *it*.

## Why not just use `west config` (or `git config url.<base>.insteadOf`)?

This is the proposal done in https://github.com/zephyrproject-rtos/west/pull/994.

West already has a config mechanism, and Git has its own native URL rewriting via `url.<base>.insteadOf`. Both look like they'd solve this, but neither actually does, for the same underlying reason: **they live outside the manifest, so they don't travel with it.**

- **They're local machine/user state, not manifest state.** `westconfig`/`.westconfig` and `.west/config` are never part of the manifest repository — they live on whatever machine runs west. The same is true of `git config`, whether set globally on a workstation or per-repo. None of that is checked in, versioned alongside the manifest, or distributed to anyone who clones the workspace or imports the manifest.
- **Every project and every user has to redo it.** Because the config isn't attached to the manifest, each downstream project, each contributor's laptop, and each CI runner/container needs its own out-of-band setup step to apply the same mirror mapping — typically some onboarding doc or provisioning script that has to be written, kept up to date by hand, and run *before* `west init`/`west update` even works. Miss that step (a new contributor, a fresh CI image, a new downstream fork) and you silently fall back to the un-mirrored upstream URLs, or `west update` fails outright in an environment that can't reach them.
- **It isn't inherited through imports.** The entire point of this feature is that a project several import-levels downstream (e.g. app → internal platform manifest → Zephyr) should transparently get the mirrored URLs without needing to know the mirror even exists. A config value set on one machine has no relationship to the manifest-import graph — it can't be "inherited" by whoever imports your manifest the way a `remapping` entry declared in the manifest itself automatically is.
- **No single point of truth.** With config-based rewriting, the actual mapping in effect on any given machine is invisible from the manifest itself — you have to go inspect that machine's config to know what URLs will really be used. With `remapping` in the manifest, the mapping is declarative, versioned, code-reviewed, and identical for every consumer by construction.

In short: config-based URL rewriting can work for a single person's single workspace, but it doesn't compose with west's import model at all — it has to be manually re-applied at every level (every project, every user, every CI job) instead of being defined once, upstream or downstream, and automatically honored by everything that imports that manifest.

## Notes

- Fully opt-in: manifests without a `remapping` section behave exactly as before.
- Plain, sequential substring replacement — no regex, no partial-match ambiguity to reason about beyond "does this substring appear."
- Covered by new tests in `tests/test_project.py`, including a multi-level import chain (app → middle → base → zephyr remote) verifying that a mirror URL set only in the top-level manifest correctly overrides remote URLs several import-levels deep, plus a case where the remapping is picked up through a manifest's own `self.import`.
