### PR TITLE
Fix incorrect f-string

### DIFF
--- a/src/west/app/project.py
+++ b/src/west/app/project.py
@@ -1616,7 +1616,7 @@ class Update(_ProjectCommand):
     def update_importer(self, project, path):
         if isinstance(project, ManifestProject):
             if not project.is_cloned():
-                self.die("manifest repository {project.abspath} was deleted")
+                self.die(f"manifest repository {project.abspath} was deleted")
         else:
             # There's no need to call self.project_is_active(),
             # because the Manifest API guarantees that 'groups' cannot


### PR DESCRIPTION
Fixed a missing f prefix that left {project.abspath} uninterpolated in this error message.

While checking when this could fire, I noticed the surrounding `isinstance(project, ManifestProject)` branch looks unreachable with the current manifest-import code, not sure if it's worth deleting as dead code or better left alone.