### PR TITLE
tests: test_config: Fix missing west_env

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -920,7 +920,7 @@ PERCENT_VALUES = ['100%', '100%%', '100%%%', 'https://example.com/some%20path']
 
 
 def local_config() -> pathlib.Path:
-    return pathlib.Path(os.environ[west_env[LOCAL]])
+    return pathlib.Path(os.environ[CONFIG_ENV_NAMES[LOCAL]])
 
 
 @pytest.mark.parametrize('value', PERCENT_VALUES)


### PR DESCRIPTION
Commit f0aa4981 and 74aa87fa both modify the same tests suite. Fix the missing west_env variable error.