### PR TITLE
configuration: do not interpolate configuration values

### DIFF
--- a/src/west/configuration.py
+++ b/src/west/configuration.py
@@ -33,6 +33,9 @@ You can override these files' locations with the ``WEST_CONFIG_SYSTEM``,
 Configuration values from later configuration files override configuration
 from earlier ones. Local values have highest precedence, and system values
 lowest.
+
+Values are stored and returned verbatim: no variable interpolation is
+performed, and no character needs escaping.
 '''
 
 import configparser
@@ -52,7 +55,9 @@ class MalformedConfig(Exception):
 
 
 def _configparser():  # for internal use
-    return configparser.ConfigParser(allow_no_value=True)
+    # Interpolation is disabled: configuration values are stored and
+    # returned verbatim, so that '%' is an ordinary character.
+    return configparser.ConfigParser(allow_no_value=True, interpolation=None)
 
 
 class _InternalCF:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -910,3 +910,33 @@ def test_list():
 def test_round_trip():
     cmd('config pytest.foo bar,baz')
     assert cmd('config pytest.foo').strip() == 'bar,baz'
+
+
+def test_round_trip_percent():
+    # A '%' is an ordinary character in a value: it is not escaped on the
+    # way in, and not interpolated on the way out.
+    url = 'https://example.com/some%20path'
+
+    cmd(['config', 'pytest.url', url])
+
+    assert cmd('config pytest.url').strip() == url
+    assert url in pathlib.Path(os.environ[west_env[LOCAL]]).read_text()
+
+
+def test_percent_in_hand_written_config():
+    # Same for a file west did not write itself. Every west command reads
+    # all configuration files and iterates over all of their options
+    # before running, so a '%' anywhere in any of them used to be fatal
+    # for every command, not just for the one using the option.
+    pathlib.Path(os.environ[west_env[LOCAL]]).write_text(
+        textwrap.dedent('''\
+        [pytest]
+        percent = 100%
+        doubled = 100%%
+        ''')
+    )
+
+    assert sorted(cmd('config -l').splitlines()) == [
+        'pytest.doubled=100%%',
+        'pytest.percent=100%',
+    ]


### PR DESCRIPTION
The internal `ConfigParser` was created with configparser's default
`BasicInterpolation`, which makes '%' a metacharacter in values. West's
documentation never mentions interpolation, but it makes a '%' in any
configuration file fatal for every west command:

```
  $ cat .west/config
  [manifest]
  path = zephyr
  [build]
  cmake-args = -DFOO=%PATH%
  $ west topdir
  configparser.InterpolationSyntaxError: '%' must be followed by '%' or
  '(', found: '%PATH%'
```

Before dispatching a command, `WestApp.run()` iterates over every option
in every configuration file twice: once to populate the deprecated
`west.configuration.config` object, and once to load aliases. The first
of the two raises, which is why the failure has nothing to do with the
command being run or with the option holding the value.

Escaping as '%%' does not help either: `_copy_to_configparser()` re-sets
the already interpolated value into a second parser, which then rejects
the '%' it just produced. Both paths date back to v0.13.0, which
introduced the Configuration class and the compatibility bridge.

Values that need a '%' are not exotic: percent-encoded URLs, paths that
contain one, and cmake or grep arguments all run into this.

Pass `interpolation=None` so that values are stored, written and returned
verbatim. Two configparser behaviours go away with it, neither of them
documented by west: '%%' is no longer unescaped to '%', and
'%(other-option)s' no longer expands to another value from the same
section.