### PR TITLE
configuration: fix the '%%' escape in configuration values

### DIFF
--- a/src/west/configuration.py
+++ b/src/west/configuration.py
@@ -33,6 +33,18 @@ You can override these files' locations with the ``WEST_CONFIG_SYSTEM``,
 Configuration values from later configuration files override configuration
 from earlier ones. Local values have highest precedence, and system values
 lowest.
+
+Values are interpolated when they are read, by configparser from the
+Python standard library: a literal ``%`` must be written as ``%%``, and
+``%(other-option)s`` expands to the value of another option in the same
+section. The exact rules, which depend on the Python version in use, are
+documented at
+https://docs.python.org/3/library/configparser.html#interpolation-of-values
+
+``west config`` and ``Configuration.set()`` escape what they write, so a
+literal ``%`` needs no care there, and an interpolation reference can only
+be added by editing a configuration file. The deprecated
+``update_config()`` function does not escape and is the exception to both.
 '''
 
 import configparser
@@ -53,6 +65,13 @@ class MalformedConfig(Exception):
 
 def _configparser():  # for internal use
     return configparser.ConfigParser(allow_no_value=True)
+
+
+def _escape_percent(value):  # for internal use
+    # Configuration values are interpolated when they are read, so a
+    # literal '%' has to be doubled on the way in. Non-string values are
+    # left alone; configparser rejects them on its own.
+    return value.replace('%', '%%') if isinstance(value, str) else value
 
 
 class _InternalCF:
@@ -112,6 +131,20 @@ class _InternalCF:
     def getfloat(self, option: str):
         return self._get(option, self.cp.getfloat)
 
+    def _malformed_value(self, section: str, key: str) -> MalformedConfig:
+        readable = [str(p) for p in self.paths]
+        return MalformedConfig(
+            f"invalid value for '{section}.{key}' in one of '{readable}': "
+            "a literal '%' must be written as '%%'"
+        )
+
+    def value(self, section: str, key: str):
+        # The interpolated value of an option, by section and key.
+        try:
+            return self.cp.get(section, key)
+        except configparser.InterpolationError as err:
+            raise self._malformed_value(section, key) from err
+
     def _get(self, option, getter):
         section, key = _InternalCF.parse_key(option)
 
@@ -119,6 +152,8 @@ class _InternalCF:
             return getter(section, key)
         except (configparser.NoOptionError, configparser.NoSectionError) as err:
             raise KeyError(option) from err
+        except configparser.InterpolationError as err:
+            raise self._malformed_value(section, key) from err
 
     def set(self, option: str, value: Any):
         self._check_single_config()
@@ -127,7 +162,7 @@ class _InternalCF:
         if section not in self.cp:
             self.cp[section] = {}
 
-        self.cp[section][key] = value
+        self.cp[section][key] = _escape_percent(value)
 
         self._write()
 
@@ -398,8 +433,10 @@ class Configuration:
                     continue
                 if section not in cp:
                     cp.add_section(section)
-                for key, value in contents.items():
-                    cp[section][key] = value
+                for key in contents:
+                    # 'cp' interpolates when it is read from, so the
+                    # value must be re-escaped.
+                    cp[section][key] = _escape_percent(cf.value(section, key))
 
         if self._system:
             load(self._system)
@@ -448,8 +485,8 @@ class Configuration:
         for section, contents in cf.cp.items():
             if section == 'DEFAULT':
                 continue
-            for key, value in contents.items():
-                ret[f'{section}.{key}'] = value
+            for key in contents:
+                ret[f'{section}.{key}'] = cf.value(section, key)
         return ret
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -910,3 +910,89 @@ def test_list():
 def test_round_trip():
     cmd('config pytest.foo bar,baz')
     assert cmd('config pytest.foo').strip() == 'bar,baz'
+
+
+PERCENT_VALUES = ['100%', '100%%', '100%%%', 'https://example.com/some%20path']
+
+
+def local_config() -> pathlib.Path:
+    return pathlib.Path(os.environ[west_env[LOCAL]])
+
+
+@pytest.mark.parametrize('value', PERCENT_VALUES)
+def test_round_trip_percent(value):
+    # A '%' does not have to be manually escaped on the command line: it is automatically
+    # escaped on the way into the file and read back verbatim.
+    cmd(['config', 'pytest.v', value])
+
+    assert cmd('config pytest.v').strip() == value
+    escaped = value.replace('%', '%%')
+    assert f'v = {escaped}\n' in local_config().read_text()
+
+
+@pytest.mark.parametrize('value', PERCENT_VALUES)
+def test_round_trip_percent_api(value):
+    # Same through the west API, which is what extension commands use.
+    update_testcfg('pytest', 'v', value)
+
+    assert wconfig.Configuration().get('pytest.v') == value
+
+
+@pytest.mark.parametrize(
+    ('stored', 'expected'),
+    [
+        ('100%%', '100%'),
+        ('100%%%%', '100%%'),
+        ('%%(not-a-ref)s', '%(not-a-ref)s'),
+    ],
+)
+def test_percent_escaped_in_hand_written_config(stored, expected):
+    # Each '%%' in a file west did not write itself stands for one
+    # literal '%'.
+    local_config().write_text(f'[pytest]\nv = {stored}\n')
+
+    assert cmd('config pytest.v').strip() == expected
+
+
+def test_percent_interpolation_in_hand_written_config():
+    # '%(other-option)s' still expands to another value from the section.
+    local_config().write_text('[pytest]\nbase = /opt/west\nsub = %(base)s/cache\n')
+
+    assert sorted(cmd('config -l').splitlines()) == [
+        'pytest.base=/opt/west',
+        'pytest.sub=/opt/west/cache',
+    ]
+
+
+@pytest.mark.parametrize('stored', ['100%', '100%%%', '100%%%%%'])
+def test_percent_unescaped_in_hand_written_config(stored):
+    # An odd number of them leaves one '%' that cannot be interpolated.
+    # Every west command reads all configuration files before running, so
+    # this is fatal for all of them; the error has to say which option is
+    # wrong and how to fix it.
+    local_config().write_text(f'[pytest]\nv = {stored}\n')
+
+    exc_info, _ = cmd_raises('config pytest.v', MalformedConfig)
+
+    assert "'pytest.v'" in str(exc_info.value)
+    assert "'%%'" in str(exc_info.value)
+
+
+def test_percent_in_deprecated_config_object():
+    # The object west populates at startup for extensions still using the
+    # deprecated API interpolates as well, so values have to reach it
+    # escaped. This is what used to break the '%%' escape.
+    local_config().write_text('[pytest]\nv = 100%%\n')
+
+    cmd('config -l')
+
+    assert wconfig.config.get('pytest', 'v') == '100%'
+
+
+def test_append_percent():
+    # 'west config -a' reads the value back before writing it again, so
+    # it must not escape what is already escaped.
+    cmd(['config', 'pytest.v', '50%'])
+    cmd(['config', '-a', 'pytest.v', '+25%'])
+
+    assert cmd('config pytest.v').strip() == '50%+25%'


### PR DESCRIPTION
configparser interpolates values when they are read, so a literal '%'
has to be written as '%%'. That escape has not worked since v0.13.0:
`_copy_to_configparser()` re-sets the already interpolated value into a
second interpolating parser, which rejects the '%' it just produced.
Because `WestApp.run()` copies every option before dispatching a command,
a single escaped value makes every west command fail:

```shell
$ cat .west/config
[manifest]
path = zephyr
[build]
cmake-args = -DFOO=100%%

$ west topdir
ValueError: invalid interpolation syntax in '-DFOO=100%' at position 12
```

Escape the value again on the way into the compatibility object, which
interpolates it back to what `Configuration.get()` returns.

With the escape working, make it unnecessary to know about: 'west config'
now escapes what it writes, so a value containing a '%' can be set from
the command line and is read back verbatim. Only hand-written files need
the escape, which is what the module documentation now says.

An unescaped '%' remains an error, but no longer a configparser traceback
from an unrelated command: interpolation failures are reported as
`MalformedConfig` naming the option and how to fix it, like the other
malformed configuration errors.

Interpolation itself keeps working, so '%(other-option)s' references in
existing configuration files are unaffected.